### PR TITLE
Add batch tags() to the workflow metadata API

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,9 @@ SagaFlow::create(CheckoutWorkflow::class)
 
 // inside handle():
 $this->tag('priority', 'high');
+
+// or several at once — idempotent across replays, re-tagging a key overwrites it
+$this->tags(['priority' => 'high', 'attempt' => 2, 'orders' => null]);
 ```
 
 Query runs with the fluent, type-safe `FlowQuery`:

--- a/docs/docs/tags-and-querying.md
+++ b/docs/docs/tags-and-querying.md
@@ -26,9 +26,19 @@ class CheckoutWorkflow extends Workflow { /* ... */ }
 ```php
 // from inside handle()
 $this->tag('priority', 'high');
+
+// or several at once
+$this->tags([
+    'priority' => 'high',
+    'attempt' => 2,      // int values are cast to string
+    'orders' => null,    // a tag with no value
+]);
 ```
 
 Explicit tags passed to `withTags()` override attribute tags with the same key.
+
+Re-tagging an existing key overwrites its value rather than adding a second tag, and both `tag()`
+and `tags()` are idempotent across replays — safe to call unconditionally at the top of `handle()`.
 
 ## Querying runs
 

--- a/src/Concerns/Workflow/ProvidesFlowMetadata.php
+++ b/src/Concerns/Workflow/ProvidesFlowMetadata.php
@@ -3,7 +3,8 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Concerns\Workflow;
 
 /**
- * Read-only access to the current run's identity/metadata, plus queryable tags.
+ * Read-only access to the current run's identity/metadata, plus queryable tags,
+ * attachable one at a time or in bulk.
  */
 trait ProvidesFlowMetadata
 {
@@ -16,6 +17,19 @@ trait ProvidesFlowMetadata
             ['key' => $key],
             ['value' => $value === null ? null : (string) $value],
         );
+    }
+
+    /**
+     * Attach several queryable tags at once, keyed by tag name. A null value
+     * records a tag with no value. Idempotent across replays.
+     *
+     * @param  array<string, string|int|null>  $tags
+     */
+    public function tags(array $tags): void
+    {
+        foreach ($tags as $key => $value) {
+            $this->tag($key, $value);
+        }
     }
 
     public function runId(): string

--- a/tests/Feature/WorkflowTagsTest.php
+++ b/tests/Feature/WorkflowTagsTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TaggingReplayWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TaggingWorkflow;
+
+it('attaches several tags at once from inside the workflow', function () {
+    $run = SagaFlow::create(TaggingWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->tags()->pluck('value', 'key')->all())
+        ->toEqualCanonicalizing([
+            // 'priority' was re-tagged by a later tags() call — last write wins.
+            'priority' => 'high',
+            // An int value is cast to string on the way in.
+            'attempt' => '1',
+            // A null value records a tag with no value.
+            'orders' => null,
+            // Set through the single-key tag() call.
+            'tenant' => 'acme',
+        ]);
+});
+
+it('never duplicates a repeated tag key', function () {
+    $run = SagaFlow::create(TaggingWorkflow::class)->runSync();
+
+    // 'priority' is written twice by the workflow, but updateOrCreate matches on
+    // (flow_run_id, key), so it stays a single row.
+    expect($run->tags()->where('key', 'priority')->count())->toBe(1)
+        ->and($run->tags()->count())->toBe(4);
+});
+
+it('keeps bulk tagging idempotent across replays', function () {
+    useDatabaseQueue();
+
+    // The action suspends the run, so handle() — and the tags() call before it —
+    // is replayed on the resume pass.
+    $run = SagaFlow::create(TaggingReplayWorkflow::class)->run();
+
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->tags()->count())->toBe(2)
+        ->and($run->tags()->pluck('value', 'key')->all())
+        ->toEqualCanonicalizing(['stage' => 'done', 'tenant' => 'acme']);
+});

--- a/tests/Fixtures/TaggingReplayWorkflow.php
+++ b/tests/Fixtures/TaggingReplayWorkflow.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Tags in bulk before an action suspends the run, so the replay pass re-runs the
+ * same tags() call. Used to prove bulk tagging stays idempotent across replays.
+ */
+final class TaggingReplayWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->tags(['stage' => 'start', 'tenant' => 'acme']);
+
+        $this->action(MakeValueAction::class, 'value')->run();
+
+        $this->tags(['stage' => 'done']);
+    }
+}

--- a/tests/Fixtures/TaggingWorkflow.php
+++ b/tests/Fixtures/TaggingWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Tags itself from inside handle(), in bulk and one at a time. Covers the runtime
+ * tagging API: value casting, valueless tags, and last-write-wins on a repeated key.
+ */
+final class TaggingWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->tags([
+            'priority' => 'low',
+            'attempt' => 1,
+            'orders' => null,
+        ]);
+
+        $this->tag('tenant', 'acme');
+
+        $this->tags(['priority' => 'high']);
+    }
+}


### PR DESCRIPTION
Closes #8.

Tagging from inside `handle()` only allowed one key at a time, while the same concept
already had a bulk form at creation (`->withTags([...])`) and declaratively
(repeatable `#[Tag]`). This adds the missing runtime form:

```php
$this->tags([
    'priority' => 'high',
    'attempt'  => 2,      // int values are cast to string
    'orders'   => null,   // a tag with no value
]);
```

`tags()` delegates to `tag()` per pair rather than issuing a bulk `upsert()`. That is
deliberate: the unique index on `flow_tags` is `(flow_run_id, key, value)`, not
`(flow_run_id, key)`, so an `upsert()` keyed on the tag name would not match the index.
Delegating keeps the existing `updateOrCreate` semantics — match on `(flow_run_id, key)`,
overwrite the value — and therefore the documented replay idempotency, with no schema change.

The change is purely additive: `tag()` is untouched, so no existing signature moves.

## Tests

The runtime tagging API had no test coverage at all — only `#[Tag]` and `withTags()` were
exercised, which left the docblock's "idempotent across replays" claim unverified.
`tests/Feature/WorkflowTagsTest.php` covers bulk tagging, value casting, valueless tags,
last-write-wins on a repeated key, and replay idempotency through the real queued path.

## Docs

Updated `docs/docs/tags-and-querying.md` and the mirrored README section.
`CHANGELOG.md` intentionally untouched — it is generated from release notes.
