### PR TITLE
Add batch tags() to the workflow metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ SagaFlow::create(CheckoutWorkflow::class)
 
 // inside handle():
 $this->tag('priority', 'high');
+
+// or several at once — both methods chain and are idempotent across replays
+$this->tags(['priority' => 'high', 'attempt' => 2, 'orders' => null]);
 ```
 
 Query runs with the fluent, type-safe `FlowQuery`:

--- a/docs/docs/tags-and-querying.md
+++ b/docs/docs/tags-and-querying.md
@@ -26,9 +26,25 @@ class CheckoutWorkflow extends Workflow { /* ... */ }
 ```php
 // from inside handle()
 $this->tag('priority', 'high');
+
+// or several at once
+$this->tags([
+    'priority' => 'high',
+    'attempt' => 2,      // int values are cast to string
+    'orders' => null,    // a tag with no value
+]);
 ```
 
 Explicit tags passed to `withTags()` override attribute tags with the same key.
+
+Both `tag()` and `tags()` return the workflow, so they chain:
+
+```php
+$this->tag('priority', 'high')->tags(['tenant' => 'acme']);
+```
+
+Re-tagging an existing key overwrites its value rather than adding a second tag, and both methods
+are idempotent across replays — safe to call unconditionally at the top of `handle()`.
 
 ## Querying runs
 

--- a/src/Concerns/Workflow/ProvidesFlowMetadata.php
+++ b/src/Concerns/Workflow/ProvidesFlowMetadata.php
@@ -3,19 +3,37 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Concerns\Workflow;
 
 /**
- * Read-only access to the current run's identity/metadata, plus queryable tags.
+ * Read-only access to the current run's identity/metadata, plus queryable tags,
+ * attachable one at a time or in bulk.
  */
 trait ProvidesFlowMetadata
 {
     /**
      * Attach a queryable tag to the current run. Idempotent across replays.
      */
-    public function tag(string $key, string|int|null $value = null): void
+    public function tag(string $key, string|int|null $value = null): static
     {
         $this->runtime->run()->tags()->updateOrCreate(
             ['key' => $key],
             ['value' => $value === null ? null : (string) $value],
         );
+
+        return $this;
+    }
+
+    /**
+     * Attach several queryable tags at once, keyed by tag name. A null value
+     * records a tag with no value. Idempotent across replays.
+     *
+     * @param  array<string, string|int|null>  $tags
+     */
+    public function tags(array $tags): static
+    {
+        foreach ($tags as $key => $value) {
+            $this->tag($key, $value);
+        }
+
+        return $this;
     }
 
     public function runId(): string

--- a/tests/Feature/WorkflowTagsTest.php
+++ b/tests/Feature/WorkflowTagsTest.php
@@ -1,0 +1,56 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TaggingReplayWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TaggingWorkflow;
+
+it('attaches several tags at once from inside the workflow', function () {
+    $run = SagaFlow::create(TaggingWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->tags()->pluck('value', 'key')->all())
+        ->toEqualCanonicalizing([
+            // 'priority' was re-tagged by a later tags() call — last write wins.
+            'priority' => 'high',
+            // An int value is cast to string on the way in.
+            'attempt' => '1',
+            // A null value records a tag with no value.
+            'orders' => null,
+            // Set through the chained tag() call.
+            'tenant' => 'acme',
+        ]);
+});
+
+it('never duplicates a repeated tag key', function () {
+    $run = SagaFlow::create(TaggingWorkflow::class)->runSync();
+
+    // 'priority' is written twice by the workflow, but updateOrCreate matches on
+    // (flow_run_id, key), so it stays a single row.
+    expect($run->tags()->where('key', 'priority')->count())->toBe(1)
+        ->and($run->tags()->count())->toBe(4);
+});
+
+it('keeps bulk tagging idempotent across replays', function () {
+    useDatabaseQueue();
+
+    // The action suspends the run, so handle() — and the tags() call before it —
+    // is replayed on the resume pass.
+    $run = SagaFlow::create(TaggingReplayWorkflow::class)->run();
+
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->tags()->count())->toBe(2)
+        ->and($run->tags()->pluck('value', 'key')->all())
+        ->toEqualCanonicalizing(['stage' => 'done', 'tenant' => 'acme']);
+});
+
+it('returns the workflow instance so tag calls chain', function () {
+    $run = SagaFlow::create(TaggingWorkflow::class)->runSync();
+
+    // The fixture only completes if tags() and tag() are chainable.
+    expect($run->status)->toBe(FlowStatus::Completed);
+});

--- a/tests/Fixtures/TaggingReplayWorkflow.php
+++ b/tests/Fixtures/TaggingReplayWorkflow.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Tags in bulk before an action suspends the run, so the replay pass re-runs the
+ * same tags() call. Used to prove bulk tagging stays idempotent across replays.
+ */
+final class TaggingReplayWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->tags(['stage' => 'start', 'tenant' => 'acme']);
+
+        $this->action(MakeValueAction::class, 'value')->run();
+
+        $this->tags(['stage' => 'done']);
+    }
+}

--- a/tests/Fixtures/TaggingWorkflow.php
+++ b/tests/Fixtures/TaggingWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Tags itself from inside handle(), in bulk and chained. Covers the runtime
+ * tagging API: value casting, valueless tags, and last-write-wins on a repeated key.
+ */
+final class TaggingWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->tags([
+            'priority' => 'low',
+            'attempt' => 1,
+            'orders' => null,
+        ])->tag('tenant', 'acme')
+            ->tags(['priority' => 'high']);
+    }
+}


### PR DESCRIPTION
Closes #8.

## What

Tagging from inside `handle()` only allowed one key at a time:

```php
$this->tag('priority', 'high');
$this->tag('tenant', 'acme');
```

…while the same concept already had a bulk form at creation (`->withTags([...])`) and
declaratively (repeatable `#[Tag]`). This adds the missing runtime form:

```php
$this->tags([
    'priority' => 'high',
    'attempt'  => 2,      // int values are cast to string
    'orders'   => null,   // a tag with no value
]);
```

Both `tag()` and `tags()` now return `static`, so they chain:

```php
$this->tag('priority', 'high')->tags(['tenant' => 'acme']);
```

## Notes on the implementation

`tags()` delegates to `tag()` per pair rather than issuing a bulk `upsert()`. That is deliberate:
the unique index on `flow_tags` is `(flow_run_id, key, value)`, **not** `(flow_run_id, key)`, so an
`upsert()` keyed on the tag name would not match the index. Delegating keeps the existing
`updateOrCreate` semantics — match on `(flow_run_id, key)`, overwrite the value — and therefore the
documented replay idempotency, with no schema change.

`void` → `static` is backward compatible for every existing caller.

## Tests

The runtime tagging API had **no test coverage at all** — only `#[Tag]` and `withTags()` were
exercised, which left the docblock's "idempotent across replays" claim unverified. New
`tests/Feature/WorkflowTagsTest.php` covers bulk tagging, value casting, valueless tags,
last-write-wins on a repeated key, chaining, and replay idempotency through the real queued path.

Full suite green (166 passed), Pint clean, PHPStan level 5 clean, docs site builds.

## Docs

Updated `docs/docs/tags-and-querying.md` and the mirrored README section.
`CHANGELOG.md` intentionally untouched — it is generated from release notes.
