### PR TITLE
Add signal-gated retries for failed saga steps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,4 @@ docs/.docusaurus
 # Private working docs (not shipped)
 CLAUDE.md
 IMPLEMENTATION_PLAN.md
+/.design

--- a/README.md
+++ b/README.md
@@ -376,7 +376,7 @@ $this->action(ChargeCard::class, $orderId)
     ->compensateWith(RefundCard::class, $orderId)
     ->retryOnSignal(
         'balance-refilled',
-        maxRetries: 3,                                  // null = unbounded
+        maxRetries: 3,                                  // null = unbounded, never negative
         waitSeconds: 86400,                             // how long one wait may last
         only: [InsufficientBalanceException::class],    // null = park on any exception
     )

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ automatically, in reverse order.
 - [Actions](#actions)
 - [Sagas & compensations](#sagas--compensations)
 - [Signals](#signals)
+- [Retry on signal](#retry-on-signal)
 - [Side effects](#side-effects)
 - [Parallel actions](#parallel-actions)
 - [Optional actions](#optional-actions)
@@ -101,8 +102,12 @@ Run the migrations:
 php artisan migrate
 ```
 
-The engine's migration ships with the package, so `migrate` picks it up directly — no publish step.
+The engine's migrations ship with the package, so `migrate` picks them up directly — no publish step.
 Future versions add their migrations the same way: `composer update` then `php artisan migrate`.
+
+> **Always migrate after an upgrade.** The engine writes its newest columns for *every* action it
+> schedules, so upgrading without `php artisan migrate` breaks ordinary workflow execution with an
+> unknown-column error — not just the newest feature. See [UPGRADING.md](UPGRADING.md).
 
 Optionally publish the config file:
 
@@ -359,6 +364,36 @@ SagaFlow::query()
     ->first()
     ?->signal('owner-synced');
 ```
+
+## Retry on signal
+
+A step that fails hard takes the whole run with it: the saga rolls back and completed work is undone.
+`retryOnSignal()` parks such a step instead — the run waits, nothing rolls back, and when the named
+signal arrives **only that step runs again**:
+
+```php
+$this->action(ChargeCard::class, $orderId)
+    ->compensateWith(RefundCard::class, $orderId)
+    ->retryOnSignal(
+        'balance-refilled',
+        maxRetries: 3,                                  // null = unbounded
+        waitSeconds: 86400,                             // how long one wait may last
+        only: [InsufficientBalanceException::class],    // null = park on any exception
+    )
+    ->run();
+```
+
+Deliver `balance-refilled` the way you deliver any other signal and `ChargeCard` runs again, alone;
+earlier steps stay completed and un-compensated. The layers stack: Laravel's `$tries` first, then
+`retryOnSignal()`, then `continueOnFailure()`, then hard failure and compensation. When the budget is
+spent or the wait times out, the step fails exactly as it would have without the policy — same
+`ActionFailedException`, same rollback.
+
+A retry consumes **no new sequence**: the step reuses its own ordinal and `action_runs` row, so
+downstream steps land identically whether it retried or not. `saga()->step()` mirrors the method.
+
+`saga-flow:list` annotates a parked run with the signal it needs, `saga-flow:show` gains a **Retry**
+column, and two events (`ActionAwaitingRetry`, `ActionRetried`) cover the lifecycle.
 
 ## Side effects
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,70 @@
+# Upgrading
+
+## From 1.0.x to 1.1.0
+
+> ### ⚠️ Run `php artisan migrate` immediately after upgrading
+>
+> This is **not** a "the new feature stays unavailable until you migrate" situation. Every action the
+> engine schedules — with or without a retry policy — writes the columns added by this release. An
+> application that upgrades the package without running its migrations will break **ordinary workflow
+> execution** with an unknown-column error on the very next action it schedules.
+>
+> ```bash
+> composer update discovery-ukraine/saga-lara-flow
+> php artisan migrate
+> ```
+>
+> Deploy the two together. If your deploy runs migrations after the new code is already serving
+> traffic, expect failures in that window.
+
+### What's new
+
+`retryOnSignal()` on an action (and on `saga()->step()`) parks a failed step until a named signal arrives, then re-runs
+that step alone instead of failing the run and compensating it. See the
+[Retry on signal](https://sagalaraflow.dev/retry-on-signal) guide.
+
+Everything in this release is additive for workflows that never call `retryOnSignal()`. The three notes below are the
+only places where existing behaviour changed.
+
+### 1. The new migration
+
+`add_retry_on_signal_to_action_runs` adds four nullable/defaulted columns to `action_runs`:
+`retry_signal`, `retry_signal_attempts`, `retry_signal_max_attempts`, and
+`queue_attempts_exhausted`. It runs from the package like the initial migration — do not
+`vendor:publish` it.
+
+### 2. `SignalRepository` gained two methods
+
+If you bound your own implementation of `DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository`, it must now also
+implement:
+
+```php
+public function earliestPendingSince(string $flowRunId, string $name, ?DateTimeInterface $since): ?FlowSignal;
+
+public function latestForSequence(string $flowRunId, int $sequence): ?FlowSignal;
+```
+
+The simplest fix is to extend `Repositories\EloquentSignalRepository` rather than implement the interface from scratch.
+
+This is a minor release rather than a major one because the repository contracts are **not a public extension point**.
+They are now marked `@internal`, and the supported way to change persistence behavior is
+`config('saga-lara-flow.models.*')`, which is unaffected. Methods may be added to these contracts in future minor
+releases on the same terms.
+
+### 3. Two signal transitions no longer raise Eloquent model events
+
+Delivering a signal into an open wait, and timing a wait out, are now written as single conditional
+`UPDATE` statements instead of `save()` calls. That is the only form that is atomic on every supported driver, and it is
+what keeps a delivery and a timeout from both claiming the same wait.
+
+The consequence: an **observer** registered on a swapped-in `models.flow_signal` no longer sees
+`updating`/`updated` for those two transitions (nor for the new "wait superseded" transition). If you rely on model
+events for auditing or multi-tenancy bookkeeping, move that listener onto the package's own events —
+`FlowSignalReceived`, `FlowSignalConsumed` — or read the `flow_events` log, both of which still record every transition.
+
+### Recommended while you are here
+
+- **Turn `repair.enabled` on.** The doctor is what recovers a step whose queue job was lost to a dying process. It is
+  off by default and does nothing until you opt in.
+- **Check your package-event listeners.** A synchronous listener that throws interrupts the engine's replay and can fail
+  a healthy run. Mark them `ShouldQueue`, or make sure they cannot throw.

--- a/config/saga-lara-flow.php
+++ b/config/saga-lara-flow.php
@@ -158,6 +158,22 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Actions
+    |--------------------------------------------------------------------------
+    | retryOnSignal() parks a failed step until a named signal arrives, then
+    | retries that step alone. max_retries caps how many signal-gated retries a
+    | step may spend when the call site does not pass its own maxRetries; null
+    | leaves it unbounded, with the per-wait timeout and the run's expires_at as
+    | the remaining brakes. A value set on the call site always wins.
+    */
+    'actions' => [
+        'retry_on_signal' => [
+            'max_retries' => null,
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Parallel actions
     |--------------------------------------------------------------------------
     | Default policy for a parallel() block when a step fails. FailFast cancels

--- a/config/saga-lara-flow.php
+++ b/config/saga-lara-flow.php
@@ -164,7 +164,8 @@ return [
     | retries that step alone. max_retries caps how many signal-gated retries a
     | step may spend when the call site does not pass its own maxRetries; null
     | leaves it unbounded, with the per-wait timeout and the run's expires_at as
-    | the remaining brakes. A value set on the call site always wins.
+    | the remaining brakes. A value set on the call site always wins. Use null
+    | rather than a negative number: a negative cap is rejected.
     */
     'actions' => [
         'retry_on_signal' => [

--- a/database/migrations/2026_08_21_000000_add_retry_on_signal_to_action_runs.php
+++ b/database/migrations/2026_08_21_000000_add_retry_on_signal_to_action_runs.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'action_runs', function (Blueprint $table): void {
+            $table->string('retry_signal')->nullable()->after('has_compensation');
+
+            $table->unsignedInteger('retry_signal_max_attempts')->nullable()->after('attempts');
+
+            $table->unsignedInteger('retry_signal_attempts')->default(0)->after('attempts');
+
+            $table->boolean('queue_attempts_exhausted')->default(false)->after('attempts');
+        });
+    }
+
+    public function down(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'action_runs', function (Blueprint $table): void {
+            $table->dropColumn([
+                'retry_signal',
+                'retry_signal_attempts',
+                'retry_signal_max_attempts',
+                'queue_attempts_exhausted',
+            ]);
+        });
+    }
+
+    private function connection(): ?string
+    {
+        return config('saga-lara-flow.database.connection');
+    }
+
+    private function prefix(): string
+    {
+        return (string) config('saga-lara-flow.database.table_prefix', '');
+    }
+};

--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -108,4 +108,6 @@ extend `FlowException` and are safe to catch; the two internal signals are the *
 :::
 
 To make a failing action *not* fail the flow, see [Optional actions](./optional-actions.md). To undo
-completed work when a later step fails, see [Sagas & compensations](./sagas-and-compensation.md).
+completed work when a later step fails, see [Sagas & compensations](./sagas-and-compensation.md). To
+park a failed step until an external signal says it is worth trying again — without rolling anything
+back — see [Retry on signal](./retry-on-signal.md).

--- a/docs/docs/artisan-commands.md
+++ b/docs/docs/artisan-commands.md
@@ -1,7 +1,7 @@
 ---
 id: artisan-commands
 title: Artisan commands
-sidebar_position: 16
+sidebar_position: 17
 ---
 
 # Artisan commands
@@ -40,6 +40,10 @@ php artisan saga-flow:cancel 01JABCDEF... --compensate
 # Re-drive a stuck run
 php artisan saga-flow:kick 01JABCDEF...
 ```
+
+A run parked by [retry on signal](./retry-on-signal.md) shows up as `waiting` in `saga-flow:list`,
+annotated with the signal it needs; `saga-flow:show` adds a **Retry** column with the signal, the
+spent budget, and the wait deadline. `saga-flow:signal` delivers the signal that restarts the step.
 
 Schedule `saga-flow:monitor` and `saga-flow:repair` for background maintenance — see
 [Expiration & monitoring](./expiration-and-monitoring.md).

--- a/docs/docs/child-workflows.md
+++ b/docs/docs/child-workflows.md
@@ -1,7 +1,7 @@
 ---
 id: child-workflows
 title: Child workflows
-sidebar_position: 11
+sidebar_position: 12
 ---
 
 # Child workflows

--- a/docs/docs/determinism-rules.md
+++ b/docs/docs/determinism-rules.md
@@ -1,7 +1,7 @@
 ---
 id: determinism-rules
 title: Determinism rules
-sidebar_position: 19
+sidebar_position: 20
 ---
 
 # Determinism rules
@@ -42,6 +42,10 @@ When a replay diverges from the recorded history — a different operation appea
 `sequence` than the one recorded — the engine raises `HistoryContractMismatchException`. Treat it as
 a signal that `handle()` became non-deterministic or that its code changed incompatibly for an
 in-flight run.
+
+A [signal-gated retry](./retry-on-signal.md) does not disturb this: a retried step keeps its own
+ordinal and reuses its `action_runs` row, and the waiting itself consumes no ordinal — so downstream
+steps land in the same place whether the step retried or not.
 
 ## Example
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -1,7 +1,7 @@
 ---
 id: events
 title: Events
-sidebar_position: 20
+sidebar_position: 21
 ---
 
 # Events
@@ -32,7 +32,8 @@ Flow lifecycle: `FlowStarted`, `FlowCompleted`, `FlowFailed`, `FlowWaiting`, `Fl
 `FlowRewoken`, `FlowCancelled`, `FlowExpired`.
 
 Actions: `ActionStarted`, `ActionCompleted`, `ActionFailed`, `ActionRedispatched`,
-`OptionalActionFailed`.
+`OptionalActionFailed`, `ActionAwaitingRetry`, `ActionRetried` (the last two cover
+[retry on signal](./retry-on-signal.md)).
 
 Compensations: `CompensationStarted`, `CompensationCompleted`, `CompensationFailed`.
 
@@ -43,6 +44,13 @@ Signals & side effects: `FlowSignalReceived`, `FlowSignalConsumed`, `SideEffectR
 `SideEffectReused`.
 
 (See `src/Events` for the full list.)
+
+:::warning Listeners must be queued, or must not throw
+These events are dispatched from inside the engine's replay. A synchronous listener that throws
+interrupts the replay at that point, and the engine reads the exception as a business failure — it
+can fail and compensate a run that was doing fine. Mark your listeners `ShouldQueue`, or make sure
+they cannot throw.
+:::
 
 ## Cancellation reason
 

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -1,7 +1,7 @@
 ---
 id: expiration-and-monitoring
 title: Expiration & monitoring
-sidebar_position: 13
+sidebar_position: 14
 ---
 
 # Expiration & monitoring
@@ -25,6 +25,10 @@ All three values are **in seconds** (here: 1 hour for a run, 10 minutes for an a
 signal wait). They are applied at write time when no explicit deadline is set: `run` on create,
 `action` on schedule, `signal` on await. `null` = off (no implicit deadline). There is no per-entity
 opt-out flag; to bypass a default for one entity, pass an explicit (far-future) deadline.
+
+The `signal` default also bounds a [retry-on-signal](./retry-on-signal.md) wait when the call site
+passes no `waitSeconds:`. A step's own `action` deadline does not: an action deadline bounds
+*execution*, and a parked step is not executing.
 
 ## Driving the sweep
 
@@ -89,6 +93,13 @@ Every parameter:
 
 The doctor only ever re-dispatches existing jobs or re-wakes flows — replay decides the rest, so it
 never creates duplicate work or mutates a business result.
+
+:::tip Turn it on in production
+Any step whose job is committed and then dispatched can lose that job to a dying process — including
+a step restarted by [retry on signal](./retry-on-signal.md), which then sits `Pending` with nothing
+behind it. `redispatch_lost_actions` is exactly the recovery for that, and it does nothing until
+`repair.enabled` is `true`.
+:::
 
 Schedule it, or loop it off the worker (`repair.queue_looping.enabled`):
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -18,9 +18,16 @@ Run the migrations:
 php artisan migrate
 ```
 
-The engine's migration ships with the package and is loaded into the migrator directly, so
-`migrate` picks it up with **no publish step**. Future versions add their migrations the same way —
+The engine's migrations ship with the package and are loaded into the migrator directly, so
+`migrate` picks them up with **no publish step**. Future versions add their migrations the same way —
 `composer update` then `php artisan migrate` is all a host app needs.
+
+:::danger Always migrate after an upgrade
+Skipping `php artisan migrate` after upgrading is not a "the new feature is unavailable" situation —
+the engine writes the new columns for **every** action it schedules, so a host app that upgrades
+without migrating breaks ordinary workflow execution with an unknown-column error. See
+[UPGRADING.md](https://github.com/discovery-ukraine/saga-lara-flow/blob/main/UPGRADING.md).
+:::
 
 Optionally publish the config file:
 
@@ -49,8 +56,9 @@ discovery — no manual wiring required.
 
 ## What gets installed
 
-- A single migration, `create_saga_lara_flow_initial_tables`, creating the engine's tables
-  (flow runs, action runs, events, signals, tags, children, compensations, side effects), all
-  prefixed with `saga_` by default.
+- Two migrations. `create_saga_lara_flow_initial_tables` creates the engine's tables (flow runs,
+  action runs, events, signals, tags, children, compensations, side effects), all prefixed with
+  `saga_` by default; `add_retry_on_signal_to_action_runs` adds the columns backing
+  [retry on signal](./retry-on-signal.md) to `action_runs`.
 - The `config/saga-lara-flow.php` config file (see [Configuration](./configuration.md)).
 - The `SagaFlow` facade and a set of `saga-flow:*` Artisan commands.

--- a/docs/docs/octane-and-multi-tenancy.md
+++ b/docs/docs/octane-and-multi-tenancy.md
@@ -1,7 +1,7 @@
 ---
 id: octane-and-multi-tenancy
 title: Octane & multi-tenancy
-sidebar_position: 18
+sidebar_position: 19
 ---
 
 # Octane & multi-tenancy

--- a/docs/docs/optional-actions.md
+++ b/docs/docs/optional-actions.md
@@ -1,7 +1,7 @@
 ---
 id: optional-actions
 title: Optional actions
-sidebar_position: 10
+sidebar_position: 11
 ---
 
 # Optional actions
@@ -46,3 +46,9 @@ class FetchRiskScore extends Action
 
 Optional actions work inside [parallel blocks](./parallel.md) too, letting a non-critical step fail
 without tearing down the group.
+
+## Combined with a retry policy
+
+An optional action can also carry [`retryOnSignal()`](./retry-on-signal.md). The retry layer runs
+first: the step parks and waits for its signal, and the fallback value is only returned once the
+retry budget is spent or the wait times out.

--- a/docs/docs/parallel.md
+++ b/docs/docs/parallel.md
@@ -1,7 +1,7 @@
 ---
 id: parallel
 title: Parallel actions
-sidebar_position: 9
+sidebar_position: 10
 ---
 
 # Parallel actions

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -1,7 +1,7 @@
 ---
 id: queues-locks-idempotency
 title: Queues, locks & idempotency
-sidebar_position: 14
+sidebar_position: 15
 ---
 
 # Queues, locks & idempotency

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -1,0 +1,205 @@
+---
+id: retry-on-signal
+title: Retry on signal
+sidebar_position: 8
+---
+
+# Retry on signal
+
+A step that fails hard takes the whole run with it: the saga rolls back and the work that already
+succeeded is undone. That is the right default for a bug, but the wrong one for a step that failed
+because *the world was not ready yet* — a card declined for insufficient funds, a downstream
+service still provisioning, an approval not yet granted.
+
+`retryOnSignal()` parks such a step instead of failing it. The run waits, nothing rolls back, and
+when the named signal arrives **only that step runs again**:
+
+```php
+public function handle(string $orderId): void
+{
+    $this->action(CreateOrder::class, $orderId)
+        ->compensateWith(CancelOrder::class, $orderId)
+        ->run();
+
+    $this->action(ChargeCard::class, $orderId)
+        ->compensateWith(RefundCard::class, $orderId)
+        ->retryOnSignal('balance-refilled')
+        ->run();
+
+    $this->action(ShipOrder::class, $orderId)->run();
+}
+```
+
+If `ChargeCard` exhausts its `$tries`, the run goes `Waiting` and the step goes `awaiting_retry`.
+`CreateOrder` stays completed and un-compensated. Delivering `balance-refilled` re-runs `ChargeCard`
+alone; if it succeeds, the workflow continues to `ShipOrder` as if nothing had happened.
+
+## The full signature
+
+```php
+->retryOnSignal(
+    string $signal,
+    ?int $maxRetries = null,   // null = unbounded
+    ?int $waitSeconds = null,  // null = monitor.expiration.defaults.signal
+    ?array $only = null,       // null = park on any exception
+)
+```
+
+- **`$signal`** — the signal name to wait for. An ordinary signal: deliver it exactly the way you
+  deliver any other (see [Signals](./signals.md)).
+- **`$maxRetries`** — how many signal-gated retry cycles this step may spend. `null` falls back to
+  `actions.retry_on_signal.max_retries` in the config, and then to unbounded.
+- **`$waitSeconds`** — how long *one* wait may last before the monitor gives up on it. A duration,
+  not a moment, because the wait repeats and a `now()->addDay()` would be recomputed on every
+  replay.
+- **`$only`** — a list of exception classes that may trigger a park. Subclasses count. Anything else
+  fails the step normally, so a `TypeError` never parks a saga for a day.
+
+```php
+$this->action(ChargeCard::class, $orderId)
+    ->compensateWith(RefundCard::class, $orderId)
+    ->retryOnSignal(
+        'balance-refilled',
+        maxRetries: 3,
+        waitSeconds: 86400,
+        only: [InsufficientBalanceException::class],
+    )
+    ->run();
+```
+
+## Where it sits among the other failure layers
+
+Failure handling stacks, and `retryOnSignal()` sits in the middle:
+
+1. **Laravel's queue retries** (`public int $tries` on the action) run first. The step parks only
+   once the queue has given up on it.
+2. **`retryOnSignal()`** parks and waits. Every arriving signal spends one cycle and re-runs the
+   step, which starts its `$tries` over.
+3. **`continueOnFailure()`** — see [Optional actions](./optional-actions.md) — takes over only after
+   the retry budget is spent or the wait times out. An optional step with a retry policy waits
+   first and falls back to its fallback value second.
+4. **Hard failure and compensation** — the ordinary path from
+   [Sagas & compensations](./sagas-and-compensation.md).
+
+When the policy gives up, the step fails exactly as it would have without any retry policy: the same
+`ActionFailedException`, carrying the message of the **last** attempt, and the same rollback. The
+seam is transparent on the way out — there is no new exception class to catch.
+
+## What ends the waiting
+
+A step stops waiting when any one of these happens:
+
+- **The signal arrives.** One cycle is spent, the step runs again.
+- **The budget runs out.** `retry_signal_attempts` reaches `maxRetries` → hard failure.
+- **The wait times out.** The monitor flips the wait to `timed_out` → hard failure.
+- **The run expires** on its own `expires_at`, or is cancelled.
+
+:::info A timed-out wait ends the policy for good
+The wait deadline bounds *the waiting*, not one wait out of several. Once a wait has timed out, the
+step fails even if budget is left — otherwise a signal that is never coming would hand the step a
+fresh deadline on every replay and the run would never finish.
+:::
+
+## The budget is read from the row, not from your code
+
+A step's ceiling is written to `action_runs.retry_signal_max_attempts` when the step is scheduled,
+and every later replay reads it from there. Changing `maxRetries:` in the workflow — or the config
+default — does **not** move the ceiling under a run that is already parked. Runs started after the
+deploy get the new value.
+
+That is deliberate: the budget belongs to the run, and a redeploy must not silently extend or cut
+short a wait that is already in flight.
+
+## Inside a saga group
+
+`saga()->step()` mirrors the method, and it means exactly the same thing:
+
+```php
+$this->saga()
+    ->step(CreateOrder::class, $orderId)->compensateWith(CancelOrder::class, $orderId)
+    ->step(ChargeCard::class, $orderId)
+        ->compensateWith(RefundCard::class, $orderId)
+        ->retryOnSignal('balance-refilled', maxRetries: 3)
+    ->step(ShipOrder::class, $orderId)
+    ->run();
+```
+
+## Delivering the signal
+
+Nothing special — it is an ordinary signal:
+
+```php
+SagaFlow::loadFlow($runId)->signal('balance-refilled');
+```
+
+```bash
+php artisan saga-flow:signal 01JABCDEF... balance-refilled
+```
+
+Usually you do not have the run id at hand. Query for it, and filter with `signalable()` (a parked
+run is `Waiting`, never `Running`):
+
+```php
+SagaFlow::query()
+    ->whereWorkflow(CheckoutWorkflow::class)
+    ->whereTag('customer', $customerId)
+    ->signalable()
+    ->handles()
+    ->first()
+    ?->signal('balance-refilled');
+```
+
+The signal's **payload is not passed to the action**. Action arguments must stay identical across
+replays, so the retried step runs with the arguments it was given originally; the payload is stored
+on the signal row for auditing. If the retry needs new data, read it inside the action.
+
+## Observing parked runs
+
+`saga-flow:list` annotates a parked run with the signal it is waiting for, and `saga-flow:show`
+gains a **Retry** column showing the signal, the spent budget, and the current deadline:
+
+```
+Seq  Status          Action       Attempts  Retry                                  Finished
+1    completed       CreateOrder  1         —                                      ...
+2    awaiting_retry  ChargeCard   3         balance-refilled 1/3 until 2026-08-24…  ...
+3    pending         ShipOrder    0         —
+```
+
+Two events cover the lifecycle — see [Events](./events.md):
+
+- **`ActionAwaitingRetry`** — fires once per park, carrying the step and the signal name.
+- **`ActionRetried`** — fires once per cycle, when the step is about to run again.
+
+Both are dispatched after the surrounding transaction commits, so a listener never reacts to a retry
+the database rolled back.
+
+## Determinism
+
+A retry does **not** consume a new sequence. The step keeps its `(flow_run_id, sequence)` ordinal
+and reuses the same `action_runs` row for every cycle, and waiting consumes no ordinal at all. That
+means downstream steps land on identical ordinals whether the step retried zero times or ten, and
+`handle()` replays exactly as it did before — see [Determinism rules](./determinism-rules.md).
+
+The counters are two different things: `attempts` keeps counting *every* execution cumulatively
+(including queue retries), while `retry_signal_attempts` counts only the signal-gated cycles.
+
+## Things worth knowing
+
+- **Don't wrap a step in your own `DB::transaction()`.** The engine suspends by throwing, so an
+  application transaction around `->run()` would roll the suspension's bookkeeping back. This is true
+  of every suspending seam in the package, not only this one.
+- **Package event listeners must be queued (`ShouldQueue`) or must not throw.** A throwing listener
+  on `ActionRetried` or `FlowSignalConsumed` interrupts the replay mid-way, and the engine reads that
+  as a business failure.
+- **Turn `repair.enabled` on in production.** If a process dies between committing a retry and
+  dispatching its job, the step sits `Pending` with no job behind it. The doctor re-dispatches it —
+  but it is off by default. See [Expiration & monitoring](./expiration-and-monitoring.md).
+- **A signal delivered in the same second the step failed counts for that failure.** The engine
+  matches a floating signal to the attempt with second resolution, so a signal that landed just
+  *before* the failure in the same second is treated as arriving after it. The cost is bounded: at
+  most one extra cycle, and the budget still applies.
+- **The three wait-signal transitions raise no Eloquent model events.** Delivery into an open wait,
+  closing a superseded wait, and timing a wait out are written as single conditional `UPDATE`s —
+  the only form that is atomic on every supported driver. An observer registered on a swapped-in
+  `models.flow_signal` will not see them. Every transition is still recorded in `flow_events`, and
+  where one exists, in the package's own Laravel event.

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -55,6 +55,11 @@ alone; if it succeeds, the workflow continues to `ShipOrder` as if nothing had h
 - **`$only`** — a list of exception classes that may trigger a park. Subclasses count. Anything else
   fails the step normally, so a `TypeError` never parks a saga for a day.
 
+`maxRetries` and `waitSeconds` must be zero or greater — `null`, not a negative number, is how you
+say "no limit". A negative value raises an `InvalidArgumentException` rather than reaching the
+database, where it would be an error on MySQL and a step that silently never parks elsewhere. The
+same applies to the configured `actions.retry_on_signal.max_retries`.
+
 ```php
 $this->action(ChargeCard::class, $orderId)
     ->compensateWith(RefundCard::class, $orderId)

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -74,3 +74,10 @@ You can trigger a rollback from outside the workflow through the handle:
 ```php
 SagaFlow::loadFlow($runId)->compensate(); // roll back completed steps, then cancel
 ```
+
+## Postponing a rollback
+
+Not every failure deserves a rollback. When a step failed only because the world was not ready — a
+declined card, a service still provisioning — `retryOnSignal()` parks that step and waits instead of
+compensating, and re-runs it alone when the signal arrives. Compensation happens only if the retry
+policy eventually gives up. See [Retry on signal](./retry-on-signal.md).

--- a/docs/docs/side-effects.md
+++ b/docs/docs/side-effects.md
@@ -1,7 +1,7 @@
 ---
 id: side-effects
 title: Side effects
-sidebar_position: 8
+sidebar_position: 9
 ---
 
 # Side effects

--- a/docs/docs/signals.md
+++ b/docs/docs/signals.md
@@ -80,6 +80,13 @@ non-terminal run — `Pending`, `Running`, or `Waiting` — and a flow parked on
 **`Waiting`**, not `Running`. Filtering by `running()` would silently miss exactly the run you are
 trying to wake.
 
+## Reviving a failed step
+
+A signal can also restart a step that already failed, instead of being awaited at a point in
+`handle()`. `->retryOnSignal('balance-refilled')` on an action parks it when it fails and re-runs it
+when that signal is delivered — using the same delivery API as everything above. See
+[Retry on signal](./retry-on-signal.md).
+
 You can also deliver from the CLI — see [Artisan commands](./artisan-commands.md):
 
 ```bash

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -1,7 +1,7 @@
 ---
 id: synchronous-execution
 title: Synchronous execution
-sidebar_position: 15
+sidebar_position: 16
 ---
 
 # Synchronous execution

--- a/docs/docs/tags-and-querying.md
+++ b/docs/docs/tags-and-querying.md
@@ -1,7 +1,7 @@
 ---
 id: tags-and-querying
 title: Tags & querying
-sidebar_position: 12
+sidebar_position: 13
 ---
 
 # Tags & querying

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -1,7 +1,7 @@
 ---
 id: testing
 title: Testing your workflows
-sidebar_position: 21
+sidebar_position: 22
 ---
 
 # Testing your workflows

--- a/docs/docs/versioning.md
+++ b/docs/docs/versioning.md
@@ -1,7 +1,7 @@
 ---
 id: versioning
 title: Versioning long-running workflows
-sidebar_position: 17
+sidebar_position: 18
 ---
 
 # Versioning long-running workflows

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -8,8 +8,8 @@
       "name": "saga-lara-flow-docs",
       "version": "1.0.0",
       "dependencies": {
-        "@docusaurus/core": "^3.7.0",
-        "@docusaurus/preset-classic": "^3.7.0",
+        "@docusaurus/core": "^3.10.2",
+        "@docusaurus/preset-classic": "^3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.1.0",
         "prism-react-renderer": "^2.3.0",
@@ -17,25 +17,40 @@
         "react-dom": "^18.3.1"
       },
       "devDependencies": {
-        "@docusaurus/module-type-aliases": "^3.7.0",
-        "@docusaurus/tsconfig": "^3.7.0",
-        "@docusaurus/types": "^3.7.0",
+        "@docusaurus/module-type-aliases": "^3.10.2",
+        "@docusaurus/tsconfig": "^3.10.2",
+        "@docusaurus/types": "^3.10.2",
         "typescript": "~5.6.2"
       },
       "engines": {
         "node": ">=18.0"
       }
     },
-    "node_modules/@algolia/abtesting": {
-      "version": "1.21.1",
-      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.21.1.tgz",
-      "integrity": "sha512-Wia5/mNTfiU0PIUN25UMfAGGdASkkwuCS9nBAdmhqrNPY/ff7U/6MgBVdwFDPsa3sA1msutPtO50gvOzx6MOXA==",
+    "node_modules/@11ty/gray-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@11ty/gray-matter/-/gray-matter-1.0.0.tgz",
+      "integrity": "sha512-7mJJl+wf1AByoT0PknQiQfOPnVNT4fevGrUBVWO4HXsnYn1aQPyRyrELYrNUFleUBM++KzMKN6QaxHPk0t/6/g==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "js-yaml": "^4.1.0",
+        "kind-of": "^6.0.3",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=11"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.23.0.tgz",
+      "integrity": "sha512-j45MBISstltys9QyQ4xf6quRiN1g7vMuwQL9VM4dx8YuRZvCQ173b9royZAx6iAbRX3IB1VnG1z//NuwyQ8jpQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -74,99 +89,99 @@
       }
     },
     "node_modules/@algolia/client-abtesting": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.55.1.tgz",
-      "integrity": "sha512-miW8RzAtBgNiEJ9fGEhsOPgWUpekAe64YcVufqXrlykj0Jjmo5nj0a5f/HAzRVX5ZuU1GAVd7BkzFDx7q50P3A==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.57.0.tgz",
+      "integrity": "sha512-JVFFujiZUCguk5tz3LZr4fTQxqpIrj4/Jw3SI7kMljSqtfLxYn/s/TWH0J2s4iNfsDpxPhgFGMotCpmDI4kZ8w==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-analytics": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.55.1.tgz",
-      "integrity": "sha512-eR3J3kB9JX6DdCvDRi3I4KPfwO6fR9HWYRXhVke2TXIoOQafMKCRAneg33JRmIrb+DnnJ/eWApJLF1O1CLPERg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.57.0.tgz",
+      "integrity": "sha512-6KqECK4ED3JJQEoDrQWnGPQzElA828xAD4qK5ceawNNyP/LcSvzAoLHjFkoTPksZ/kxj6VUtCRH+IHZesLltng==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-common": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.55.1.tgz",
-      "integrity": "sha512-P5ak7EurwYqgAiDyb95mgA3WRR/Zu8CPMv36lWTISvL2AmlPyqQPy2nX/KEJRTcwaeTWwrk6wJV4/M93GfjOWw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.57.0.tgz",
+      "integrity": "sha512-uqpGF3oXYsoCbQq5d7BzNrNTfIfuvJyGP1CKvSW27T9boUg7KOwyxsAw1AX0a3jSW2HrYEJ/NN+Z4MiGivbpeQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-insights": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.55.1.tgz",
-      "integrity": "sha512-OVtj9uA//+pjvKQI5INnzbyLrf3ClNv3XRbWswwJ2kHIStQNHtBfHo+LofNB/WhM9xjuXlW5ANn2aMj65UGx7w==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.57.0.tgz",
+      "integrity": "sha512-u5NboJVJXDEFplvNnqqX4CxkXPYysjJRj47hOSh9329H8kG5gFLKJBIiS5utMQ+GZm8xQl3Te7NInDk6elEADQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-personalization": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.55.1.tgz",
-      "integrity": "sha512-oKlVFlp+qbIEe4p7E54zSiP2gEV/vDu972Ykv8VDMFwEvreS7m0YKA3a8hGGHwc7yiBUGGiR3LlwzMLfnJmy6Q==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.57.0.tgz",
+      "integrity": "sha512-uzc0b2LmHAK9/QID4xeo35OG84AkZl4YewkCqawqAOGLjT2eZpM/OZx45ESygMHG30Ws+ZTSdluPtMJcUnrbWQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-query-suggestions": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.55.1.tgz",
-      "integrity": "sha512-BOVrld6vdtsFmotVDMTVQfYXwrVplJ+DUvy60JFi+tkWV698q2J9NNPKEO3dr5qxtSLKQP4vHF8n+3U5PDWhOQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.57.0.tgz",
+      "integrity": "sha512-dIAhnM6ue/ssa5PjgNfu4g8A4yTojl9ZOUzZU3wIaIKRerL2R/3Emuf9n/D6ICXXP167KC6XCeC7nliSw7cuSw==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/client-search": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.55.1.tgz",
-      "integrity": "sha512-GAqHl9zERhC3bbBfubwUu07G3UXO06gORvOcsiTBZB3et0s3auNUbHlYdYNp4VKa3sUZqH5AcD3OKzU/KDGXjQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.57.0.tgz",
+      "integrity": "sha512-2TTPTTKSJmCptvhCm4Xf3bBYMqZni+Pgc2hVdqc4l9wsBpSJNVTVIKpnd10OubUgkGcmppVDj1XQqYaf6EnPSQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -179,81 +194,81 @@
       "license": "MIT"
     },
     "node_modules/@algolia/ingestion": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.55.1.tgz",
-      "integrity": "sha512-BXZw+C+gsWL7pZvbnhJUnCXASiDLGcQxVV7h55Pyh2DmSzwdZIVccE5xc9RVD2trtrhIqk5smuODTxtaZqd0IA==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.57.0.tgz",
+      "integrity": "sha512-W4JseHKt+pzOxlFV+T3MWEG0h4Z2Se5zjoXUD0ewlw8aOWMG/yjRdopUdLQsXULepB/My2tDuZjkwk2sMfsUrQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/monitoring": {
-      "version": "1.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.55.1.tgz",
-      "integrity": "sha512-9g/ceZrZTqA62FA3588Xj0onRPjDNfu0pVQqefK0rrHp9H6Wblph/YmzGjZ2g8uqbTh0ZGIvAGCzErU8f7MHpA==",
+      "version": "1.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.57.0.tgz",
+      "integrity": "sha512-BrxJVE0/eLinEPICCD7BKN/2xnt0nkjge70u8zzE2ISP3fuB3tjLgcwpanUycvlHBFLI4gK0l5ol54p6IYuR/Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/recommend": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.55.1.tgz",
-      "integrity": "sha512-cZTIrGyAP+W4A6jDVwvWM/JOaoJKQkD/2a5eLUEeNdKAD45jN7BCpsMDONyhZlosLa4UwL8uiINQzj4iFy9nqg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.57.0.tgz",
+      "integrity": "sha512-Gc29jkeiLKlVfHvyrIgyUHHE+aYTdXEeLfK42rjr5/1TTVsYwUJz0XkvoIBIqfMjcDg6gXeHb1jTUZ0H+SYIlQ==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/client-common": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-browser-xhr": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.55.1.tgz",
-      "integrity": "sha512-N6I3leW0UO8Y9Zv90yo2UHgYGuxZO0mjbvzNxDIJDjO0qECEF7Z9XMvSNeUWXQh/iNDA9lr8MfEy3rmZGIcclw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.57.0.tgz",
+      "integrity": "sha512-PIPnPN7MP3fp2VAi01BVXhCWmD366ZB2Hkq5TlYKtThd4KxUtMmaaNDpFgVCTXtSIqWVZLJntOHRvxg/sIPd8Q==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-fetch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.55.1.tgz",
-      "integrity": "sha512-ukU5zeeFs44rQkzv+TRdYard+d+3lmPGs8lPZhHtWE8rfz+LlBSF6s9kP3VQ7LeOYL8Dz0u6tZfnyTrqrumbHQ==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.57.0.tgz",
+      "integrity": "sha512-AX3RlOudXMdTwtwUqdAf5hAVLvXfOZZH1FZh6ALDdrhVLT0TtAIe48N6nYcWcTnwoTxK/wDIQqZ19IMjK8zJAA==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/@algolia/requester-node-http": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.55.1.tgz",
-      "integrity": "sha512-lCwXyijwPm3vbYHpBXPRomMcD6mgiptmps27gnMCf4HK+u/AOeFPBnIFh4V3l4A5SnP9VRiKBZqwGBpUH0vaTg==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.57.0.tgz",
+      "integrity": "sha512-cWZc1dKb7wy9/wPpwMtL1y89gK2G7y2A47Coa7zwf1ydtIeJm4+S+XxoQ2b/ZRiQnrC1YHavLjYUPDCdnT7Khg==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/client-common": "5.55.1"
+        "@algolia/client-common": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
@@ -322,13 +337,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
-      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.8.tgz",
+      "integrity": "sha512-gZbepsdh3WDtgZKWL+vTPh71LSBrm/Y4/QDZBVCcYfmeTEEuoOYwlSy+G1StfJg+/Zy550u/3TATbm7qDbbMtg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/parser": "^7.29.8",
+        "@babel/types": "^7.29.8",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -621,12 +636,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
-      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.8.tgz",
+      "integrity": "sha512-E8lTAYNB1KW+FH+VGJuZM1ioAx2E6oVlvQFRrf5P8ZZmsiJXYAD9vTFV7yyEURNzgh1dFqMZuO6tUwcARbqFCA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.7"
+        "@babel/types": "^7.29.8"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1227,15 +1242,15 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
-      "integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.8.tgz",
+      "integrity": "sha512-6iSnEK0zlkLKU4heofK/AdmRD4e2SHVpJMtrwnTCzhnaM98ria4rTrOXBBi45BTTYnJtO8txnPsX4fChYXkmeA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-module-transforms": "^7.29.7",
         "@babel/helper-plugin-utils": "^7.29.7",
         "@babel/helper-validator-identifier": "^7.29.7",
-        "@babel/traverse": "^7.29.7"
+        "@babel/traverse": "^7.29.8"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1531,9 +1546,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-regenerator": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.7.tgz",
-      "integrity": "sha512-rNNFV0DBAJp988xW2DOntfDoYn1eR8GGF5AT5vYc+rjyfaQkM242c9tZUHHPe7KYaiJizXPWhQTzzdbXySyhBw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-regenerator/-/plugin-transform-regenerator-7.29.8.tgz",
+      "integrity": "sha512-0UpIXPtdDtMXfnV2OJAVMLpj3H/92vmkA6lpSRakmycJvj3VUy6Xs1dM8tXRugupykr5WB+LpiVl0J8LMVg2mg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7"
@@ -1621,9 +1636,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-spread": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.7.tgz",
-      "integrity": "sha512-/u5K1QWada7tbYNqTjMh96718g9NTwh9tfPJMsSmVsQwGT447FskV+KcfeXkXq2GWki4EM/MuTdmBec+hOuVTQ==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-spread/-/plugin-transform-spread-7.29.8.tgz",
+      "integrity": "sha512-4S9ksMGVWUshvgK0mKfvZky7leuG5/uoFVwMpAomJ8bMoDJiNHRVmc1EglwW/CmGVSqqWpEbXm9FmbRit22qoA==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.29.7",
@@ -1947,17 +1962,17 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
-      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.8.tgz",
+      "integrity": "sha512-I5z7H3bf/41ktsNVLtpN0wAa336HkqIHQ5BuPLEhTkt1jVSyZpeNKIzTgEWmlxjdg81R0IgUCcaE+Ok3NvrfZg==",
       "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
-        "@babel/generator": "^7.29.7",
+        "@babel/generator": "^7.29.8",
         "@babel/helper-globals": "^7.29.7",
-        "@babel/parser": "^7.29.7",
+        "@babel/parser": "^7.29.8",
         "@babel/template": "^7.29.7",
-        "@babel/types": "^7.29.7",
+        "@babel/types": "^7.29.8",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1965,9 +1980,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.29.7",
@@ -2221,9 +2236,9 @@
       }
     },
     "node_modules/@csstools/postcss-cascade-layers/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -2642,9 +2657,9 @@
       }
     },
     "node_modules/@csstools/postcss-is-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3089,9 +3104,9 @@
       }
     },
     "node_modules/@csstools/postcss-scope-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -3313,9 +3328,9 @@
       }
     },
     "node_modules/@docsearch/core": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.6.3.tgz",
-      "integrity": "sha512-rUOujwIpxJRgD7+kicVsI3D5sqBvdiRTquzWBpTEXZs8ZXfGbfzpus5HqumaNYTppN2HvH8E2yNuRwYdHJeOlA==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/core/-/core-4.7.0.tgz",
+      "integrity": "sha512-p/9xVKmPDj3FPvMfPf5naVO3Ej8SCbcUugGvx1+8GgkuBNbqxqN2Irx3WLBv8VY0jH7XpRwKWdlmjXLZsmTLsg==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3335,20 +3350,20 @@
       }
     },
     "node_modules/@docsearch/css": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.6.3.tgz",
-      "integrity": "sha512-nlOwcXcsNAptQl4vlL4MA78qNJKO0Qlds5GuBjCoePgkebTXLSf8Qt1oyZ3YBshYupKXG9VRGEsk1zr23d+bzQ==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-4.7.0.tgz",
+      "integrity": "sha512-Sk5xkdRFeE7PeWjG9l4AfTwdvMfr9wHiwNNCpHXT4v4SNyNMKdHGvEILc31BgaVFGDDNbv5u/a73tofRiwbEZw==",
       "license": "MIT"
     },
     "node_modules/@docsearch/react": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.6.3.tgz",
-      "integrity": "sha512-Bg2wdDsoQVlNCcEKuEJAU04tvHCqgx8rIu+uIoM4pRtcx3TBKJuXutJik3LTA8LRc9YEyHkrYUrmcC0D7BYf+g==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-x6oedjJ8O8/pIDBsMo5Orca3/6cQCz616/CwthVe68l43mqnj2lrJ9kFQITBqy8hMsS3nWeBWFoVO5dJ1DCFKA==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "1.19.2",
-        "@docsearch/core": "4.6.3",
-        "@docsearch/css": "4.6.3"
+        "@docsearch/core": "4.7.0",
+        "@docsearch/css": "4.7.0"
       },
       "peerDependencies": {
         "@types/react": ">= 16.8.0 < 20.0.0",
@@ -3404,9 +3419,9 @@
       }
     },
     "node_modules/@docusaurus/babel": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.1.tgz",
-      "integrity": "sha512-DZzFO1K3v/GoEt1fx1DiYHF4en+PuhtQf1AkQJa5zu3CoeKSpr5cpQRUlz3jr0m44wyzmSXu9bVpfir+N4+8bg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/babel/-/babel-3.10.2.tgz",
+      "integrity": "sha512-aJ1hpGyvfkte3dDAfNbWM4biW4yWZBVz7TIGLZP+v+tWOBgxX3e0N5ZIXHIvmfNNXTI77pcHUx3KmtOk05Ze3Q==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
@@ -3418,8 +3433,8 @@
         "@babel/preset-typescript": "^7.25.9",
         "@babel/runtime": "^7.25.9",
         "@babel/traverse": "^7.25.9",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-plugin-dynamic-import-node": "^2.3.3",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0"
@@ -3429,17 +3444,17 @@
       }
     },
     "node_modules/@docusaurus/bundler": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.1.tgz",
-      "integrity": "sha512-HIqQPvbqnnQRe4NsBd1774KRarjXqS6wHsWELtyuSs1gCfvixJO2jUGH/OEBtr1Gvzpw+ze5CjGMvSJ8UE1KUw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/bundler/-/bundler-3.10.2.tgz",
+      "integrity": "sha512-i0ZNcy0f0WhaOlYVgzLsWhIoEXO9kS3HRoKPtgE6vQtZUq7arKZaYdNBudr3mqCmd+TyOkwtwfHgs1ENj07r5g==",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.25.9",
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/cssnano-preset": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/cssnano-preset": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "babel-loader": "^9.2.1",
         "clean-css": "^5.3.3",
         "copy-webpack-plugin": "^11.0.0",
@@ -3472,18 +3487,18 @@
       }
     },
     "node_modules/@docusaurus/core": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.1.tgz",
-      "integrity": "sha512-3pf2fXXw0eVk8WnC3T4LIigRDupcpvngpKo9Vy7mYyBhuddc0klDUuZAIfzMoK6z05pdlk6EFC/vBSX43+1O5w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/core/-/core-3.10.2.tgz",
+      "integrity": "sha512-EYByj6nk+aD9KeVxV6Hmo2/nAAT79P21Y82ycTBOBtrmqilloIbIEhgL2/8Xpt2Jz/pgNqHAwyusOGwmbKeJmA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/babel": "3.10.1",
-        "@docusaurus/bundler": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/babel": "3.10.2",
+        "@docusaurus/bundler": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "boxen": "^6.2.1",
         "chalk": "^4.1.2",
         "chokidar": "^3.5.3",
@@ -3491,7 +3506,7 @@
         "combine-promises": "^1.1.0",
         "commander": "^5.1.0",
         "core-js": "^3.31.1",
-        "detect-port": "^1.5.1",
+        "detect-port": "^2.1.0",
         "escape-html": "^1.0.3",
         "eta": "^2.2.0",
         "eval": "^0.1.8",
@@ -3539,9 +3554,9 @@
       }
     },
     "node_modules/@docusaurus/cssnano-preset": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.1.tgz",
-      "integrity": "sha512-eNfHGcTKCSq6xmcavAkX3RRclHaE2xRCMParlDXLdXVP01/a2e/jKXMj/0ULnLFQSNwwuI62L0Ge8J+nZsR7UQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/cssnano-preset/-/cssnano-preset-3.10.2.tgz",
+      "integrity": "sha512-4gCnHRbJLTloiwfvFAa92tgb2gI4KYhvjfQVYnEaiMO/EgvWfCo1LwytHXen+1oZAN0VAlS0JAPxp3MsvKDa3A==",
       "license": "MIT",
       "dependencies": {
         "cssnano-preset-advanced": "^6.1.2",
@@ -3554,9 +3569,9 @@
       }
     },
     "node_modules/@docusaurus/logger": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.1.tgz",
-      "integrity": "sha512-oPjNFnfJsRCkePVjkGrxWGq4MvJKRQT0r9jOP0eRBTZ7Wr9FAbzdP/Gjs0I2Ss6YRkPoEgygKG112OkE6skvJw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/logger/-/logger-3.10.2.tgz",
+      "integrity": "sha512-gSEwqtPfCAnC3ZSJY6xL7tcIfgg0vFD39jbv93eakuweyvO2864xR0K+kmKwBhkTCtWRNjuGGnb5rdmkD/ndqw==",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
@@ -3567,14 +3582,14 @@
       }
     },
     "node_modules/@docusaurus/mdx-loader": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.1.tgz",
-      "integrity": "sha512-GRmeb/wQ+iXRrFwcHBfgQhrJxGElgCsoTWZYDhccjsZVne1p8MK/EpQVIloXttz76TCe78kKD5AEG9n1xc1oxQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/mdx-loader/-/mdx-loader-3.10.2.tgz",
+      "integrity": "sha512-9Fd4V/SFjfrVQ0JH5EN0+iPWyFunvTeQE3gfyFeetqPaXMP0OylIjOw16dCuXG4NZJrYdBqwzjh18/h3gRi47w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/mdx": "^3.0.0",
         "@slorber/remark-comment": "^1.0.0",
         "escape-html": "^1.0.3",
@@ -3606,12 +3621,12 @@
       }
     },
     "node_modules/@docusaurus/module-type-aliases": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.1.tgz",
-      "integrity": "sha512-YoOZKUdGlp8xSYhuAkGdSo5Ydkbq4V4eK3sD8v0a2hloxCWdQbNBhkc+Ko9QyjpESc0BYcIGM5iHVAy5hdFV6w==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/module-type-aliases/-/module-type-aliases-3.10.2.tgz",
+      "integrity": "sha512-h/I5e4jaAhDHW4vaLENi1i2hnOEnXY1t9R+nnRTbgUl7ymVRzN/HF7dDfj8rKYGj8gfIge+Ef+iYRAMtbGvsrQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3625,19 +3640,19 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-blog": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.1.tgz",
-      "integrity": "sha512-mmkgE6Q2+K74tnkou7tXlpDLvoCU/qkSa2GSQ3XUiHWvcebCoDQzS670RR3tO8PmaWlIyWWISYWzZLuMfxunRA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-blog/-/plugin-content-blog-3.10.2.tgz",
+      "integrity": "sha512-0cbEnNKf0InmLkhj/+nVRmqEnWEoOE8Mh+2x1qOXI0qYpCnphq4RXknVJ8BvybKRXqYVvbmdMfiJSup+k4tm5w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "cheerio": "1.0.0-rc.12",
         "combine-promises": "^1.1.0",
         "feed": "^4.2.2",
@@ -3660,20 +3675,20 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-docs": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.1.tgz",
-      "integrity": "sha512-2jRVrtzjf8LClGTHQlwlwuD3wQXRx3WEoF7XUarJ8Ou+0onV+SLtejsyfY9JLpfUh9hPhXM4pbBGkyAY4Bi3HQ==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-docs/-/plugin-content-docs-3.10.2.tgz",
+      "integrity": "sha512-Sqwl4FPoZBDrlY8I2VU2H8O0M91CHp9T8ToMSkTZmjvHCif+1laqfXi6sTk8IfyVS/trN5yNjcWd1bFsGB6W5Q==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@types/react-router-config": "^5.0.7",
         "combine-promises": "^1.1.0",
         "fs-extra": "^11.1.1",
@@ -3693,16 +3708,16 @@
       }
     },
     "node_modules/@docusaurus/plugin-content-pages": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.1.tgz",
-      "integrity": "sha512-huJpaRPMl42nsFwuCXvV8bVDj2MazuwRJIUylI/RSlmZeJssVoZXeCjVf1y+1Drtpa9SKcdGn8yoJ76IRJijtw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-content-pages/-/plugin-content-pages-3.10.2.tgz",
+      "integrity": "sha512-h5R12sZ/vV9EPiVjvIl9YFCOwkpwXes7dQMYt3EvP6Pphu4amHxxTqWxf08Fl5DR8h+oZMbWpFTNw5vKEYfvzQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "tslib": "^2.6.0",
         "webpack": "^5.88.1"
@@ -3716,15 +3731,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-css-cascade-layers": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.1.tgz",
-      "integrity": "sha512-r//fn+MNHkE1wCof8T29VAQezt1enGCpsFxoziBbvLgBM4JfXN2P3rxrBaavHmvLvm7lYkpJeitcDthwnmWCTw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-css-cascade-layers/-/plugin-css-cascade-layers-3.10.2.tgz",
+      "integrity": "sha512-UkdvQby5OQUKWrw3lLnSTJXQ6VETaUVTuPQX9AABtmFm5h+ifEBx1OQ+LN726Q4byuwBf2ElHkf4qU4hTxdvRg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3732,14 +3747,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-debug": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.1.tgz",
-      "integrity": "sha512-9KqOpKNfAyqGZykRb9LhIT/vyRF6sm/ykhjj/39JvaJahDS+jZJE0Z1Wfz9q3DUNDTMNN0Q7u/kk4rKKU+IJuA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-debug/-/plugin-debug-3.10.2.tgz",
+      "integrity": "sha512-8vbZNOSCpnsT57EY6CgN7sgRVmx3KTYwO8Uvo2pbxOyb8tbqAwtT9SslqaQ41HbA1v1hpn5RP7u5s2KvRwAFpQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
         "fs-extra": "^11.1.1",
         "react-json-view-lite": "^2.3.0",
         "tslib": "^2.6.0"
@@ -3753,14 +3768,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-analytics": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.1.tgz",
-      "integrity": "sha512-8o0P1KtmgdYQHH+oInitPpRWI0Of5XednAX4+DMhQNSmGSRNrsEEHg1ebv35m9AgRClfAytCJ5jA9KvcASTyuA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-analytics/-/plugin-google-analytics-3.10.2.tgz",
+      "integrity": "sha512-kMHMBK9j4VAtgd5owwrRLRIi0EjkrpXlX7ePj1+y68XfVZV9I1T4S+koPDm+Hfw2TtnyHvh0uNrDvjz+DjQGVA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3772,15 +3787,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-gtag": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.1.tgz",
-      "integrity": "sha512-pu3xIUo5o/zCMLfUY9BO5KOwSH0zIsAGyFRPvXHayFSA5XIhCU/SFuB0g0ZNjFn9niZLCaNvoeAuOGFJZq0fdw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-gtag/-/plugin-google-gtag-3.10.2.tgz",
+      "integrity": "sha512-Vt90nNFhtAChRe9+it1hcHFgFvETdSnOkL5Bma+p6E/yU2tAYrvvyk+gv+LJGM2ZUkyKuKXLRsZ2Lb0bO7+Vog==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
-        "@types/gtag.js": "^0.0.20",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3792,14 +3806,14 @@
       }
     },
     "node_modules/@docusaurus/plugin-google-tag-manager": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.1.tgz",
-      "integrity": "sha512-f6fyGHiCm7kJHBtAisGQS5oNBnpnMTYQZxDXeVrnw/3zWU+LMA22pr6UHGYkBKDbN+qPC5QHG3NuOfzQLq3+Lw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-google-tag-manager/-/plugin-google-tag-manager-3.10.2.tgz",
+      "integrity": "sha512-MLCffCldysi/R0nzJQP7ZWd0xAoGNnSTiVOo6TTR6mKVGFhE+/XArGe67ZcaZv1uytgQXoXs92VJrgVDrz80rQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -3811,17 +3825,17 @@
       }
     },
     "node_modules/@docusaurus/plugin-sitemap": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.1.tgz",
-      "integrity": "sha512-C26MbmmqgdjkDq1htaZ3aD7LzEDKFWXfpyQpt0EOUThuq5nV77zDaedV20yHcVo9p+3ey9aZ4pbHA0D3QcZTzg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-sitemap/-/plugin-sitemap-3.10.2.tgz",
+      "integrity": "sha512-PODkwg5XetLML3hU/3xpCKJUZ9cqExLaBnD/Fzzwj2VHogLeqnDisLIujae87zuze7T4mCm2A6KEqZkyiz07EQ==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "fs-extra": "^11.1.1",
         "sitemap": "^7.1.1",
         "tslib": "^2.6.0"
@@ -3835,15 +3849,15 @@
       }
     },
     "node_modules/@docusaurus/plugin-svgr": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.1.tgz",
-      "integrity": "sha512-6SFxsmjWFkVLDmBUvFK6i72QjUwqyQFe4Ovz+SUJophJjOyVG3ZZG5IQpBC/kX/Gfv1yWeU9nWauH6F6Q7QX/Q==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/plugin-svgr/-/plugin-svgr-3.10.2.tgz",
+      "integrity": "sha512-JgfT3jWM0TJ8Uw0cEcqxHpybngQY1vlBYpuuNO+gEh5iPh5Ar+vxq/u9CFrYsWeXy48BN7Db76Pzp2edNXUQ8A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@svgr/core": "8.1.0",
         "@svgr/webpack": "^8.1.0",
         "tslib": "^2.6.0",
@@ -3858,26 +3872,26 @@
       }
     },
     "node_modules/@docusaurus/preset-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.1.tgz",
-      "integrity": "sha512-YO/FL8v1zmbxoTso6mjMz/RDjhaTJxb1UpFFTDdY5847LLDCeyYiYlrhyTbgN1RIN3xnkLKZ9Lj1x8hUzI4JOg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/preset-classic/-/preset-classic-3.10.2.tgz",
+      "integrity": "sha512-a4B3VczmDl99zK0EufDQYomdJ186WDingjmDXxhN2PNPS9Ty/Y2M5CLFX1KQMRKqRTLiRDKfutzG5IY1FC/ceg==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/plugin-css-cascade-layers": "3.10.1",
-        "@docusaurus/plugin-debug": "3.10.1",
-        "@docusaurus/plugin-google-analytics": "3.10.1",
-        "@docusaurus/plugin-google-gtag": "3.10.1",
-        "@docusaurus/plugin-google-tag-manager": "3.10.1",
-        "@docusaurus/plugin-sitemap": "3.10.1",
-        "@docusaurus/plugin-svgr": "3.10.1",
-        "@docusaurus/theme-classic": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-search-algolia": "3.10.1",
-        "@docusaurus/types": "3.10.1"
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/plugin-css-cascade-layers": "3.10.2",
+        "@docusaurus/plugin-debug": "3.10.2",
+        "@docusaurus/plugin-google-analytics": "3.10.2",
+        "@docusaurus/plugin-google-gtag": "3.10.2",
+        "@docusaurus/plugin-google-tag-manager": "3.10.2",
+        "@docusaurus/plugin-sitemap": "3.10.2",
+        "@docusaurus/plugin-svgr": "3.10.2",
+        "@docusaurus/theme-classic": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-search-algolia": "3.10.2",
+        "@docusaurus/types": "3.10.2"
       },
       "engines": {
         "node": ">=20.0"
@@ -3888,24 +3902,24 @@
       }
     },
     "node_modules/@docusaurus/theme-classic": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.1.tgz",
-      "integrity": "sha512-VU1RK0qb2pab0si4r7HFK37cYco8VzqLj3u1PspVipSr/z/GPVKHO4/HXbnePqHoWDk8urjyGSeatH0NIMBM1A==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-classic/-/theme-classic-3.10.2.tgz",
+      "integrity": "sha512-JqTSLQmqmA9uKWZsD5iwBGJ4JyKB4/yTw6PsSXVPRJG/6GAm/u+add9Iip+hvwP12/AnPNztrdxsI14NJW4KeA==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/plugin-content-blog": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/plugin-content-pages": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/plugin-content-blog": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/plugin-content-pages": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "@mdx-js/react": "^3.0.0",
         "clsx": "^2.0.0",
         "copy-text-to-clipboard": "^3.2.0",
@@ -3929,15 +3943,15 @@
       }
     },
     "node_modules/@docusaurus/theme-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.1.tgz",
-      "integrity": "sha512-0YtmIeoNo1fIw65LO8+/1dPgmDV86UmhMkow37gzjytuiCSQm9xob6PJy0L4kuQEMTLfUOGvkXvZr7GPrHquMA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-common/-/theme-common-3.10.2.tgz",
+      "integrity": "sha512-R9b/vMpK1yye6hNZTA6x/ivRv+at6GhxnXcxkpzCGzO1R1RwiquqiFg2wMFh6aqlJTpWRFKpFD2TzCDQcyOU0A==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/mdx-loader": "3.10.1",
-        "@docusaurus/module-type-aliases": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/mdx-loader": "3.10.2",
+        "@docusaurus/module-type-aliases": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "@types/history": "^4.7.11",
         "@types/react": "*",
         "@types/react-router-config": "*",
@@ -3957,20 +3971,20 @@
       }
     },
     "node_modules/@docusaurus/theme-search-algolia": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.1.tgz",
-      "integrity": "sha512-OTaARARVZj2GvkJQjB+1jOIxntRaXea+G+fMsNqrZBAU1O1vJKDW22R7kECOHW27oJCLFN9HKaZeRrfAUyviug==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-search-algolia/-/theme-search-algolia-3.10.2.tgz",
+      "integrity": "sha512-1msxllyhi/5m77JukXtp5UFnUAriwZIC1oJ7MTnpQpCwLTbclJi5BK5n28CTZuSXpQN2ewbbnqRgAhMM6c6ihg==",
       "license": "MIT",
       "dependencies": {
         "@algolia/autocomplete-core": "^1.19.2",
         "@docsearch/react": "^3.9.0 || ^4.3.2",
-        "@docusaurus/core": "3.10.1",
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/plugin-content-docs": "3.10.1",
-        "@docusaurus/theme-common": "3.10.1",
-        "@docusaurus/theme-translations": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-validation": "3.10.1",
+        "@docusaurus/core": "3.10.2",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/plugin-content-docs": "3.10.2",
+        "@docusaurus/theme-common": "3.10.2",
+        "@docusaurus/theme-translations": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-validation": "3.10.2",
         "algoliasearch": "^5.37.0",
         "algoliasearch-helper": "^3.26.0",
         "clsx": "^2.0.0",
@@ -3989,9 +4003,9 @@
       }
     },
     "node_modules/@docusaurus/theme-translations": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.1.tgz",
-      "integrity": "sha512-cLMyaKivjBVWKMJuWqyFVVgtqe8DPJNPkog0bn8W1MDVAKcPdxRFycBfC1We1RaNp7Rdk513bmtW78RR6OBxBw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/theme-translations/-/theme-translations-3.10.2.tgz",
+      "integrity": "sha512-iv20wrxnyXkY89LM3TzRlzGlt5fIGO5UnaR6UL1ZVfB9RRFjxQFQ6awDrwAc6Km8Y5gD8pInuwYPF+6/TiCxXA==",
       "license": "MIT",
       "dependencies": {
         "fs-extra": "^11.1.1",
@@ -4002,16 +4016,16 @@
       }
     },
     "node_modules/@docusaurus/tsconfig": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.1.tgz",
-      "integrity": "sha512-rYvB7yqkdqWIpAbDzQljGfM4cDBkLTbhmagZBEcsyj6oPUsz47lmW2pYdN1j+7sGFgltbAmQH62xfbrij4Eh6Q==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/tsconfig/-/tsconfig-3.10.2.tgz",
+      "integrity": "sha512-5GiB7h/nFsMFPO9mCqcRNE1yA5TSXXNCshNIgHPL6fCPOjcTDixs6qjQBu8ddkgPcicwCvOA7n3jeK2rGdJk6g==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@docusaurus/types": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.1.tgz",
-      "integrity": "sha512-XYMK8k1szDCFMw2V+Xyen0g7Kee1sP3dtFnl7vkGkZOkeAJ/oPDQPL8iz4HBKOo/cwU8QeV6onVjMqtP+tFzsw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/types/-/types-3.10.2.tgz",
+      "integrity": "sha512-B6rvfwIFSapUqUJjMriZswX13K8l5Z7AcmVE6uTEJpYddQieSTR12DsGaFtcZAIDsQd4p+0WTl0Vc6jmZK0Trw==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
@@ -4045,21 +4059,21 @@
       }
     },
     "node_modules/@docusaurus/utils": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.1.tgz",
-      "integrity": "sha512-3ojeJry9xBYdJO6qoyyzqeJFSJBVx2mXhyDzSdjwL2+URFQMf+h25gG38iswGImicK0ELjTd1EL2xzk8hf3QPw==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils/-/utils-3.10.2.tgz",
+      "integrity": "sha512-xx0W3eav2uW1NRIpuHJWNwLTC15xPNjU4Uxi9NSnd3swYC96BE3vFiT93SD8s24kmAAWNwgZwfZ2fghGZ01Lcw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/types": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@11ty/gray-matter": "^1.0.0",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/types": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "escape-string-regexp": "^4.0.0",
         "execa": "^5.1.1",
         "file-loader": "^6.2.0",
         "fs-extra": "^11.1.1",
         "github-slugger": "^1.5.0",
         "globby": "^11.1.0",
-        "gray-matter": "^4.0.3",
         "jiti": "^1.20.0",
         "js-yaml": "^4.1.0",
         "lodash": "^4.17.21",
@@ -4077,12 +4091,12 @@
       }
     },
     "node_modules/@docusaurus/utils-common": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.1.tgz",
-      "integrity": "sha512-5mFSgEADtnFxFH7RLw02QA5MpU5JVUCj0MPeIvi/aF4Fi45tQRIuTwXoXDqJ+1VfQJuYJGz3SI63wmGz4HvXzA==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-common/-/utils-common-3.10.2.tgz",
+      "integrity": "sha512-x3Dz6jv6iQKBNjBmVTu8p57abMp/VNTUgKBMgRVXJc5444orBTsArv0+cdfrXTiz/VMmHfDRVkPbL7GH2B7T7w==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/types": "3.10.1",
+        "@docusaurus/types": "3.10.2",
         "tslib": "^2.6.0"
       },
       "engines": {
@@ -4090,14 +4104,14 @@
       }
     },
     "node_modules/@docusaurus/utils-validation": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.1.tgz",
-      "integrity": "sha512-cRv1X69jwaWv47waglllgZVWzeBFLhl53XT/XED/83BerVBTC5FTP8WTcVl8Z6sZOegDSwitu/wpCSPCDOT6lg==",
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/@docusaurus/utils-validation/-/utils-validation-3.10.2.tgz",
+      "integrity": "sha512-sn8unbDfUL585NtR3cwHefPicOyaHvPaX7VD0aOg/siIxUBoKyKKaGEqzJZDS64mM43TnxurkYDtmB1wsJlZsw==",
       "license": "MIT",
       "dependencies": {
-        "@docusaurus/logger": "3.10.1",
-        "@docusaurus/utils": "3.10.1",
-        "@docusaurus/utils-common": "3.10.1",
+        "@docusaurus/logger": "3.10.2",
+        "@docusaurus/utils": "3.10.2",
+        "@docusaurus/utils-common": "3.10.2",
         "fs-extra": "^11.2.0",
         "joi": "^17.9.2",
         "js-yaml": "^4.1.0",
@@ -4949,9 +4963,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.27.10",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.10.tgz",
-      "integrity": "sha512-MTBk/3jGLNB2tVxv6uLlFh1iu64iYOQ2PbdOSK3NW8JZsmlaOh2q6sdtKowBhfw8QFLmYNzTW4/oK4uATIi6ZA==",
+      "version": "0.27.12",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.12.tgz",
+      "integrity": "sha512-hhyNJ+nbR6ZR7pToHvllEFun9TL0sbL+tk/ON75lo+Xas054uez98qRbsuNt7MBCyZKK4+8Yli/OAGZhmfBZ/g==",
       "license": "MIT"
     },
     "node_modules/@sindresorhus/is": {
@@ -5332,16 +5346,10 @@
         "@types/send": "*"
       }
     },
-    "node_modules/@types/gtag.js": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@types/gtag.js/-/gtag.js-0.0.20.tgz",
-      "integrity": "sha512-wwAbk3SA2QeU67unN7zPxjEHmPmlXwZXZvQEpbEUQuMCRGgKyE1m6XDuTUA9b6pCGb/GqJmdfMOY5LuDjJSbbg==",
-      "license": "MIT"
-    },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
-      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
       "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
@@ -5599,9 +5607,9 @@
       "license": "MIT"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.2.tgz",
-      "integrity": "sha512-5jsZFwgR5rTdKwidH9Qmat75RKwqfpKlWWB1frDkljN127mwqBu8K0PYo7/hFpF03IEJpfVPpCQDY/eDx3iHvA==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
       "license": "ISC"
     },
     "node_modules/@webassemblyjs/ast": {
@@ -5851,12 +5859,12 @@
       }
     },
     "node_modules/address": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/address/-/address-1.2.2.tgz",
-      "integrity": "sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/address/-/address-2.0.3.tgz",
+      "integrity": "sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 10.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/aggregate-error": {
@@ -5918,34 +5926,34 @@
       }
     },
     "node_modules/algoliasearch": {
-      "version": "5.55.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.55.1.tgz",
-      "integrity": "sha512-FyaFnnsbVPtevQwqSj/SdxE3jAsSsY0BEH8IVLf9rXxEBdAhAmT6VKCVSMWoaPIHVN1Eufh/1w8q6k8URpIkWw==",
+      "version": "5.57.0",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.57.0.tgz",
+      "integrity": "sha512-HpND7MBGctOAkd1GoQoDZCGoCpqNTS5NG1LuhElFet3RdLJkwnyTYZXZhXwtpAQPrI36fqQ3eT6KQrdKDTKu3A==",
       "license": "MIT",
       "dependencies": {
-        "@algolia/abtesting": "1.21.1",
-        "@algolia/client-abtesting": "5.55.1",
-        "@algolia/client-analytics": "5.55.1",
-        "@algolia/client-common": "5.55.1",
-        "@algolia/client-insights": "5.55.1",
-        "@algolia/client-personalization": "5.55.1",
-        "@algolia/client-query-suggestions": "5.55.1",
-        "@algolia/client-search": "5.55.1",
-        "@algolia/ingestion": "1.55.1",
-        "@algolia/monitoring": "1.55.1",
-        "@algolia/recommend": "5.55.1",
-        "@algolia/requester-browser-xhr": "5.55.1",
-        "@algolia/requester-fetch": "5.55.1",
-        "@algolia/requester-node-http": "5.55.1"
+        "@algolia/abtesting": "1.23.0",
+        "@algolia/client-abtesting": "5.57.0",
+        "@algolia/client-analytics": "5.57.0",
+        "@algolia/client-common": "5.57.0",
+        "@algolia/client-insights": "5.57.0",
+        "@algolia/client-personalization": "5.57.0",
+        "@algolia/client-query-suggestions": "5.57.0",
+        "@algolia/client-search": "5.57.0",
+        "@algolia/ingestion": "1.57.0",
+        "@algolia/monitoring": "1.57.0",
+        "@algolia/recommend": "5.57.0",
+        "@algolia/requester-browser-xhr": "5.57.0",
+        "@algolia/requester-fetch": "5.57.0",
+        "@algolia/requester-node-http": "5.57.0"
       },
       "engines": {
         "node": ">= 14.0.0"
       }
     },
     "node_modules/algoliasearch-helper": {
-      "version": "3.29.1",
-      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.1.tgz",
-      "integrity": "sha512-6ck2YFudF2Pje7szQoPBiRFTGfd+1I+0I/WfLPGn0bj1kvrFoOQmNyedNiDxTk3/r4IfSLDYk+RA4G7u8H6+yA==",
+      "version": "3.29.3",
+      "resolved": "https://registry.npmjs.org/algoliasearch-helper/-/algoliasearch-helper-3.29.3.tgz",
+      "integrity": "sha512-gVOMbbPVrCO3Xs+B+BLAIGFqIQow6qHMTYCEeBqLQB9m4ZmKUqMwkEumlal2iyyezHEd4Y0FvFTLbCRutCutIQ==",
       "license": "MIT",
       "dependencies": {
         "@algolia/events": "^4.0.1"
@@ -6092,9 +6100,9 @@
       }
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.2",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
-      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "version": "10.5.4",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+      "integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6111,8 +6119,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.4",
-        "caniuse-lite": "^1.0.30001799",
+        "browserslist": "^4.28.6",
+        "caniuse-lite": "^1.0.30001806",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -6218,9 +6226,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.40",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
-      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "version": "2.11.18",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.18.tgz",
+      "integrity": "sha512-1iEmLEYSiE1SeBoAfPo/Mnx3PzfzHUkDK61ASkCpuk3YXugYLH5DYK1SzqV55F8FMI6s0F+/tCP7Polz1QRjxw==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6365,9 +6373,9 @@
       }
     },
     "node_modules/browserslist": {
-      "version": "4.28.4",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
-      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "version": "4.28.8",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.8.tgz",
+      "integrity": "sha512-V2NpofLblG64mfOtSgDhOJESZEGogzDMBv/q+W6oc4LXWP/q75eOXoOaaOu1EOadB9U4Bwx/e0yzbvwKH8zalA==",
       "funding": [
         {
           "type": "opencollective",
@@ -6384,11 +6392,11 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "baseline-browser-mapping": "^2.10.38",
-        "caniuse-lite": "^1.0.30001799",
-        "electron-to-chromium": "^1.5.376",
-        "node-releases": "^2.0.48",
-        "update-browserslist-db": "^1.2.3"
+        "baseline-browser-mapping": "^2.11.12",
+        "caniuse-lite": "^1.0.30001809",
+        "electron-to-chromium": "^1.5.402",
+        "node-releases": "^2.0.53",
+        "update-browserslist-db": "^1.3.0"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -6554,9 +6562,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001800",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
-      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "version": "1.0.30001809",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001809.tgz",
+      "integrity": "sha512-xxWVywk6a6Arlk+hymeycyn/VgqEfLDxupvhH/xiY5SJ/18kmi9o6MiO320DCUzypORHLtvh0I4i04tUhCNHNQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -6863,9 +6871,9 @@
       "license": "MIT"
     },
     "node_modules/colord": {
-      "version": "2.9.3",
-      "resolved": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
-      "integrity": "sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/colord/-/colord-2.10.0.tgz",
+      "integrity": "sha512-AidJptpBJmjTclAp9BkLwJi0T93fo5epJnbaZslpg6QVzpHjAiveF55mE9AcUJiGMqRHgMDY8soMsQtuNYMHfw==",
       "license": "MIT"
     },
     "node_modules/colorette": {
@@ -7160,12 +7168,15 @@
       }
     },
     "node_modules/core-js-compat": {
-      "version": "3.49.0",
-      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.49.0.tgz",
-      "integrity": "sha512-VQXt1jr9cBz03b331DFDCCP90b3fanciLkgiOoy8SBHy06gNf+vQ1A3WFLqG7I8TipYIKeYK9wxd0tUrvHcOZA==",
+      "version": "3.50.0",
+      "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.50.0.tgz",
+      "integrity": "sha512-XGpFGbMLHwSt74YLTKho7Ib242qi6O8MSX+sRokV4oz7iKXvQWGYZthjIhjRGMxjzVkAubBO512dKGYcefmX3Q==",
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1"
+        "browserslist": "^4.28.7"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       },
       "funding": {
         "type": "opencollective",
@@ -7271,9 +7282,9 @@
       }
     },
     "node_modules/css-blank-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7345,9 +7356,9 @@
       }
     },
     "node_modules/css-has-pseudo/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -7500,9 +7511,9 @@
       }
     },
     "node_modules/cssdb": {
-      "version": "8.9.0",
-      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.9.0.tgz",
-      "integrity": "sha512-J8jOU/hLjaXcO1LldOLraJSQpfLXRKof0I7mtbRyOy2AAXgqst0x9rlgi2qXeD6d0ou3ZLqcPAMqYVbpCbrxEw==",
+      "version": "8.10.0",
+      "resolved": "https://registry.npmjs.org/cssdb/-/cssdb-8.10.0.tgz",
+      "integrity": "sha512-+JWEEjjoqkPY7iGHps3SaCT2w67Zpaj9zHvhCJ2iPBavKHwgtOOD2YEbZSCU8VO2uVGpKdYjVz+j6bhkNSjZ0g==",
       "funding": [
         {
           "type": "opencollective",
@@ -7859,20 +7870,19 @@
       "license": "MIT"
     },
     "node_modules/detect-port": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-1.6.1.tgz",
-      "integrity": "sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/detect-port/-/detect-port-2.1.0.tgz",
+      "integrity": "sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==",
       "license": "MIT",
       "dependencies": {
-        "address": "^1.0.1",
-        "debug": "4"
+        "address": "^2.0.1"
       },
       "bin": {
-        "detect": "bin/detect-port.js",
-        "detect-port": "bin/detect-port.js"
+        "detect": "dist/commonjs/bin/detect-port.js",
+        "detect-port": "dist/commonjs/bin/detect-port.js"
       },
       "engines": {
-        "node": ">= 4.0.0"
+        "node": ">= 16.0.0"
       }
     },
     "node_modules/devlop": {
@@ -8043,9 +8053,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.383",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
-      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "version": "1.5.412",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.412.tgz",
+      "integrity": "sha512-z4rMe3esBzlzovKHj4gxJnsCGZRK5l4baUvm+gCGJBPE+gsyUMKsuU9tnEUtI1dOebXz1ytAPGjvXhmQ7rIPwA==",
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -8240,19 +8250,6 @@
       },
       "engines": {
         "node": ">=8.0.0"
-      }
-    },
-    "node_modules/esprima": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-      "license": "BSD-2-Clause",
-      "bin": {
-        "esparse": "bin/esparse.js",
-        "esvalidate": "bin/esvalidate.js"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/esrecurse": {
@@ -9111,43 +9108,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "license": "ISC"
-    },
-    "node_modules/gray-matter": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
-      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
-      "license": "MIT",
-      "dependencies": {
-        "js-yaml": "^3.13.1",
-        "kind-of": "^6.0.2",
-        "section-matter": "^1.0.0",
-        "strip-bom-string": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
-    "node_modules/gray-matter/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
-    "node_modules/gray-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/gzip-size": {
       "version": "6.0.0",
@@ -10256,9 +10216,9 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.4",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.4.tgz",
-      "integrity": "sha512-1RuuER6kmt8K8I3nIWvPZKi5RQCb568ZPyY4Pwjlua+yo+63ZTmIwxLZH0heBmiKN4uxjvCiarDrjaeH84xicQ==",
+      "version": "17.13.6",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.6.tgz",
+      "integrity": "sha512-ImNZaq/LSysofih+xIGYfR0WUXMA9GLUNB//YTCSrZptoRmVgaNAdJyi6K1kXi9pkLEoSkoI8I4UwtNiu/D7nw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/hoek": "^9.3.0",
@@ -10275,9 +10235,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "funding": [
         {
           "type": "github",
@@ -13073,9 +13033,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -13131,9 +13091,9 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.50",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
-      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "version": "2.0.53",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.53.tgz",
+      "integrity": "sha512-D9UOmYG3UH1V+ENW56t5QXBwJw1YEY18ruVeus89Rw+SyIgjPkCO84bRzO3uNIYosJbNwiabWVn48o3uJLjxFQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -13729,9 +13689,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -13748,7 +13708,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -13782,9 +13742,9 @@
       }
     },
     "node_modules/postcss-attribute-case-insensitive/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14026,9 +13986,9 @@
       }
     },
     "node_modules/postcss-custom-selectors/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14064,9 +14024,9 @@
       }
     },
     "node_modules/postcss-dir-pseudo-class/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14192,9 +14152,9 @@
       }
     },
     "node_modules/postcss-focus-visible/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14230,9 +14190,9 @@
       }
     },
     "node_modules/postcss-focus-within/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14519,9 +14479,9 @@
       }
     },
     "node_modules/postcss-modules-local-by-default/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14547,9 +14507,9 @@
       }
     },
     "node_modules/postcss-modules-scope/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -14646,9 +14606,9 @@
       }
     },
     "node_modules/postcss-nesting/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15009,9 +14969,9 @@
       }
     },
     "node_modules/postcss-pseudo-class-any-link/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -15102,9 +15062,9 @@
       }
     },
     "node_modules/postcss-selector-not/node_modules/postcss-selector-parser": {
-      "version": "7.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
-      "integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
+      "version": "7.1.5",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.5.tgz",
+      "integrity": "sha512-KvvtD7SrlBP7dlgkBghEE3r84CABm5SmV2aNcG4oCA+qDnJ/tvKonFVvwWAyyWUEwxuNawdfEAZKP9zM3oZ2Uw==",
       "license": "MIT",
       "dependencies": {
         "cssesc": "^3.0.0",
@@ -16234,9 +16194,9 @@
       "license": "MIT"
     },
     "node_modules/sax": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
-      "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.1.tgz",
+      "integrity": "sha512-42tBVwLWnaQvW5zc4HbZrTuWccECCZfBi92FDuwtqxasH+JbPB3/FOKb1m222K42R4WxuxzzMsTswfzgtSu64Q==",
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -16852,12 +16812,6 @@
         "wbuf": "^1.7.3"
       }
     },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/srcset": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/srcset/-/srcset-4.0.0.tgz",
@@ -17067,15 +17021,18 @@
       }
     },
     "node_modules/svg-parser": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.4.tgz",
-      "integrity": "sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==",
-      "license": "MIT"
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/svg-parser/-/svg-parser-2.0.5.tgz",
+      "integrity": "sha512-FuT74puvVMJQ8sgFxgOKPex5MbxPeltqCXJV3wR9Xq+vPHaF+tTdE1lhJcwspUxjtjvXy1NwqcSLZx9UNwHawg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/svgo": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-      "integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+      "integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
       "license": "MIT",
       "dependencies": {
         "commander": "^7.2.0",
@@ -17623,9 +17580,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
-      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.3.1.tgz",
+      "integrity": "sha512-ZZ61DsRsOnakl74HAmp3oSN4aXUmEWXf+i/yv0h7tIBfICc3VdrFErQKUUKPgu3AMsTUMbcongALEN4l6GSUrQ==",
       "funding": [
         {
           "type": "opencollective",

--- a/docs/package.json
+++ b/docs/package.json
@@ -13,8 +13,8 @@
     "typecheck": "tsc"
   },
   "dependencies": {
-    "@docusaurus/core": "^3.7.0",
-    "@docusaurus/preset-classic": "^3.7.0",
+    "@docusaurus/core": "^3.10.2",
+    "@docusaurus/preset-classic": "^3.10.2",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.1.0",
     "prism-react-renderer": "^2.3.0",
@@ -22,13 +22,17 @@
     "react-dom": "^18.3.1"
   },
   "devDependencies": {
-    "@docusaurus/module-type-aliases": "^3.7.0",
-    "@docusaurus/tsconfig": "^3.7.0",
-    "@docusaurus/types": "^3.7.0",
+    "@docusaurus/module-type-aliases": "^3.10.2",
+    "@docusaurus/tsconfig": "^3.10.2",
+    "@docusaurus/types": "^3.10.2",
     "typescript": "~5.6.2"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 3 chrome version",
       "last 3 firefox version",

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -16,6 +16,7 @@ const sidebars: SidebarsConfig = {
         'actions',
         'sagas-and-compensation',
         'signals',
+        'retry-on-signal',
         'side-effects',
         'parallel',
         'optional-actions',

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -264,8 +264,12 @@ class ActionBuilder
             } catch (Throwable $exception) {
                 // A step with a retry policy is resolved solely on replay: only the
                 // seam knows the only-filter and the budget. Replay so it sees the
-                // Failed row and decides whether to park or to give up.
-                if ($this->retrySignal !== null) {
+                // Failed row and decides whether to park or to give up — but only
+                // when the row really did fail. A throw from before that (a listener,
+                // an observer, an action class that will not resolve) leaves nothing
+                // for the seam to read, and replaying would suspend a sync run on a
+                // job that does not exist.
+                if ($this->retrySignal !== null && $this->recordedFailure($flowRun->id, $sequence)) {
                     $suspender->suspendInline('action', $sequence);
                 }
 
@@ -817,6 +821,15 @@ class ActionBuilder
      * (looked up by its (flow_run_id, sequence) identity) as OptionalFailed so the
      * replay resolves the fallback instead of a business error.
      */
+    /**
+     * Whether the step at this ordinal is recorded as Failed — the state the seam
+     * needs to decide anything. A missing row counts as no failure.
+     */
+    private function recordedFailure(string $flowRunId, int $sequence): bool
+    {
+        return app(ActionRunRepository::class)->find($flowRunId, $sequence)?->status === ActionStatus::Failed;
+    }
+
     private function markOptionalFailed(string $flowRunId, int $sequence): void
     {
         $step = app(ActionRunRepository::class)->find($flowRunId, $sequence);

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -237,7 +237,11 @@ class ActionBuilder
         $continueOnFailure = $this->resolvedContinueOnFailure();
         $expiresAt = $this->resolvedExpiresAt();
         $actionName = $this->resolvedActionName();
-        $retrySignalMaxAttempts = $this->resolvedMaxRetries();
+        // Only a step that carries the policy gets a ceiling written. Storing the
+        // global default on every action would leave an unrelated number in the
+        // column, and awaitRetry()'s ??= would then keep it instead of the ceiling
+        // the seam actually parked on when a later deploy adds retryOnSignal().
+        $retrySignalMaxAttempts = $this->retrySignal === null ? null : $this->resolvedMaxRetries();
 
         if ($this->runtime->mode() === RunMode::Sync) {
             try {

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -28,6 +28,7 @@ use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Support\AttributeReader;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
 use Throwable;
 
 /**
@@ -169,6 +170,9 @@ class ActionBuilder
         ?int $waitSeconds = null,
         ?array $only = null,
     ): static {
+        $this->rejectNegative('maxRetries', $maxRetries);
+        $this->rejectNegative('waitSeconds', $waitSeconds);
+
         $this->retrySignal = $signal;
         $this->retryMaxRetries = $maxRetries;
         $this->retryWaitSeconds = $waitSeconds;
@@ -761,7 +765,28 @@ class ActionBuilder
 
         $configured = config('saga-lara-flow.actions.retry_on_signal.max_retries');
 
-        return $configured === null ? null : (int) $configured;
+        if ($configured === null) {
+            return null;
+        }
+
+        $this->rejectNegative('actions.retry_on_signal.max_retries', (int) $configured);
+
+        return (int) $configured;
+    }
+
+    /**
+     * Reject a negative budget or wait before it can be persisted. The columns are
+     * unsigned, so a negative value means an error on MySQL and a step that silently
+     * never parks on the drivers that store it; failing here says which value is
+     * wrong, the same way on every driver.
+     */
+    private function rejectNegative(string $name, ?int $value): void
+    {
+        if ($value !== null && $value < 0) {
+            throw new InvalidArgumentException(
+                "retryOnSignal() {$name} must be zero or greater, got {$value}.",
+            );
+        }
     }
 
     /**

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -6,22 +6,28 @@ use Closure;
 use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
 use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationFailurePolicy;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationEntry;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowSuspender;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\HistoryContractGuard;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Support\AttributeReader;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\DB;
 use Throwable;
 
 /**
@@ -38,6 +44,10 @@ use Throwable;
  * it fails too — its compensation must then be idempotent and safe when the step did
  * nothing. onCompensationFailure() overrides the default Stop policy. All three
  * resolve with precedence action > group (saga()) > config.
+ *
+ * retryOnSignal() turns a failure into a wait: the step parks on a named signal, and
+ * each delivery re-runs THIS step alone at the very same ordinal. The seam is the only
+ * decision-maker, so nothing else resolves the row it reads back.
  */
 class ActionBuilder
 {
@@ -58,6 +68,17 @@ class ActionBuilder
     private mixed $fallbackValueOnFail = null;
 
     private ?DateTimeInterface $expiresAt = null;
+
+    private ?string $retrySignal = null;
+
+    private ?int $retryMaxRetries = null;
+
+    private ?int $retryWaitSeconds = null;
+
+    /**
+     * @var list<class-string<Throwable>>|null
+     */
+    private ?array $retryOnly = null;
 
     /**
      * @param  array<int, mixed>  $arguments
@@ -124,6 +145,39 @@ class ActionBuilder
     }
 
     /**
+     * Wait for a named signal instead of failing this step. When the step gives up
+     * (its queue $tries are spent) the flow parks: the step lands AwaitingRetry, a
+     * wait-signal is recorded, and the run goes Waiting. Delivering $signal re-runs
+     * THIS step alone — the same (flow_run_id, sequence) ordinal, the same arguments,
+     * no new sequence — so replay and every downstream step stay deterministic. A
+     * failure of the retry parks again.
+     *
+     * $maxRetries caps the signal-gated cycles (null falls back to
+     * actions.retry_on_signal.max_retries, and null there means unbounded);
+     * $waitSeconds bounds ONE wait (null falls back to the configured default signal
+     * timeout);
+     * $only restricts the policy to the listed exception classes and their
+     * subclasses (null reacts to every failure). Once the budget is spent, the wait
+     * times out, or the failure falls outside $only, the step fails exactly as it
+     * would have without this policy.
+     *
+     * @param  list<class-string<Throwable>>|null  $only
+     */
+    public function retryOnSignal(
+        string $signal,
+        ?int $maxRetries = null,
+        ?int $waitSeconds = null,
+        ?array $only = null,
+    ): static {
+        $this->retrySignal = $signal;
+        $this->retryMaxRetries = $maxRetries;
+        $this->retryWaitSeconds = $waitSeconds;
+        $this->retryOnly = $only;
+
+        return $this;
+    }
+
+    /**
      * Also compensate this step if the step itself fails (not only when a later step
      * fails). For non-atomic actions that may leave partial effects. The compensation
      * must be idempotent and tolerate "the step did nothing". Overrides the group and
@@ -183,6 +237,7 @@ class ActionBuilder
         $continueOnFailure = $this->resolvedContinueOnFailure();
         $expiresAt = $this->resolvedExpiresAt();
         $actionName = $this->resolvedActionName();
+        $retrySignalMaxAttempts = $this->resolvedMaxRetries();
 
         if ($this->runtime->mode() === RunMode::Sync) {
             try {
@@ -195,8 +250,17 @@ class ActionBuilder
                     $continueOnFailure,
                     expiresAt: $expiresAt,
                     actionName: $actionName,
+                    retrySignal: $this->retrySignal,
+                    retrySignalMaxAttempts: $retrySignalMaxAttempts,
                 );
             } catch (Throwable $exception) {
+                // A step with a retry policy is resolved solely on replay: only the
+                // seam knows the only-filter and the budget. Replay so it sees the
+                // Failed row and decides whether to park or to give up.
+                if ($this->retrySignal !== null) {
+                    $suspender->suspendInline('action', $sequence);
+                }
+
                 // Optional step: no retries inline, so give up now — mark it
                 // OptionalFailed and replay so the seam resolves the fallback.
                 if ($continueOnFailure) {
@@ -222,6 +286,8 @@ class ActionBuilder
             $continueOnFailure,
             $expiresAt,
             $actionName,
+            $this->retrySignal,
+            $retrySignalMaxAttempts,
         );
 
         $suspender->suspend('action', $sequence);
@@ -229,13 +295,20 @@ class ActionBuilder
 
     /**
      * @throws FlowSuspended
+     * @throws Throwable
      */
     private function resolve(ActionRun $step, int $sequence): mixed
     {
         switch ($step->status) {
             case ActionStatus::Completed:
                 return $this->resolveCompleted($step, $sequence);
+            case ActionStatus::AwaitingRetry:
+                return $this->resolveAwaitingRetry($step, $sequence);
             case ActionStatus::OptionalFailed:
+                // Terminal, even when the workflow now carries a policy, the row was
+                // scheduled without: the give-up hook has already published
+                // action.optional_failed. A row that carries the policy never lands
+                // here until the seam itself ends the retries.
                 return $this->resolveOptionalFailed($step, $sequence);
             case ActionStatus::Expired:
                 // Monitor-enforced expiry. An optional step gives up gracefully
@@ -247,9 +320,31 @@ class ActionBuilder
                 $this->resolveExpired($step, $sequence);
                 // no break — resolveExpired never returns.
             case ActionStatus::Failed:
+                // The queue still owes this step attempts of its own: let them play
+                // out before a retry cycle is spent on what may be transient. Without
+                // this a signal could park — and re-run — a step still in flight.
+                if ($this->carriesRetryPolicy($step) && $this->queueRetriesRemain($step)) {
+                    app(FlowSuspender::class)->suspend('action', $sequence);
+                }
+
+                if ($this->shouldRetryOnSignal($step)) {
+                    $this->parkForRetry($step, $sequence);
+                }
+
                 // An optional step still has retries left: it is not yet
                 // OptionalFailed, so wait rather than surface a business error.
                 if ($this->resolvedContinueOnFailure()) {
+                    if ($this->retrySignal !== null) {
+                        return $this->giveUpAfterRetry($step, $sequence);
+                    }
+
+                    // The hook leaves a step carrying a policy for the seam to
+                    // settle. If a deploy removed retryOnSignal() before the queue ran
+                    // out, nothing will write OptionalFailed and no job is left.
+                    if ($step->retry_signal !== null && $step->queue_attempts_exhausted) {
+                        return $this->giveUpAfterRetry($step, $sequence);
+                    }
+
                     app(FlowSuspender::class)->suspend('action', $sequence);
                 }
 
@@ -310,6 +405,382 @@ class ActionBuilder
         }
 
         return $this->fallbackValueOnFail;
+    }
+
+    /**
+     * Replay a step parked on its retry signal: retry it when the signal landed,
+     * give up when the wait timed out, keep waiting otherwise.
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function resolveAwaitingRetry(ActionRun $step, int $sequence): mixed
+    {
+        $suspender = app(FlowSuspender::class);
+
+        // Compensation-only planning never restarts work and never mutates: the
+        // parked step is the live frontier, so stop here.
+        if ($this->runtime->isCollecting()) {
+            $suspender->suspend('action', $sequence);
+        }
+
+        $signal = app(SignalRepository::class)
+            ->latestForSequence($this->runtime->run()->id, $sequence);
+
+        // No wait-signal to resolve (history repaired or pruned): keep waiting
+        // rather than invent a retry the operator never asked for.
+        if ($signal === null) {
+            $suspender->suspend('action', $sequence);
+        }
+
+        // The monitor timed the wait out: fail the way this step would have failed
+        // if it had never carried a retry policy.
+        if ($signal->status === SignalStatus::TimedOut) {
+            return $this->giveUpAfterRetry($step, $sequence);
+        }
+
+        // Delivered while we were parked: bind it to this ordinal and retry.
+        if ($signal->status === SignalStatus::Received) {
+            $this->consumeAndRetry($signal, $step, $sequence);
+        }
+
+        // Bound by a pass that died before the retry landed: the wait is over.
+        if ($signal->status === SignalStatus::Consumed) {
+            $this->retryNow($step, $sequence);
+        }
+
+        // Still Waiting — but a signal delivered while this seam was looking for one
+        // lands as a floating row that deliver() never matched against the wait-signal.
+        // Take it here so the very first signal is not swallowed.
+        $delivered = app(SignalRepository::class)
+            ->earliestPendingSince($this->runtime->run()->id, $signal->name, $step->finished_at);
+
+        // Close the spent wait-signal and bind the floating row to this ordinal, so no
+        // later await consumes the same signal twice. A lost claim means a delivery
+        // landed in the wait-signal itself, which the next replay resolves.
+        if ($delivered !== null && $this->handOverDelivery($signal, $delivered, $sequence)) {
+            $this->retryNow($step, $sequence);
+        }
+
+        $suspender->suspend('action', $sequence);
+    }
+
+    /**
+     * Park a failed step on its retry signal and suspend the flow. Never returns:
+     * either the retry starts immediately (a signal was already delivered) or the
+     * flow goes Waiting until one is.
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function parkForRetry(ActionRun $step, int $sequence): never
+    {
+        $suspender = app(FlowSuspender::class);
+
+        // Compensation-only planning never starts new work: stop at the frontier.
+        if ($this->runtime->isCollecting()) {
+            $suspender->suspend('action', $sequence);
+        }
+
+        /** @var string $signal */
+        $signal = $this->retrySignal;
+
+        $flowRun = $this->runtime->run();
+
+        // The signal may have been delivered in the window between this attempt's
+        // failure being written and this replay parking. Take it only if it arrived
+        // after the attempt finished — an older floating signal belongs elsewhere.
+        $delivered = app(SignalRepository::class)
+            ->earliestPendingSince($flowRun->id, $signal, $step->finished_at);
+
+        if ($delivered !== null) {
+            $this->consumeAndRetry($delivered, $step, $sequence);
+        }
+
+        // Adopt a signal an earlier pass left open here instead of recording a second
+        // one: delivery fulfils the OLDEST open row for a name while
+        // resolveAwaitingRetry() reads the NEWEST, so two would strand the run.
+        $abandoned = app(SignalRepository::class)->latestForSequence($flowRun->id, $sequence);
+
+        if ($abandoned !== null && $abandoned->name === $signal) {
+            // Delivered into that row before this replay reached it: acknowledged,
+            // and it belongs to this park, so spend it rather than lose it.
+            if ($abandoned->status === SignalStatus::Received) {
+                $this->consumeAndRetry($abandoned, $step, $sequence);
+            }
+
+            if ($abandoned->status === SignalStatus::Waiting) {
+                $this->park($step, $signal, $sequence, record: false);
+            }
+        }
+
+        $this->park($step, $signal, $sequence);
+    }
+
+    /**
+     * Write the parking — the wait-signal at this ordinal and the step's transition to
+     * AwaitingRetry — in one transaction, so a process that dies mid-parking leaves
+     * either all of it or none. Suspending stays outside: it throws, and a throw inside
+     * would roll the parking back.
+     *
+     * $record is false when an open signal from an earlier pass was adopted.
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function park(ActionRun $step, string $signal, int $sequence, bool $record = true): never
+    {
+        $this->connection()->transaction(function () use ($step, $signal, $sequence, $record): void {
+            if ($record) {
+                app(SignalRecorder::class)->recordSignalWaiting(
+                    $this->runtime->run(),
+                    $signal,
+                    $sequence,
+                    $this->retryWaitSeconds === null ? null : now()->addSeconds($this->retryWaitSeconds),
+                );
+            }
+
+            app(ActionRecorder::class)->awaitRetry($step, $signal, $this->budgetFor($step));
+        });
+
+        app(FlowSuspender::class)->suspend('action', $sequence);
+    }
+
+    /**
+     * Close a spent wait-signal and claim the floating delivery that ended its wait,
+     * atomically. Returns false when the signal is no longer Waiting: it received a
+     * delivery of its own, which the next replay resolves.
+     *
+     * @throws Throwable
+     */
+    private function handOverDelivery(FlowSignal $signal, FlowSignal $delivered, int $sequence): bool
+    {
+        $recorder = app(SignalRecorder::class);
+        $flowRun = $this->runtime->run();
+
+        return (bool) $this->connection()
+            ->transaction(function () use ($recorder, $flowRun, $signal, $delivered, $sequence): bool {
+                if (! $recorder->consumeWhileWaiting($flowRun, $signal, $sequence)) {
+                    return false;
+                }
+
+                $recorder->consumeSignal($flowRun, $delivered, $sequence);
+
+                return true;
+            });
+    }
+
+    /**
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function consumeAndRetry(FlowSignal $signal, ActionRun $step, int $sequence): never
+    {
+        // Spending the signal and spending the cycle it pays for are one transition:
+        // a crash between them would leave the signal Consumed and the step Failed,
+        // and the next replay — which only looks for an unconsumed signal — would park
+        // again for a delivery nobody owes. Starting the step stays outside.
+        $this->connection()->transaction(function () use ($signal, $step, $sequence): void {
+            app(SignalRecorder::class)->consumeSignal($this->runtime->run(), $signal, $sequence);
+
+            app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt());
+        });
+
+        $this->startRetriedStep($step, $sequence);
+    }
+
+    /**
+     * The package's own connection, for the writes of the retry protocol that have to
+     * land together or not at all.
+     */
+    private function connection(): ConnectionInterface
+    {
+        return DB::connection(config('saga-lara-flow.database.connection') ?: null);
+    }
+
+    /**
+     * Spend one retry cycle and run the step again at its own ordinal: rewind the row
+     * to Pending, then start it. Used where the signal that pays for the cycle was
+     * already consumed by an earlier pass.
+     *
+     * @throws FlowSuspended
+     */
+    private function retryNow(ActionRun $step, int $sequence): never
+    {
+        app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt());
+
+        $this->startRetriedStep($step, $sequence);
+    }
+
+    /**
+     * Run a step the seam has just rewound to Pending: inline (sync) or as a fresh
+     * job (queued). Either way the flow replays from the top afterwards, so the next
+     * pass decides what the new outcome means.
+     *
+     * @throws FlowSuspended
+     */
+    private function startRetriedStep(ActionRun $step, int $sequence): never
+    {
+        $suspender = app(FlowSuspender::class);
+        $dispatcher = app(ActionDispatcher::class);
+
+        if ($this->runtime->mode() === RunMode::Sync) {
+            try {
+                $dispatcher->execute($step);
+            } catch (Throwable) {
+                // The failure is already persisted on the row; the replay below is
+                // what decides whether to park again or to give up.
+            }
+
+            $suspender->suspendInline('action', $sequence);
+        }
+
+        $dispatcher->redispatch($step);
+
+        $suspender->suspend('action', $sequence);
+    }
+
+    /**
+     * The retry policy is over (budget spent, wait timed out, or the failure fell
+     * outside only): resolve the step exactly as it would have resolved without the
+     * policy. An optional step is marked OptionalFailed here — the queued give-up
+     * hook deliberately leaves that to the seam for a step with a retry signal.
+     */
+    private function giveUpAfterRetry(ActionRun $step, int $sequence): mixed
+    {
+        if (! $this->resolvedContinueOnFailure()) {
+            // A timed-out wait arrives here on an AwaitingRetry row (the other ways
+            // in are already Failed); leaving it would show a compensated run still
+            // holding a step that claims to be waiting.
+            app(ActionRecorder::class)->settleAwaitingRetry($step);
+
+            $this->resolveFailed($step, $sequence);
+        }
+
+        if ($step->status !== ActionStatus::OptionalFailed) {
+            app(ActionRecorder::class)->optionalFail($step);
+        }
+
+        return $this->resolveOptionalFailed($step, $sequence);
+    }
+
+    /**
+     * Whether this replay pass should park the failed step for a signal-gated retry.
+     * The seam decides alone: the only-filter is never persisted, and the budget and
+     * the wait are read from the row.
+     */
+    private function shouldRetryOnSignal(ActionRun $step): bool
+    {
+        if ($this->retrySignal === null) {
+            return false;
+        }
+
+        $maxRetries = $this->budgetFor($step);
+
+        if ($maxRetries !== null && $step->retry_signal_attempts >= $maxRetries) {
+            return false;
+        }
+
+        // A wait that timed out ends the policy, budget or no budget: the deadline
+        // bounds the waiting, not one wait out of many. Without this a step whose
+        // signal never comes would be handed a fresh wait on every replay.
+        if ($this->waitTimedOut($step)) {
+            return false;
+        }
+
+        return $this->matchesOnly($step);
+    }
+
+    /**
+     * Whether a retry policy applies at all — the one the workflow asks for now, or
+     * the one the row was scheduled with. The row has to count, or removing
+     * retryOnSignal() would let an early replay finally fail a step the queue is
+     * still retrying.
+     */
+    private function carriesRetryPolicy(ActionRun $step): bool
+    {
+        return $this->retrySignal !== null || $step->retry_signal !== null;
+    }
+
+    /**
+     * The budget this step is held to. The row carries the cap resolved when it was
+     * scheduled, and that is what the events and saga-flow:show report, so that is
+     * what replay enforces — otherwise a config change would silently move a cap the
+     * operator is still being shown. A row with no policy yet falls back to the
+     * resolved value.
+     */
+    private function budgetFor(ActionRun $step): ?int
+    {
+        return $step->retry_signal === null
+            ? $this->resolvedMaxRetries()
+            : $step->retry_signal_max_attempts;
+    }
+
+    /**
+     * Whether the wait at this step's ordinal has run out of time. The newest row
+     * there is the current wait: a spent cycle leaves it Consumed, and only the
+     * monitor writes TimedOut.
+     */
+    private function waitTimedOut(ActionRun $step): bool
+    {
+        $signal = app(SignalRepository::class)
+            ->latestForSequence($this->runtime->run()->id, $step->sequence);
+
+        return $signal?->status === SignalStatus::TimedOut;
+    }
+
+    /**
+     * Whether Laravel's own queue retries are still outstanding. Read off the row,
+     * where the queue's failure hook wrote it, rather than re-derived from the
+     * action's $tries: that value lives in code and can change under a job already in
+     * flight. Sync mode has no queue behind it.
+     */
+    private function queueRetriesRemain(ActionRun $step): bool
+    {
+        if ($this->runtime->mode() === RunMode::Sync) {
+            return false;
+        }
+
+        return ! $step->queue_attempts_exhausted;
+    }
+
+    /**
+     * Resolve the retry budget: an explicit maxRetries: wins, then the configured
+     * global cap, then null — unbounded, with the wait timeout and the run's own
+     * expires_at as the remaining brakes.
+     */
+    private function resolvedMaxRetries(): ?int
+    {
+        if ($this->retryMaxRetries !== null) {
+            return $this->retryMaxRetries;
+        }
+
+        $configured = config('saga-lara-flow.actions.retry_on_signal.max_retries');
+
+        return $configured === null ? null : (int) $configured;
+    }
+
+    /**
+     * Whether the recorded failure falls inside the only: filter. Subclasses count
+     * (is_a with allow_string), a null filter accepts everything, and a failure with
+     * no recorded class is never retried under an explicit filter.
+     */
+    private function matchesOnly(ActionRun $step): bool
+    {
+        if ($this->retryOnly === null) {
+            return true;
+        }
+
+        $failure = $step->exception['class'] ?? null;
+
+        if (! is_string($failure)) {
+            return false;
+        }
+
+        return array_any(
+            $this->retryOnly,
+            fn (string $candidate): bool => is_a($failure, $candidate, allow_string: true),
+        );
     }
 
     /**

--- a/src/Builders/SagaStepBuilder.php
+++ b/src/Builders/SagaStepBuilder.php
@@ -11,8 +11,9 @@ use Throwable;
  * One step of a saga() group: an action plus its compensation. compensateWith()
  * (class or closure), an optional per-step onCompensationFailure() and
  * compensateStepOnSelfFailure() override the group settings (precedence action > group >
- * config). step()/run() delegate back to the group so the fluent chain reads as a
- * single transactional block.
+ * config). retryOnSignal() mirrors the action-level policy so a step inside a group
+ * can park on a signal too. step()/run() delegate back to the group so the fluent
+ * chain reads as a single transactional block.
  */
 final class SagaStepBuilder
 {
@@ -26,6 +27,17 @@ final class SagaStepBuilder
     private ?CompensationFailurePolicy $policy = null;
 
     private ?bool $compensateOnSelfFailure = null;
+
+    private ?string $retrySignal = null;
+
+    private ?int $retryMaxRetries = null;
+
+    private ?int $retryWaitSeconds = null;
+
+    /**
+     * @var list<class-string<Throwable>>|null
+     */
+    private ?array $retryOnly = null;
 
     /**
      * @param  array<int, mixed>  $arguments
@@ -54,6 +66,28 @@ final class SagaStepBuilder
     public function compensateStepOnSelfFailure(bool $compensate = true): self
     {
         $this->compensateOnSelfFailure = $compensate;
+
+        return $this;
+    }
+
+    /**
+     * Wait for a named signal instead of failing this step. Mirrors
+     * ActionBuilder::retryOnSignal(), which documents the semantics. A parked step
+     * suspends the group where it stands: the steps already completed keep their
+     * compensations on the stack and roll back only if this one eventually gives up.
+     *
+     * @param  list<class-string<Throwable>>|null  $only
+     */
+    public function retryOnSignal(
+        string $signal,
+        ?int $maxRetries = null,
+        ?int $waitSeconds = null,
+        ?array $only = null,
+    ): self {
+        $this->retrySignal = $signal;
+        $this->retryMaxRetries = $maxRetries;
+        $this->retryWaitSeconds = $waitSeconds;
+        $this->retryOnly = $only;
 
         return $this;
     }
@@ -97,6 +131,15 @@ final class SagaStepBuilder
 
         if ($this->compensateOnSelfFailure !== null) {
             $action->compensateStepOnSelfFailure($this->compensateOnSelfFailure);
+        }
+
+        if ($this->retrySignal !== null) {
+            $action->retryOnSignal(
+                $this->retrySignal,
+                $this->retryMaxRetries,
+                $this->retryWaitSeconds,
+                $this->retryOnly,
+            );
         }
 
         return $action

--- a/src/Builders/SignalWaitBuilder.php
+++ b/src/Builders/SignalWaitBuilder.php
@@ -11,7 +11,7 @@ use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalWaiter;
  * Fluent form of awaitSignal: $this->signal('name')->timeoutAfter($when)->wait().
  * Equivalent to $this->awaitSignal('name', timeout: $when).
  *
- * timeoutAfter() persists a deadline on the wait-marker; the monitor times the wait
+ * timeoutAfter() persists a deadline on the wait-signal; the monitor times the wait
  * out after it passes and wait() then throws AwaitSignalTimeoutException on replay.
  */
 final class SignalWaitBuilder
@@ -24,7 +24,7 @@ final class SignalWaitBuilder
     ) {}
 
     /**
-     * Set a wait deadline. The monitor flips the wait-marker to TimedOut once it
+     * Set a wait deadline. The monitor flips the wait-signal to TimedOut once it
      * passes, and wait() surfaces AwaitSignalTimeoutException on the next replay.
      */
     public function timeoutAfter(?DateTimeInterface $timeout): SignalWaitBuilder

--- a/src/Concerns/Workflow/InteractsWithSignals.php
+++ b/src/Concerns/Workflow/InteractsWithSignals.php
@@ -20,7 +20,7 @@ trait InteractsWithSignals
      * signal already arrived it resolves inline, otherwise the flow suspends and
      * resumes when the signal is delivered. Replays return the same payload.
      *
-     * Passing $timeout persists a deadline on the wait-marker: once it passes the
+     * Passing $timeout persists a deadline on the wait-signal: once it passes the
      * monitor times the wait out and this throws AwaitSignalTimeoutException on the
      * next replay (catch it to react, or let it fail and roll back the flow).
      *

--- a/src/Console/Commands/FlowListCommand.php
+++ b/src/Console/Commands/FlowListCommand.php
@@ -2,11 +2,14 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Console\Commands;
 
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\FlowManager;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowTag;
 use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
 
 /**
  * Lists flow runs with optional filters, newest first — a thin CLI over
@@ -59,18 +62,64 @@ class FlowListCommand extends Command
             return self::SUCCESS;
         }
 
+        $parked = $this->retrySignalsByRun($runs);
+
         $this->table(
             ['ID', 'Workflow', 'Status', 'Created', 'Tags'],
             $runs->map(fn (FlowRun $run): array => [
                 $run->id,
                 class_basename($run->workflow_class),
-                $run->status->value,
+                $this->formatStatus($run, $parked),
                 (string) $run->created_at,
                 $this->formatTags($run),
             ])->all(),
         );
 
         return self::SUCCESS;
+    }
+
+    /**
+     * The signals the listed runs are parked on, keyed by run id. A run parked by
+     * retryOnSignal() is plainly Waiting like any other, so without this the signal
+     * that would unblock it is invisible until the operator opens the run. One query
+     * for the whole page.
+     *
+     * @param  Collection<int, FlowRun>  $runs
+     * @return Collection<string, string>
+     */
+    private function retrySignalsByRun(Collection $runs): Collection
+    {
+        /** @var class-string<ActionRun> $model */
+        $model = config('saga-lara-flow.models.action_run');
+
+        return $model::query()
+            ->whereIn('flow_run_id', $runs->pluck('id')->all())
+            ->where('status', ActionStatus::AwaitingRetry)
+            ->whereNotNull('retry_signal')
+            ->get(['flow_run_id', 'retry_signal'])
+            ->groupBy('flow_run_id')
+            ->map(fn (Collection $steps): string => $steps
+                ->pluck('retry_signal')
+                ->unique()
+                ->implode(', '));
+    }
+
+    /**
+     * The status cell, with the signal a parked run waits on appended to it.
+     *
+     * Only a Waiting run is annotated: a step keeps its AwaitingRetry status after the
+     * run around it is cancelled, and naming a signal there would send the operator
+     * after a delivery a terminal run refuses.
+     *
+     * @param  Collection<string, string>  $parked
+     */
+    private function formatStatus(FlowRun $run, Collection $parked): string
+    {
+        $signals = $run->status === FlowStatus::Waiting ? $parked->get($run->id) : null;
+
+        return $signals === null
+            ? $run->status->value
+            : "{$run->status->value} (retry: {$signals})";
     }
 
     private function formatTags(FlowRun $run): string

--- a/src/Console/Commands/FlowShowCommand.php
+++ b/src/Console/Commands/FlowShowCommand.php
@@ -2,6 +2,9 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Console\Commands;
 
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\FlowManager;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
@@ -73,6 +76,8 @@ class FlowShowCommand extends Command
             return;
         }
 
+        $signals = $this->openRetrySignals($run);
+
         $rows = [];
 
         /** @var ActionRun $action */
@@ -82,11 +87,67 @@ class FlowShowCommand extends Command
                 $action->status->value,
                 $action->action_name ?? class_basename($action->action_class),
                 $action->attempts,
+                $this->formatRetry($run, $action, $signals),
                 (string) $action->finished_at,
             ];
         }
 
-        $this->table(['Seq', 'Status', 'Action', 'Attempts', 'Finished'], $rows);
+        $this->table(['Seq', 'Status', 'Action', 'Attempts', 'Retry', 'Finished'], $rows);
+    }
+
+    /**
+     * The still-open wait-signals of this run, keyed by the sequence they park — where
+     * the deadline lives for a step showing up as awaiting_retry.
+     *
+     * @return array<int, FlowSignal>
+     */
+    private function openRetrySignals(FlowRun $run): array
+    {
+        $signals = [];
+
+        $waiting = $run->signals()
+            ->where('status', SignalStatus::Waiting)
+            ->whereNotNull('wait_sequence')
+            ->get();
+
+        /** @var FlowSignal $signal */
+        foreach ($waiting as $signal) {
+            $signals[(int) $signal->wait_sequence] = $signal;
+        }
+
+        return $signals;
+    }
+
+    /**
+     * The retry cell for one step: the signal it waits on and how much of its budget
+     * is spent (an unset max is unbounded), plus the current wait deadline while the
+     * step is actually parked. Steps without a retry policy stay blank.
+     *
+     * The deadline shows only while the run itself is Waiting: a cancelled run keeps
+     * both the AwaitingRetry step and its timeout_at, and "until ..." there would be a
+     * countdown for a wait nothing will resolve.
+     *
+     * @param  array<int, FlowSignal>  $signals
+     */
+    private function formatRetry(FlowRun $run, ActionRun $action, array $signals): string
+    {
+        if ($action->retry_signal === null) {
+            return '—';
+        }
+
+        $max = $action->retry_signal_max_attempts === null
+            ? '∞'
+            : (string) $action->retry_signal_max_attempts;
+
+        $label = "{$action->retry_signal} {$action->retry_signal_attempts}/{$max}";
+
+        if ($action->status !== ActionStatus::AwaitingRetry || $run->status !== FlowStatus::Waiting) {
+            return $label;
+        }
+
+        $signal = $signals[$action->sequence] ?? null;
+
+        return $signal?->timeout_at === null ? $label : "{$label} until {$signal->timeout_at}";
     }
 
     private function renderSignals(FlowRun $run): void
@@ -99,10 +160,16 @@ class FlowShowCommand extends Command
 
         /** @var FlowSignal $signal */
         foreach ($run->signals as $signal) {
-            $rows[] = [$signal->name, $signal->status->value, (string) $signal->received_at];
+            $rows[] = [
+                $signal->name,
+                $signal->status->value,
+                $signal->wait_sequence ?? '—',
+                (string) $signal->received_at,
+                (string) $signal->timeout_at,
+            ];
         }
 
-        $this->table(['Signal', 'Status', 'Received'], $rows);
+        $this->table(['Signal', 'Status', 'Seq', 'Received', 'Timeout'], $rows);
     }
 
     private function renderCompensations(FlowRun $run): void

--- a/src/Contracts/ActionRunRepository.php
+++ b/src/Contracts/ActionRunRepository.php
@@ -4,6 +4,11 @@ namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
 
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface ActionRunRepository
 {
     public function find(string $flowRunId, int $sequence): ?ActionRun;

--- a/src/Contracts/FlowChildRepository.php
+++ b/src/Contracts/FlowChildRepository.php
@@ -5,6 +5,11 @@ namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowChild;
 use Illuminate\Database\Eloquent\Collection;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface FlowChildRepository
 {
     /**

--- a/src/Contracts/FlowRepository.php
+++ b/src/Contracts/FlowRepository.php
@@ -5,6 +5,11 @@ namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface FlowRepository
 {
     /**

--- a/src/Contracts/Serializer.php
+++ b/src/Contracts/Serializer.php
@@ -7,6 +7,10 @@ namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
  * back. Implementations must round-trip scalars, arrays, Arrayable/
  * JsonSerializable objects and Eloquent models (stored as a reference and
  * rehydrated on the way out).
+ *
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
  */
 interface Serializer
 {

--- a/src/Contracts/SideEffectRepository.php
+++ b/src/Contracts/SideEffectRepository.php
@@ -4,6 +4,11 @@ namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
 
 use DiscoveryUkraine\SagaLaraFlow\Models\SideEffect;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface SideEffectRepository
 {
     public function find(string $flowRunId, int $sequence): ?SideEffect;

--- a/src/Contracts/SignalRepository.php
+++ b/src/Contracts/SignalRepository.php
@@ -2,8 +2,14 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Contracts;
 
+use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface SignalRepository
 {
     /**
@@ -19,13 +25,28 @@ interface SignalRepository
     public function earliestPending(string $flowRunId, string $name): ?FlowSignal;
 
     /**
+     * The earliest delivered-but-unconsumed signal with this name that arrived at or
+     * after $since (FIFO by ULID; a null $since means "any"). Lets the retry seam catch
+     * a signal delivered between a step's failure and the replay that parks it, while
+     * ignoring older floating signals that belong to an earlier wait.
+     */
+    public function earliestPendingSince(string $flowRunId, string $name, ?DateTimeInterface $since): ?FlowSignal;
+
+    /**
      * The earliest open wait-signal with this name (FIFO by ULID), used by signal
      * delivery to fulfil a parked awaitSignal.
      */
     public function earliestWaiting(string $flowRunId, string $name): ?FlowSignal;
 
     /**
-     * Open wait-markers (status Waiting) whose timeout_at deadline has passed,
+     * The MOST RECENT wait-signal recorded at this (flow_run_id, wait_sequence)
+     * ordinal. A retried step parks at the same ordinal once per retry cycle, so
+     * several rows can share it, and only the newest describes the current wait.
+     */
+    public function latestForSequence(string $flowRunId, int $sequence): ?FlowSignal;
+
+    /**
+     * Open wait-signals (status Waiting) whose timeout_at deadline has passed,
      * oldest first, capped at $limit. Used by the monitor to time signal waits out.
      *
      * @return iterable<int, FlowSignal>

--- a/src/Contracts/StateMachine.php
+++ b/src/Contracts/StateMachine.php
@@ -6,6 +6,11 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
+/**
+ * @internal This contract is an implementation seam for the package's own
+ * runtime, not a public extension point. Methods may be added to it in a minor
+ * release; swap behaviour through config('saga-lara-flow.models.*') instead.
+ */
 interface StateMachine
 {
     /**

--- a/src/Enums/ActionStatus.php
+++ b/src/Enums/ActionStatus.php
@@ -8,6 +8,7 @@ enum ActionStatus: string
     case Running = 'running';
     case Completed = 'completed';
     case Failed = 'failed';
+    case AwaitingRetry = 'awaiting_retry';
     case OptionalFailed = 'optional_failed';
     case Expired = 'expired';
     case Cancelled = 'cancelled';

--- a/src/Enums/FlowEventType.php
+++ b/src/Enums/FlowEventType.php
@@ -18,6 +18,8 @@ enum FlowEventType: string
     case ActionStarted = 'action.started';
     case ActionCompleted = 'action.completed';
     case ActionFailed = 'action.failed';
+    case ActionAwaitingRetry = 'action.awaiting_retry';
+    case ActionRetried = 'action.retried';
     case ActionOptionalFailed = 'action.optional_failed';
     case ActionExpired = 'action.expired';
     case ActionRedispatched = 'action.redispatched';

--- a/src/Events/ActionAwaitingRetry.php
+++ b/src/Events/ActionAwaitingRetry.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Events;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+
+/**
+ * Dispatched when a failed step parks on its retryOnSignal() signal instead of
+ * failing the flow. Unlike ActionFailed this is not terminal: the step keeps its
+ * ordinal, its exception and its place in the saga while it waits for $signal (or
+ * for the wait to time out). Exactly one fires per parking.
+ *
+ * Dispatched after the surrounding transaction commits, so a listener never reacts
+ * to a retry the database rolled back.
+ */
+final readonly class ActionAwaitingRetry implements ShouldDispatchAfterCommit
+{
+    public function __construct(
+        public ActionRun $actionRun,
+        public string $signal,
+    ) {}
+}

--- a/src/Events/ActionRetried.php
+++ b/src/Events/ActionRetried.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Events;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+
+/**
+ * Dispatched when a parked step starts another signal-gated retry cycle: one unit of
+ * its budget is spent and the same (flow_run_id, sequence) ordinal is about to run
+ * again. Exactly one fires per cycle, and retry_signal_attempts already counts it.
+ *
+ * Dispatched after the surrounding transaction commits, so a listener never reacts
+ * to a retry the database rolled back.
+ */
+final readonly class ActionRetried implements ShouldDispatchAfterCommit
+{
+    public function __construct(
+        public ActionRun $actionRun,
+    ) {}
+}

--- a/src/Events/FlowSignalConsumed.php
+++ b/src/Events/FlowSignalConsumed.php
@@ -3,8 +3,13 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Events;
 
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
 
-final readonly class FlowSignalConsumed
+/**
+ * Dispatched after the surrounding transaction commits, so a listener never reacts to
+ * a consumption the database rolled back.
+ */
+final readonly class FlowSignalConsumed implements ShouldDispatchAfterCommit
 {
     public function __construct(
         public FlowSignal $signal,

--- a/src/Exceptions/AwaitSignalTimeoutException.php
+++ b/src/Exceptions/AwaitSignalTimeoutException.php
@@ -6,7 +6,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 
 /**
  * Business failure surfaced to the workflow when an awaited signal is found in the
- * TimedOut state during replay — the monitor flipped its wait-marker after its
+ * TimedOut state during replay — the monitor flipped its wait-signal after its
  * timeout_at deadline passed. Like ActionFailedException it is a legitimate
  * business error (not an internal control signal): catching it in handle() lets the
  * workflow react to the timeout; leaving it uncaught fails the flow and rolls back.

--- a/src/Jobs/RunActionJob.php
+++ b/src/Jobs/RunActionJob.php
@@ -16,6 +16,12 @@ use Throwable;
  * drive loop can replay and move on. Carries the action's native $tries/$timeout
  * so Laravel's queue retry semantics apply. On final failure it still resumes
  * the workflow, so the failure surfaces as a business error on replay.
+ *
+ * $retryGeneration is the signal-gated retry cycle this job was sent for, so a job
+ * from an earlier cycle can recognise itself as stale. A payload written before the
+ * field existed carries null and is read as cycle 0. It is a plain declared property
+ * rather than a promoted one on purpose: such a payload is unserialized without the
+ * constructor, and only a class-level default keeps the typed property initialized.
  */
 class RunActionJob implements ShouldQueue
 {
@@ -25,10 +31,15 @@ class RunActionJob implements ShouldQueue
 
     public int $timeout;
 
+    public ?int $retryGeneration = null;
+
     public function __construct(
         public string $actionRunId,
         public string $actionClass,
+        ?int $retryGeneration = null,
     ) {
+        $this->retryGeneration = $retryGeneration;
+
         $defaults = get_class_vars($this->actionClass);
 
         $this->tries = isset($defaults['tries']) ? (int) $defaults['tries'] : 1;
@@ -46,9 +57,25 @@ class RunActionJob implements ShouldQueue
             return;
         }
 
+        // Left over from an earlier retry cycle: the row has moved on, so running it
+        // now would execute the step a second time without a signal. The workflow is
+        // still resumed — this job may be the only wake left if the pass that rewound
+        // the row died before sending the live one.
+        if ($action->retry_signal_attempts !== ($this->retryGeneration ?? 0)) {
+            $this->resumeWorkflow($action);
+
+            return;
+        }
+
         // Skip a step already settled out of band: Completed on an earlier attempt,
-        // or Expired by the monitor (a late job must not resurrect an expired step).
-        if (! in_array($action->status, [ActionStatus::Completed, ActionStatus::Expired], true)) {
+        // Expired by the monitor (a late job must not resurrect an expired step), or
+        // parked on a retry signal (only the seam may restart it, and only once the
+        // signal lands).
+        if (! in_array(
+            $action->status,
+            [ActionStatus::Completed, ActionStatus::Expired, ActionStatus::AwaitingRetry],
+            true,
+        )) {
             $dispatcher->execute($action);
         }
 
@@ -63,9 +90,25 @@ class RunActionJob implements ShouldQueue
             return;
         }
 
+        // An earlier cycle's outcome says nothing about the cycle the row is on now,
+        // so it must not settle anything — but resume for the same reason as handle().
+        if ($action->retry_signal_attempts !== ($this->retryGeneration ?? 0)) {
+            $this->resumeWorkflow($action);
+
+            return;
+        }
+
+        // Record the queue giving up authoritatively, so the retry seam never has to
+        // guess it from the action's current $tries.
+        app(ActionRecorder::class)->markQueueAttemptsExhausted($action);
+
         // Optional step exhausted its retries: record it as OptionalFailed so the
-        // workflow resolves the fallback instead of failing on replay.
-        if ($action->continue_on_failure && $action->status === ActionStatus::Failed) {
+        // workflow resolves the fallback instead of failing on replay. A step with a
+        // retry policy is exempt: only the seam knows its only-filter and its budget,
+        // so it decides on replay whether this failure is final at all.
+        if ($action->retry_signal === null
+            && $action->continue_on_failure
+            && $action->status === ActionStatus::Failed) {
             app(ActionRecorder::class)->optionalFail($action);
         }
 

--- a/src/Models/ActionRun.php
+++ b/src/Models/ActionRun.php
@@ -18,11 +18,15 @@ use Illuminate\Support\Carbon;
  * @property ActionStatus $status
  * @property bool $continue_on_failure
  * @property bool $has_compensation
+ * @property ?string $retry_signal
+ * @property int $retry_signal_attempts
+ * @property ?int $retry_signal_max_attempts
  * @property ?int $parallel_group
  * @property ?array<int|string, mixed> $arguments
  * @property ?array<int|string, mixed> $result
  * @property ?array<int|string, mixed> $exception
  * @property int $attempts
+ * @property bool $queue_attempts_exhausted
  * @property ?Carbon $started_at
  * @property ?Carbon $finished_at
  * @property ?Carbon $expires_at
@@ -46,11 +50,14 @@ class ActionRun extends Model
             'status' => ActionStatus::class,
             'continue_on_failure' => 'boolean',
             'has_compensation' => 'boolean',
+            'retry_signal_attempts' => 'integer',
+            'retry_signal_max_attempts' => 'integer',
             'parallel_group' => 'integer',
             'arguments' => 'array',
             'result' => 'array',
             'exception' => 'array',
             'attempts' => 'integer',
+            'queue_attempts_exhausted' => 'boolean',
             'started_at' => 'datetime',
             'finished_at' => 'datetime',
             'expires_at' => 'datetime',

--- a/src/Repositories/EloquentSignalRepository.php
+++ b/src/Repositories/EloquentSignalRepository.php
@@ -2,6 +2,7 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Repositories;
 
+use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
@@ -28,6 +29,18 @@ class EloquentSignalRepository implements SignalRepository
             ->first();
     }
 
+    public function earliestPendingSince(string $flowRunId, string $name, ?DateTimeInterface $since): ?FlowSignal
+    {
+        return $this->model()::query()
+            ->where('flow_run_id', $flowRunId)
+            ->where('name', $name)
+            ->where('status', SignalStatus::Received)
+            ->whereNull('wait_sequence')
+            ->when($since !== null, fn ($query) => $query->where('received_at', '>=', $since))
+            ->orderBy('id')
+            ->first();
+    }
+
     public function earliestWaiting(string $flowRunId, string $name): ?FlowSignal
     {
         return $this->model()::query()
@@ -36,6 +49,15 @@ class EloquentSignalRepository implements SignalRepository
             ->where('status', SignalStatus::Waiting)
             ->whereNotNull('wait_sequence')
             ->orderBy('id')
+            ->first();
+    }
+
+    public function latestForSequence(string $flowRunId, int $sequence): ?FlowSignal
+    {
+        return $this->model()::query()
+            ->where('flow_run_id', $flowRunId)
+            ->where('wait_sequence', $sequence)
+            ->orderByDesc('id')
             ->first();
     }
 

--- a/src/Runtime/ActionDispatcher.php
+++ b/src/Runtime/ActionDispatcher.php
@@ -9,6 +9,7 @@ use DiscoveryUkraine\SagaLaraFlow\Jobs\RunActionJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Support\TenancyManager;
+use Illuminate\Foundation\Bus\PendingDispatch;
 use Throwable;
 
 /**
@@ -40,6 +41,8 @@ class ActionDispatcher
         bool $continueOnFailure = false,
         ?DateTimeInterface $expiresAt = null,
         ?string $actionName = null,
+        ?string $retrySignal = null,
+        ?int $retrySignalMaxAttempts = null,
     ): ActionRun {
         $actionRun = $this->recorder->scheduleAction(
             $flowRun,
@@ -51,10 +54,43 @@ class ActionDispatcher
             null,
             $expiresAt,
             $actionName,
+            $retrySignal,
+            $retrySignalMaxAttempts,
         );
 
-        $job = RunActionJob::dispatch($actionRun->id, $actionClass);
+        $this->route(
+            RunActionJob::dispatch($actionRun->id, $actionClass, $actionRun->retry_signal_attempts),
+            $flowRun,
+        );
 
+        return $actionRun;
+    }
+
+    /**
+     * Send a fresh RunActionJob for a step that is already persisted and has just
+     * been rewound to Pending by a signal-gated retry. The row — and therefore its
+     * (flow_run_id, sequence) ordinal, arguments and history — is reused as is. The
+     * job carries the cycle it belongs to, so a job left over from an earlier cycle
+     * recognises itself as stale and does nothing.
+     */
+    public function redispatch(ActionRun $actionRun): void
+    {
+        $this->route(
+            RunActionJob::dispatch(
+                $actionRun->id,
+                $actionRun->action_class,
+                $actionRun->retry_signal_attempts,
+            ),
+            $actionRun->flowRun,
+        );
+    }
+
+    /**
+     * Put an action job on the run's own connection/queue, honouring the package's
+     * after_commit setting. Shared by the first dispatch and by every retry.
+     */
+    private function route(PendingDispatch $job, FlowRun $flowRun): void
+    {
         if ($flowRun->connection !== null) {
             $job->onConnection($flowRun->connection);
         }
@@ -66,8 +102,6 @@ class ActionDispatcher
         if (config('saga-lara-flow.queue.after_commit')) {
             $job->afterCommit();
         }
-
-        return $actionRun;
     }
 
     /**
@@ -87,6 +121,8 @@ class ActionDispatcher
         ?int $parallelGroup = null,
         ?DateTimeInterface $expiresAt = null,
         ?string $actionName = null,
+        ?string $retrySignal = null,
+        ?int $retrySignalMaxAttempts = null,
     ): ActionRun {
         $actionRun = $this->recorder->scheduleAction(
             $run,
@@ -98,6 +134,8 @@ class ActionDispatcher
             $parallelGroup,
             $expiresAt,
             $actionName,
+            $retrySignal,
+            $retrySignalMaxAttempts,
         );
 
         $this->execute($actionRun);

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -84,6 +84,15 @@ final readonly class ActionRecorder
         return $actionRun;
     }
 
+    /**
+     * How long the doctor leaves a freshly dispatched action alone before calling its
+     * job lost.
+     */
+    private function repairGrace(): int
+    {
+        return (int) config('saga-lara-flow.repair.grace_seconds', 60);
+    }
+
     private function defaultExpiry(): ?DateTimeInterface
     {
         $seconds = config('saga-lara-flow.monitor.expiration.defaults.action');
@@ -269,6 +278,15 @@ final readonly class ActionRecorder
         // A fresh job means a fresh native-attempt allowance: the queue has not given
         // up on this cycle yet, whatever it did to the previous one.
         $actionRun->queue_attempts_exhausted = false;
+
+        // The doctor holds a fresh Pending row off for grace_seconds by comparing
+        // created_at, which a reused row passed long ago. Without an explicit hold it
+        // would treat this cycle's job as lost the instant it is dispatched and send a
+        // second one, and the generation token cannot tell two jobs of the same cycle
+        // apart. The attempt counter restarts with the cycle for the same reason: a
+        // budget spent on earlier cycles must not deny this one its recovery.
+        $actionRun->repair_attempts = 0;
+        $actionRun->repair_available_at = Carbon::now()->addSeconds($this->repairGrace());
 
         $deadline = $expiresAt ?? $this->defaultExpiry();
 

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -7,9 +7,11 @@ use DiscoveryUkraine\SagaLaraFlow\Concerns\NormalizesExceptions;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionAwaitingRetry;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionCompleted;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionRedispatched;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
 use DiscoveryUkraine\SagaLaraFlow\Events\OptionalActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
@@ -47,6 +49,8 @@ final readonly class ActionRecorder
         ?int $parallelGroup = null,
         ?DateTimeInterface $expiresAt = null,
         ?string $actionName = null,
+        ?string $retrySignal = null,
+        ?int $retrySignalMaxAttempts = null,
     ): ActionRun {
         /** @var class-string<ActionRun> $model */
         $model = config('saga-lara-flow.models.action_run');
@@ -65,6 +69,10 @@ final readonly class ActionRecorder
             'expires_at' => $expiresAt ?? $this->defaultExpiry(),
             'arguments' => $this->serializer->serialize($arguments),
             'attempts' => 0,
+            'queue_attempts_exhausted' => false,
+            'retry_signal' => $retrySignal,
+            'retry_signal_attempts' => 0,
+            'retry_signal_max_attempts' => $retrySignalMaxAttempts,
         ]);
 
         $actionRun->save();
@@ -177,6 +185,109 @@ final readonly class ActionRecorder
         );
 
         event(new OptionalActionFailed($actionRun));
+    }
+
+    /**
+     * Record that the queue has finished retrying this step's current job, from the
+     * one place that knows: Laravel's own failure hook. The retry seam reads this
+     * instead of comparing the attempts counter with the action's $tries, which lives
+     * in code and can change under a job already in flight. No event is appended —
+     * this is queue bookkeeping, not a step in the flow's history.
+     */
+    public function markQueueAttemptsExhausted(ActionRun $actionRun): void
+    {
+        if ($actionRun->queue_attempts_exhausted) {
+            return;
+        }
+
+        $actionRun->queue_attempts_exhausted = true;
+        $actionRun->save();
+    }
+
+    /**
+     * Close a parked step that has given up: put it back into the Failed state the
+     * retry policy deferred, keeping the exception and finished_at of the attempt that
+     * failed. No event is appended — action.failed was recorded back then, and the
+     * give-up is visible from the flow's own failure and the timed-out wait-signal.
+     */
+    public function settleAwaitingRetry(ActionRun $actionRun): void
+    {
+        if ($actionRun->status !== ActionStatus::AwaitingRetry) {
+            return;
+        }
+
+        $actionRun->status = ActionStatus::Failed;
+        $actionRun->save();
+    }
+
+    /**
+     * Park a failed step on its retry signal: flip it to AwaitingRetry and append an
+     * action.awaiting_retry event. The step is NOT terminal — the recorded exception
+     * and finished_at of the last attempt are kept so the seam can decide again once
+     * the signal arrives (or the wait-signal times out).
+     */
+    public function awaitRetry(ActionRun $actionRun, string $signal, ?int $maxAttempts = null): void
+    {
+        $actionRun->status = ActionStatus::AwaitingRetry;
+        $actionRun->retry_signal = $signal;
+
+        // A row scheduled without a policy adopts one here, and the cap has to be
+        // written with the signal: from this parking on the budget is read off the
+        // row, so an empty column would silently mean unbounded.
+        $actionRun->retry_signal_max_attempts ??= $maxAttempts;
+
+        $actionRun->save();
+
+        $this->events->record(
+            $actionRun->flowRun,
+            FlowEventType::ActionAwaitingRetry,
+            $actionRun->sequence,
+            $actionRun,
+            [
+                'signal' => $signal,
+                'retry_signal_attempts' => $actionRun->retry_signal_attempts,
+                'retry_signal_max_attempts' => $actionRun->retry_signal_max_attempts,
+            ]
+        );
+
+        event(new ActionAwaitingRetry($actionRun, $signal));
+    }
+
+    /**
+     * Start another signal-gated retry cycle: spend one unit of the budget and rewind
+     * the row to Pending so the very same (flow_run_id, sequence) ordinal runs again.
+     * `attempts` is deliberately untouched — it counts queue attempts within one
+     * execution — and the previous exception stands until the new attempt overwrites it.
+     */
+    public function retryAction(ActionRun $actionRun, ?DateTimeInterface $expiresAt = null): void
+    {
+        $actionRun->retry_signal_attempts = $actionRun->retry_signal_attempts + 1;
+        $actionRun->status = ActionStatus::Pending;
+        $actionRun->started_at = null;
+        $actionRun->finished_at = null;
+
+        // A fresh job means a fresh native-attempt allowance: the queue has not given
+        // up on this cycle yet, whatever it did to the previous one.
+        $actionRun->queue_attempts_exhausted = false;
+
+        $deadline = $expiresAt ?? $this->defaultExpiry();
+
+        $actionRun->expires_at = $deadline === null ? null : Carbon::instance($deadline);
+        $actionRun->save();
+
+        $this->events->record(
+            $actionRun->flowRun,
+            FlowEventType::ActionRetried,
+            $actionRun->sequence,
+            $actionRun,
+            [
+                'signal' => $actionRun->retry_signal,
+                'retry_signal_attempts' => $actionRun->retry_signal_attempts,
+                'retry_signal_max_attempts' => $actionRun->retry_signal_max_attempts,
+            ]
+        );
+
+        event(new ActionRetried($actionRun));
     }
 
     /**

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -251,7 +251,7 @@ final readonly class FlowDoctor
     {
         $flow = $action->flowRun;
 
-        $job = RunActionJob::dispatch($action->id, $action->action_class);
+        $job = RunActionJob::dispatch($action->id, $action->action_class, $action->retry_signal_attempts);
 
         if ($flow->connection !== null) {
             $job->onConnection($flow->connection);

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -24,7 +24,7 @@ use Throwable;
  * configured batch size.
  *
  * Every transition the sweep performs moves the entity out of the status its scan
- * filters on (a run leaves Running/Waiting, a wait-marker Waiting→TimedOut, an
+ * filters on (a run leaves Running/Waiting, a wait-signal Waiting→TimedOut, an
  * action Pending/Running→Expired), so re-running sweep() is idempotent.
  */
 final readonly class FlowMonitor
@@ -134,7 +134,11 @@ final readonly class FlowMonitor
             return false;
         }
 
-        $this->signalRecorder->timeoutSignal($signal);
+        // Lost to a delivery that landed since the batch was read: the wait is over
+        // on its own terms, and the replay the delivery already scheduled resolves it.
+        if (! $this->signalRecorder->timeoutSignal($signal)) {
+            return false;
+        }
 
         $this->wake($run);
 

--- a/src/Runtime/HistoryContractGuard.php
+++ b/src/Runtime/HistoryContractGuard.php
@@ -106,6 +106,16 @@ final readonly class HistoryContractGuard
      */
     public function expectSignal(string $flowRunId, int $sequence, string $name): ?FlowSignal
     {
+        $requested = "signal '{$name}'";
+
+        // A signal is the one operation whose ordinal can already be occupied: a step
+        // parked by retryOnSignal() records its wait-signal at the step's OWN ordinal.
+        // So the cross-type check has to run before the row is handed back, not only
+        // when the slot looks free — otherwise editing an in-flight workflow from
+        // action() to awaitSignal() would quietly consume the retry wait-signal
+        // instead of reporting a broken history contract.
+        $this->rejectAction($flowRunId, $sequence, $requested);
+
         $signal = $this->signalRepository->find($flowRunId, $sequence);
 
         if ($signal !== null) {
@@ -121,9 +131,6 @@ final readonly class HistoryContractGuard
             return $signal;
         }
 
-        $requested = "signal '{$name}'";
-
-        $this->rejectAction($flowRunId, $sequence, $requested);
         $this->rejectSideEffect($flowRunId, $sequence, $requested);
         $this->rejectChild($flowRunId, $sequence, $requested);
 

--- a/src/Runtime/SignalDispatcher.php
+++ b/src/Runtime/SignalDispatcher.php
@@ -12,7 +12,9 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
  * Delivers an external signal into a run and wakes it. If the run is parked on a
  * matching awaitSignal, the open wait-signal is fulfilled in place; otherwise the
  * signal is stored as a floating Received row for a future awaitSignal to consume
- * (FIFO). Terminal runs reject signals.
+ * (FIFO). Delivery runs outside the queue and holds no lock, so filling a signal is
+ * a conditional write that falls back to the floating row when it loses.
+ * Terminal runs reject signals.
  */
 readonly class SignalDispatcher
 {
@@ -34,9 +36,14 @@ readonly class SignalDispatcher
 
         $waitingSignal = $this->repository->earliestWaiting($flowRun->id, $name);
 
-        $signal = $waitingSignal !== null
-            ? $this->recorder->fulfilWaitingSignal($waitingSignal, $payload)
-            : $this->recorder->storeReceivedSignal($flowRun, $name, $payload);
+        $signal = $waitingSignal === null
+            ? null
+            : $this->recorder->fulfilWaitingSignal($waitingSignal, $payload);
+
+        // No open wait-signal, or the one we found was claimed by a retry seam while
+        // we were writing: keep the delivery as a floating Received row rather than
+        // attaching it to a spent signal, where nothing would look for it again.
+        $signal ??= $this->recorder->storeReceivedSignal($flowRun, $name, $payload);
 
         if (config('saga-lara-flow.signals.wake_workflow_on_signal')) {
             $this->wake($flowRun);

--- a/src/Runtime/SignalRecorder.php
+++ b/src/Runtime/SignalRecorder.php
@@ -28,7 +28,7 @@ final readonly class SignalRecorder
      * the suspension and the signal row itself is visible via FlowRun::signals().
      *
      * A non-null $timeoutAt persists the awaitSignal(timeout:) / timeoutAfter()
-     * deadline so the monitor can later time the wait-marker out.
+     * deadline so the monitor can later time the wait-signal out.
      */
     public function recordSignalWaiting(
         FlowRun $flowRun,
@@ -92,14 +92,23 @@ final readonly class SignalRecorder
      * flip it to Received, keeping its wait_sequence so the parked awaitSignal can
      * resolve it on replay.
      *
+     * The flip is conditional: delivery holds no lock, so a retry seam may have
+     * claimed the signal since it was read. Returns null then — the signal is spent,
+     * and the caller stores this delivery as a floating one instead.
+     *
      * @param  array<int|string, mixed>  $payload
      */
-    public function fulfilWaitingSignal(FlowSignal $signal, array $payload): FlowSignal
+    public function fulfilWaitingSignal(FlowSignal $signal, array $payload): ?FlowSignal
     {
-        $signal->payload = $payload;
-        $signal->status = SignalStatus::Received;
-        $signal->received_at = Carbon::now();
-        $signal->save();
+        $claimed = $this->claimWaiting($signal, [
+            'payload' => $payload,
+            'status' => SignalStatus::Received,
+            'received_at' => Carbon::now(),
+        ]);
+
+        if (! $claimed) {
+            return null;
+        }
 
         $this->emitSignalReceived($signal->flowRun, $signal);
 
@@ -128,14 +137,50 @@ final readonly class SignalRecorder
     }
 
     /**
-     * Time out a still-Waiting wait-marker (monitor): flip it to TimedOut and
+     * Consume a wait-signal for this sequence, but only while it is still Waiting.
+     * Returns false when a delivery landed in it since the caller read it: that
+     * delivery is real, and taking it here too would turn two signals into one.
+     *
+     * This closes a signal that received nothing itself — the delivery that ended its
+     * wait arrived as a separate floating row — so the history row is appended but no
+     * FlowSignalConsumed is dispatched. The row carrying the payload dispatches it,
+     * once, so a listener counting consumptions sees one per delivered signal.
+     */
+    public function consumeWhileWaiting(FlowRun $flowRun, FlowSignal $signal, int $sequence): bool
+    {
+        $claimed = $this->claimWaiting($signal, [
+            'status' => SignalStatus::Consumed,
+            'wait_sequence' => $sequence,
+            'consumed_at' => Carbon::now(),
+        ]);
+
+        if (! $claimed) {
+            return false;
+        }
+
+        $this->events->record($flowRun, FlowEventType::SignalConsumed, $sequence, $signal, [
+            'name' => $signal->name,
+            'superseded' => true,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Time out a still-Waiting wait-signal (monitor): flip it to TimedOut and
      * append a signal.timed_out event. On replay the parked awaitSignal resolves it
      * by throwing AwaitSignalTimeoutException. No Laravel event is dispatched.
+     *
+     * Conditional for the same reason delivery is: the monitor writes a batch one row
+     * at a time, so a delivery can land in one between the read and this write, and
+     * calling that acknowledged signal a timeout would roll a saga back. Returns false
+     * when the row has moved on, so the monitor neither counts it nor wakes the run.
      */
-    public function timeoutSignal(FlowSignal $signal): void
+    public function timeoutSignal(FlowSignal $signal): bool
     {
-        $signal->status = SignalStatus::TimedOut;
-        $signal->save();
+        if (! $this->claimWaiting($signal, ['status' => SignalStatus::TimedOut])) {
+            return false;
+        }
 
         $this->events->record(
             $signal->flowRun,
@@ -144,6 +189,43 @@ final readonly class SignalRecorder
             $signal,
             ['name' => $signal->name],
         );
+
+        return true;
+    }
+
+    /**
+     * Move a wait-signal out of Waiting in a single conditional write, and sync the
+     * in-memory model to match when it lands. Returns false when the row is no longer
+     * Waiting: someone else moved it first and this caller must not write over them.
+     *
+     * The condition lives in the UPDATE itself: it is the only form every supported
+     * driver enforces atomically, since lockForUpdate() compiles to nothing on SQLite.
+     * The price is that these transitions raise no Eloquent model events, so an
+     * observer on a swapped-in models.flow_signal will not see them; flow_events and
+     * the package's own Laravel events still record every one.
+     *
+     * The model is re-read rather than filled from the values just written: those are
+     * already database-ready, and pushing an encoded JSON payload back through the
+     * casts would encode it twice.
+     *
+     * @param  array<string, mixed>  $values
+     */
+    private function claimWaiting(FlowSignal $signal, array $values): bool
+    {
+        $attributes = $signal->newInstance()->forceFill($values)->getAttributes();
+
+        $claimed = $signal->newQuery()
+            ->whereKey($signal->getKey())
+            ->where('status', SignalStatus::Waiting)
+            ->update($attributes) === 1;
+
+        if (! $claimed) {
+            return false;
+        }
+
+        $signal->refresh();
+
+        return true;
     }
 
     private function emitSignalReceived(FlowRun $flowRun, FlowSignal $signal): void

--- a/src/Runtime/SignalWaiter.php
+++ b/src/Runtime/SignalWaiter.php
@@ -21,7 +21,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
  * Signals are the special identity case: a delivered signal carries no
  * sequence; an awaitSignal at ordinal S creates a wait-signal with wait_sequence
  * = S. A timeout deadline (awaitSignal(timeout:) / timeoutAfter()) is persisted on
- * the wait-marker; the monitor flips it to TimedOut after the deadline, and the
+ * the wait-signal; the monitor flips it to TimedOut after the deadline, and the
  * parked awaitSignal then resolves it by throwing AwaitSignalTimeoutException.
  */
 readonly class SignalWaiter
@@ -70,7 +70,7 @@ readonly class SignalWaiter
                 SignalStatus::Consumed => $this->serializer->deserialize($signal->payload),
                 // Delivered into the signal since we parked: consume and move on.
                 SignalStatus::Received => $this->consume($flowRun, $signal, $sequence),
-                // The monitor timed the wait-marker out: surface a business error the
+                // The monitor timed the wait-signal out: surface a business error the
                 // workflow may catch, otherwise it fails the flow and rolls back.
                 SignalStatus::TimedOut => throw AwaitSignalTimeoutException::for($signal, $sequence),
                 // Still parked (Waiting): keep waiting.

--- a/src/SagaLaraFlowServiceProvider.php
+++ b/src/SagaLaraFlowServiceProvider.php
@@ -45,6 +45,7 @@ class SagaLaraFlowServiceProvider extends PackageServiceProvider
             ->name('saga-lara-flow')
             ->hasConfigFile()
             ->hasMigration('2026_07_02_000000_create_saga_lara_flow_initial_tables')
+            ->hasMigration('2026_08_21_000000_add_retry_on_signal_to_action_runs')
             ->runsMigrations()
             ->hasCommands([
                 MakeWorkflowCommand::class,

--- a/tests/Feature/MigrationLoadingTest.php
+++ b/tests/Feature/MigrationLoadingTest.php
@@ -5,21 +5,28 @@ use Illuminate\Support\Facades\Schema;
 // The provider calls runsMigrations(), so a host app installs with just
 // `php artisan migrate` — no vendor:publish step. Two things must hold, and each
 // has bitten us before:
-//   1. The migration must actually load. It ships as a real `.php` (not `.php.stub`),
-//      because Laravel's migrator only treats a registered path as a migration file
-//      when it ends in `.php` — a `.php.stub` path is silently globbed as a directory
-//      and skipped (the v1.0.1 bug).
-//   2. Its name must carry a timestamp prefix, like every first-party Laravel package
-//      migration, so it reads as `2026_07_02_000000_create_...` in the migrations table
-//      and `migrate:status` — not a bare, dateless `create_...` (the v1.0.2 wart).
-it('resolves the migration with a timestamped name so migrate:status is well-formed', function (): void {
-    $names = collect(app('migrator')->getMigrationFiles(app('migrator')->paths()))->keys();
+//   1. Every migration must actually load. They ship as real `.php` files (not
+//      `.php.stub`), because Laravel's migrator only treats a registered path as a
+//      migration file when it ends in `.php` — a `.php.stub` path is silently
+//      globbed as a directory and skipped (the v1.0.1 bug).
+//   2. Each name must carry a timestamp prefix, like every first-party Laravel
+//      package migration, so it reads as `2026_07_02_000000_create_...` in the
+//      migrations table and `migrate:status` — not a bare, dateless `create_...`
+//      (the v1.0.2 wart).
+// And since 1.1.0 there is a third: the package ships MORE THAN ONE migration, so
+// each additional file needs its own ->hasMigration() call or it never loads.
+it('resolves every shipped migration with a timestamped name so migrate:status is well-formed', function (): void {
+    $registered = collect(app('migrator')->getMigrationFiles(app('migrator')->paths()))->keys();
 
-    $engineMigration = $names->first(fn (string $name): bool => str_contains($name,
-        'create_saga_lara_flow_initial_tables'));
+    $shipped = collect(glob(__DIR__.'/../../database/migrations/*.php') ?: [])
+        ->map(fn (string $path): string => basename($path, '.php'));
 
-    expect($engineMigration)->not->toBeNull()
-        ->and($engineMigration)->toMatch('/^\d{4}_\d{2}_\d{2}_\d{6}_create_saga_lara_flow_initial_tables$/');
+    expect($shipped)->not->toBeEmpty();
+
+    foreach ($shipped as $name) {
+        expect($name)->toMatch('/^\d{4}_\d{2}_\d{2}_\d{6}_[a-z0-9_]+$/')
+            ->and($registered)->toContain($name);
+    }
 });
 
 it('creates the engine tables via artisan migrate, with no publish step', function (): void {
@@ -33,4 +40,26 @@ it('creates the engine tables via artisan migrate, with no publish step', functi
     expect(Schema::hasTable('saga_flow_runs'))->toBeTrue()
         ->and(Schema::hasTable('saga_action_runs'))->toBeTrue()
         ->and(Schema::hasTable('saga_flow_events'))->toBeTrue();
+});
+
+it('adds the retry-on-signal columns to action_runs', function (): void {
+    expect(Schema::hasColumn('saga_action_runs', 'retry_signal'))->toBeTrue()
+        ->and(Schema::hasColumn('saga_action_runs', 'retry_signal_attempts'))->toBeTrue()
+        ->and(Schema::hasColumn('saga_action_runs', 'retry_signal_max_attempts'))->toBeTrue()
+        ->and(Schema::hasColumn('saga_action_runs', 'queue_attempts_exhausted'))->toBeTrue();
+});
+
+it('rolls the retry-on-signal columns back down again', function (): void {
+    $migration = include __DIR__.'/../../database/migrations/2026_08_21_000000_add_retry_on_signal_to_action_runs.php';
+    $migration->down();
+
+    expect(Schema::hasColumn('saga_action_runs', 'retry_signal'))->toBeFalse()
+        ->and(Schema::hasColumn('saga_action_runs', 'retry_signal_attempts'))->toBeFalse()
+        ->and(Schema::hasColumn('saga_action_runs', 'retry_signal_max_attempts'))->toBeFalse()
+        ->and(Schema::hasColumn('saga_action_runs', 'queue_attempts_exhausted'))->toBeFalse()
+        ->and(Schema::hasColumn('saga_action_runs', 'attempts'))->toBeTrue();
+
+    $migration->up();
+
+    expect(Schema::hasColumn('saga_action_runs', 'retry_signal'))->toBeTrue();
 });

--- a/tests/Feature/RetryOnSignalOperatorTest.php
+++ b/tests/Feature/RetryOnSignalOperatorTest.php
@@ -1,0 +1,332 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionAwaitingRetry;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalSagaGroupWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * The operator surface of retryOnSignal(): the saga() group mirror, the two
+ * lifecycle events, and what saga-flow:show / :list / :signal make of a parked
+ * run. The mechanics themselves are covered by RetryOnSignalTest (sync) and
+ * RetryOnSignalQueuedTest (queued).
+ *
+ * Waking the run on delivery is off by default here: most of these tests replay
+ * the run inline afterwards, which keeps them on the sync path instead of letting
+ * a resume job decide the outcome. The tests that are about delivery itself turn
+ * it back on and use the real database queue.
+ */
+beforeEach(function () {
+    FlakyPaymentAction::reset();
+    CompensationLog::reset();
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+});
+
+/**
+ * Deliver the retry signal and replay the run inline, the way a resumed job would.
+ */
+function driveAfterSignal(FlowRun $run): FlowRun
+{
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    return app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+}
+
+/**
+ * Park a run on 'balance-refilled' at sequence 1 on the real database queue, with
+ * waking left on so a delivery drives the run exactly as it would in production.
+ */
+function parkedQueuedRun(int $failures = 1): FlowRun
+{
+    useDatabaseQueue();
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', true);
+
+    FlakyPaymentAction::reset(failures: $failures);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-cli', 3)
+        ->run();
+
+    drainQueue();
+
+    return SagaFlow::findRun($run->id);
+}
+
+/**
+ * Run a console command and hand back everything it printed. Chained
+ * expectsOutputToContain() assertions are consumed against successive writes, so
+ * several substrings of one rendered table are checked here instead.
+ */
+function commandOutput(string $command, array $parameters = []): string
+{
+    Artisan::call($command, $parameters);
+
+    return Artisan::output();
+}
+
+it('mirrors retryOnSignal on a saga() group step', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalSagaGroupWorkflow::class)
+        ->withArguments('order-group')
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal)->toBe('balance-refilled')
+        // The step ahead of it completed and its compensation is still only stacked:
+        // parking is not a rollback.
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('retries a saga() group step when its signal arrives', function () {
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalSagaGroupWorkflow::class)
+        ->withArguments('order-group-2')
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $final = driveAfterSignal($run);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->count())->toBe(3);
+
+    $step = $final->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::Completed)
+        ->and($step->retry_signal_attempts)->toBe(1)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('carries the budget from a saga() group step into the give-up', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalSagaGroupWorkflow::class)
+        ->withArguments('order-group-3', 1)
+        ->runSync();
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($step->retry_signal_max_attempts)->toBe(1);
+
+    // One cycle is all the mirrored budget allows: the second failure is final and
+    // the completed step ahead of it rolls back.
+    $final = driveAfterSignal($run);
+
+    expect($final->status)->toBe(FlowStatus::Failed)
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('dispatches one awaiting-retry event per parking and one retried event per cycle', function () {
+    Event::fake([ActionAwaitingRetry::class, ActionRetried::class]);
+
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-events')
+        ->runSync();
+
+    Event::assertDispatchedTimes(ActionAwaitingRetry::class, 1);
+    Event::assertDispatchedTimes(ActionRetried::class, 0);
+
+    Event::assertDispatched(
+        ActionAwaitingRetry::class,
+        fn (ActionAwaitingRetry $event): bool => $event->signal === 'balance-refilled'
+            && $event->actionRun->sequence === 1
+            && $event->actionRun->status === ActionStatus::AwaitingRetry,
+    );
+
+    driveAfterSignal($run);
+
+    // One cycle spent, and the failure that ended it parked the step again.
+    Event::assertDispatchedTimes(ActionRetried::class, 1);
+    Event::assertDispatchedTimes(ActionAwaitingRetry::class, 2);
+
+    Event::assertDispatched(
+        ActionRetried::class,
+        fn (ActionRetried $event): bool => $event->actionRun->retry_signal_attempts === 1,
+    );
+});
+
+it('dispatches no retry events for a step that never parks', function () {
+    Event::fake([ActionAwaitingRetry::class, ActionRetried::class]);
+
+    FlakyPaymentAction::reset(failures: 0);
+
+    SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-clean')->runSync();
+
+    Event::assertNotDispatched(ActionAwaitingRetry::class);
+    Event::assertNotDispatched(ActionRetried::class);
+});
+
+it('renders a parked step in saga-flow:show', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-show', 3, null, 900)
+        ->runSync();
+
+    $output = commandOutput('saga-flow:show', ['run' => $run->id]);
+
+    expect($output)->toContain('awaiting_retry')
+        // The signal, how much of the budget is spent, and how long the wait still
+        // has — everything needed to decide whether to send the signal by hand.
+        ->and($output)->toContain('balance-refilled 0/3 until')
+        // The wait-signal is tied to the step it parks.
+        ->and($output)->toMatch('/balance-refilled\s+\|\s+waiting\s+\|\s+1\s+\|/');
+
+    // The retry cell lives in the actions table, so --compact keeps it.
+    expect(commandOutput('saga-flow:show', ['run' => $run->id, '--compact' => true]))
+        ->toContain('balance-refilled 0/3');
+});
+
+it('shows an unbounded retry budget as infinite in saga-flow:show', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    // No maxRetries and no configured default: the budget is unbounded.
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-unbounded')
+        ->runSync();
+
+    expect(commandOutput('saga-flow:show', ['run' => $run->id]))
+        ->toContain('balance-refilled 0/∞');
+});
+
+it('keeps the retry column blank for steps without a policy', function () {
+    FlakyPaymentAction::reset(failures: 0);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-plain')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed);
+
+    $output = commandOutput('saga-flow:show', ['run' => $run->id]);
+
+    // The policy stays visible on a step that succeeded first time — with a spent
+    // budget of zero, which is how an operator tells "never parked" from "recovered".
+    expect($output)->toContain('balance-refilled 0/')
+        ->and($output)->not->toContain('awaiting_retry')
+        ->and($output)->toMatch('/MakeValueAction\s+\|\s+1\s+\|\s+—\s+\|/');
+});
+
+it('marks a run parked on a retry signal in saga-flow:list', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-list')
+        ->runSync();
+
+    expect(commandOutput('saga-flow:list'))
+        ->toContain($run->id)
+        ->toContain('waiting (retry: balance-refilled)');
+});
+
+it('drops the retry annotation once the run is no longer waiting', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-cancelled')
+        ->runSync();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    $cancelled = SagaFlow::findRun($run->id);
+
+    // The step keeps its status — nothing rewrites action rows on cancellation —
+    // so the annotation has to be gated on the run, not on the step. A terminal run
+    // refuses signals, and naming one here would send the operator after a delivery
+    // that does nothing.
+    expect($cancelled->status)->toBe(FlowStatus::Cancelled)
+        ->and($cancelled->actions()->where('sequence', 1)->first()->status)
+        ->toBe(ActionStatus::AwaitingRetry);
+
+    expect(commandOutput('saga-flow:list'))
+        ->toContain('cancelled')
+        ->not->toContain('(retry:');
+
+    // Same reasoning in saga-flow:show. The wait-signal keeps its timeout_at, so the
+    // deadline is still there to print — but counting down to it would promise the
+    // operator a wait that nothing is going to resolve.
+    expect(commandOutput('saga-flow:show', ['run' => $run->id]))
+        ->toContain('balance-refilled 0/')
+        ->not->toContain('until');
+});
+
+it('leaves an ordinary waiting run unannotated in saga-flow:list', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and(commandOutput('saga-flow:list'))->not->toContain('(retry:');
+});
+
+it('finds a parked run through the query API', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-query')
+        ->runSync();
+
+    // A parked run is Waiting like any other, so it is both listable and still a
+    // legal signal target — nothing about the retry seam narrows that.
+    expect(SagaFlow::query()->waiting()->get()->pluck('id')->all())->toContain($run->id)
+        ->and(SagaFlow::query()->signalable()->count())->toBe(1)
+        ->and(SagaFlow::query()->active()->count())->toBe(1);
+});
+
+it('drives a parked run to completion through saga-flow:signal', function () {
+    $run = parkedQueuedRun();
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and($run->actions()->where('sequence', 1)->first()->status)
+        ->toBe(ActionStatus::AwaitingRetry);
+
+    Artisan::call('saga-flow:signal', ['run' => $run->id, 'name' => 'balance-refilled']);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->retry_signal_attempts)->toBe(1)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('carries a signal payload from saga-flow:signal into the retried run', function () {
+    $run = parkedQueuedRun();
+
+    Artisan::call('saga-flow:signal', [
+        'run' => $run->id,
+        'name' => 'balance-refilled',
+        '--payload' => '{"topped_up":500}',
+    ]);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed);
+
+    // The delivery that ended the wait is the marker at the step's own ordinal, and
+    // it kept the payload the operator sent.
+    $marker = $final->signals()->orderByDesc('id')->first();
+
+    expect($marker->wait_sequence)->toBe(1)
+        ->and($marker->payload)->toBe(['topped_up' => 500]);
+});

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -507,6 +507,112 @@ it('leaves a parked step alone in the monitor and the doctor', function () {
         ->and(FlakyPaymentAction::$calls)->toBe(1);
 });
 
+/**
+ * Park a step, age it past the repair grace window the way a real wait would, then
+ * deliver the signal and stop the queue the moment the seam has committed the retry
+ * and dispatched its job — the window in which the doctor may mistake that job for
+ * a lost one.
+ */
+function stageDispatchedRetry(string $orderId): ActionRun
+{
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments($orderId)->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // A real wait outlives the grace window many times over, and the row keeps the
+    // created_at it was first scheduled with.
+    ActionRun::query()->whereKey($step->id)->update(['created_at' => now()->subMinutes(10)]);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    workUntilStatus($run, 1, ActionStatus::Pending);
+
+    return $step->fresh();
+}
+
+it('does not let the doctor duplicate the job of a retry cycle it just started', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $step = stageDispatchedRetry('order-q31');
+
+    expect($step->retry_signal_attempts)->toBe(1)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+
+    // The row is older than the grace window, so only the hold written with the retry
+    // keeps the doctor off it.
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+
+    drainQueue();
+
+    // One signal, one execution. A second job for the same generation would have run
+    // the step again on the failure, since the generation token cannot tell the two
+    // apart and Failed is deliberately not in the job's skip list.
+    expect(FlakyPaymentAction::$calls)->toBe(2)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(1);
+});
+
+it('still recovers a retry job that was genuinely lost', function () {
+    FlakyPaymentAction::reset(failures: 1);
+
+    $step = stageDispatchedRetry('order-q32');
+
+    // The hold is a delay, not an exemption: drop the job and let it expire.
+    DB::connection('testing')->table('jobs')->delete();
+
+    ActionRun::query()->whereKey($step->id)->update(['repair_available_at' => now()->subMinute()]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(1);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($step->flow_run_id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::Completed);
+});
+
+it('gives each retry cycle its own repair budget', function () {
+    FlakyPaymentAction::reset(failures: 1);
+
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q33')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    // Repairs spent before the step ever parked: without a reset they would deny this
+    // cycle the recovery it has not used yet.
+    ActionRun::query()->whereKey($step->id)->update([
+        'created_at' => now()->subMinutes(10),
+        'repair_attempts' => (int) config('saga-lara-flow.repair.max_attempts'),
+    ]);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    workUntilStatus($run, 1, ActionStatus::Pending);
+
+    $step->refresh();
+
+    expect($step->repair_attempts)->toBe(0);
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    ActionRun::query()->whereKey($step->id)->update(['repair_available_at' => now()->subMinute()]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(1);
+});
+
 it('does not restart or re-park a parked step while collecting compensations', function () {
     useDatabaseQueue();
     FlakyPaymentAction::reset(failures: 99);

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -1,0 +1,1070 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
+use DiscoveryUkraine\SagaLaraFlow\Events\FlowSignalConsumed;
+use DiscoveryUkraine\SagaLaraFlow\Events\FlowSignalReceived;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\RunActionJob;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\HistoryContractGuard;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FailingWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalFallbackWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryBudgetSagaWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliablePaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliableRetryOnSignalWorkflow;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Queued-mode coverage for retryOnSignal(): the real RunActionJob →
+ * ResumeWorkflowJob path, the deadlines the monitor enforces, the budget running
+ * out, and the races between an externally delivered signal and the seam.
+ */
+beforeEach(function () {
+    FlakyPaymentAction::reset();
+    UnreliablePaymentAction::reset();
+    CompensationLog::reset();
+});
+
+/**
+ * Process exactly one queued job, so a test can inspect the run between two steps
+ * of the async path instead of after the whole queue has drained.
+ */
+function workOneJob(): void
+{
+    // --sleep=0: an empty queue would otherwise cost the worker's default three
+    // seconds, and these helpers are called in loops.
+    Artisan::call('queue:work', ['--once' => true, '--sleep' => 0, '--no-interaction' => true]);
+}
+
+/**
+ * Drive the queue one job at a time until the step at $sequence satisfies $ready, so
+ * a test can stop between two jobs instead of after the whole queue has drained.
+ */
+function workUntil(FlowRun $run, int $sequence, Closure $ready): void
+{
+    for ($i = 0; $i < 20; $i++) {
+        $step = $run->actions()->where('sequence', $sequence)->first();
+
+        if ($step !== null && $ready($step)) {
+            return;
+        }
+
+        workOneJob();
+    }
+
+    throw new RuntimeException('the step never reached the state this test waits for');
+}
+
+function workUntilStatus(FlowRun $run, int $sequence, ActionStatus $status): void
+{
+    workUntil($run, $sequence, fn (ActionRun $step): bool => $step->status === $status);
+}
+
+it('retries the parked step through the real queue', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q1')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and($run->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['charged']['calls'] ?? null)->toBe(2);
+
+    $actions = $final->actions()->orderBy('sequence')->get();
+
+    // The retried step kept its own ordinal and its own row; nothing around it moved
+    // or ran a second time.
+    expect($actions)->toHaveCount(3)
+        ->and($actions[1]->sequence)->toBe(1)
+        ->and($actions[1]->retry_signal_attempts)->toBe(1)
+        ->and($actions[1]->attempts)->toBe(2)
+        ->and($actions[0]->attempts)->toBe(1)
+        ->and($actions[2]->sequence)->toBe(2)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('gives up and rolls the saga back once the retry budget is spent', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryBudgetSagaWorkflow::class)->withArguments('order-q2', 1)->run();
+    drainQueue();
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    // One retry was allowed, it failed too, and the step then failed exactly as it
+    // would have without any retry policy.
+    expect($final->status)->toBe(FlowStatus::Failed)
+        ->and($final->exception['class'] ?? null)->toBe(ActionFailedException::class)
+        ->and($final->exception['message'] ?? '')->toContain('insufficient balance')
+        ->and(FlakyPaymentAction::$calls)->toBe(2);
+
+    $step = $final->actions()->where('sequence', 2)->first();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->retry_signal_attempts)->toBe(1);
+
+    // Reverse order, and the failed step itself is not compensated by default.
+    expect(CompensationLog::all())->toBe(['undo:packed', 'undo:reserved']);
+});
+
+it('gives up when the wait deadline passes', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-q3', null, null, 60)
+        ->run();
+    drainQueue();
+
+    $marker = SagaFlow::findRun($run->id)->signals()->first();
+
+    expect($marker->status)->toBe(SignalStatus::Waiting)
+        ->and($marker->timeout_at)->not->toBeNull();
+
+    $this->travel(120)->seconds();
+
+    expect(app(FlowMonitor::class)->sweep()['signals'])->toBe(1);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Failed)
+        ->and($final->exception['class'] ?? null)->toBe(ActionFailedException::class)
+        ->and($final->exception['message'] ?? '')->toContain('insufficient balance')
+        ->and($final->signals()->first()->status)->toBe(SignalStatus::TimedOut)
+        ->and(CompensationLog::all())->toBe(['undo:created'])
+        // The step gave up: it is Failed, not still claiming to wait for a signal on
+        // a run that has already compensated.
+        ->and($final->actions()->where('sequence', 1)->first()->status)
+        ->toBe(ActionStatus::Failed);
+});
+
+it('parks when the failure matches only by subclass', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-q4', null, [Exception::class])
+        ->run();
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    // RuntimeException is not listed, but it is an Exception — is_a walks the
+    // hierarchy, so the policy applies.
+    expect($final->status)->toBe(FlowStatus::Waiting)
+        ->and($final->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('reaches the optional fallback only after the retry budget is spent', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(OptionalRetryOnSignalWorkflow::class)
+        ->withArguments('order-q5', 1)
+        ->run();
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id);
+
+    // continueOnFailure() does not short-circuit the policy: the step parks first
+    // and the downstream step has not been scheduled yet.
+    expect($parked->status)->toBe(FlowStatus::Waiting)
+        ->and($parked->actions()->count())->toBe(1)
+        ->and($parked->actions()->first()->status)->toBe(ActionStatus::AwaitingRetry);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['charged'] ?? null)->toBe('unpaid');
+
+    $step = $final->actions()->where('sequence', 0)->first();
+
+    expect($step->status)->toBe(ActionStatus::OptionalFailed)
+        ->and($step->retry_signal_attempts)->toBe(1);
+});
+
+it('leaves the same ordinals behind whether or not the step was retried', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 2);
+
+    $retried = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q6')->run();
+    drainQueue();
+
+    SagaFlow::loadFlow($retried->id)->signal('balance-refilled');
+    drainQueue();
+
+    SagaFlow::loadFlow($retried->id)->signal('balance-refilled');
+    drainQueue();
+
+    FlakyPaymentAction::reset();
+
+    $straight = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q6')->run();
+    drainQueue();
+
+    $withRetries = runStateSnapshot($retried->id);
+    $withoutRetries = runStateSnapshot($straight->id);
+
+    $shape = fn (array $snapshot): array => [
+        'status' => $snapshot['status'],
+        'actions' => array_map(
+            fn (array $action): array => [
+                'sequence' => $action['sequence'],
+                'status' => $action['status'],
+                'action_class' => $action['action_class'],
+            ],
+            $snapshot['actions'],
+        ),
+    ];
+
+    // Two retry cycles leave no trace in the ordinals: the downstream step sits at
+    // the same sequence it would have without them.
+    expect($shape($withRetries))->toBe($shape($withoutRetries));
+});
+
+it('does not lose a signal delivered between the failure and the parking', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q7')->run();
+
+    // Stop right after the attempt failed, before the resume that would park it.
+    workUntilStatus($run, 1, ActionStatus::Failed);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    expect($run->signals()->where('status', SignalStatus::Received)->count())->toBe(1);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->retry_signal_attempts)->toBe(1);
+
+    // The seam took the floating signal instead of parking, so no wait marker was
+    // ever written and the step never went AwaitingRetry.
+    $signals = $final->signals()->get();
+
+    expect($signals)->toHaveCount(1)
+        ->and($signals[0]->status)->toBe(SignalStatus::Consumed)
+        ->and($signals[0]->wait_sequence)->toBe(1)
+        ->and($final->events()->where('type', FlowEventType::ActionAwaitingRetry->value)->count())->toBe(0);
+});
+
+it('ignores a floating signal that predates the failed attempt', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q8')->run();
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    // Age it: this signal belongs to something that happened before the attempt that
+    // is about to fail, so it must not be claimed by this step's retry.
+    $run->signals()->first()->update(['received_at' => now()->subMinute()]);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+    $step = $final->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(0)
+        ->and(FlakyPaymentAction::$calls)->toBe(1);
+
+    $signals = $final->signals()->orderBy('id')->get();
+
+    expect($signals)->toHaveCount(2)
+        ->and($signals[0]->status)->toBe(SignalStatus::Received)
+        ->and($signals[0]->wait_sequence)->toBeNull()
+        ->and($signals[1]->status)->toBe(SignalStatus::Waiting);
+});
+
+it('takes a floating signal that landed after the wait marker was written', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q9')->run();
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id);
+
+    expect($parked->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // Reproduce the delivery that raced the marker: deliver() looked for a waiting
+    // marker before the seam had written one, so the signal landed floating.
+    app(SignalRecorder::class)->storeReceivedSignal($parked, 'balance-refilled', []);
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->retry_signal_attempts)->toBe(1);
+
+    // Both rows end Consumed at this step's ordinal: the marker because its wait is
+    // over, the floating row because it is the delivery that ended it.
+    $signals = $final->signals()->orderBy('id')->get();
+
+    expect($signals)->toHaveCount(2)
+        ->and($signals->pluck('status')->all())->toBe([SignalStatus::Consumed, SignalStatus::Consumed])
+        ->and($signals->pluck('wait_sequence')->all())->toBe([1, 1]);
+});
+
+it('waits for the queue to run out of attempts before spending a retry cycle', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(UnreliableRetryOnSignalWorkflow::class)->withArguments('order-q10')->run();
+
+    // Stop after the first of the action's two native attempts.
+    workUntilStatus($run, 0, ActionStatus::Failed);
+
+    $step = $run->actions()->first();
+
+    expect($step->attempts)->toBe(1)
+        ->and(UnreliablePaymentAction::$calls)->toBe(1);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    // Age it so it unambiguously predates the attempt still to come: this test is
+    // about the gate, not about which attempt may claim a borderline signal.
+    $run->signals()->first()->update(['received_at' => now()->subMinute()]);
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+
+    $step->refresh();
+
+    // The queue still owes this step an attempt, so the seam waited instead of
+    // spending a retry cycle on it. Nothing has told it the queue is done.
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->queue_attempts_exhausted)->toBeFalse()
+        ->and($step->retry_signal_attempts)->toBe(0)
+        ->and($run->signals()->where('status', SignalStatus::Waiting)->count())->toBe(0);
+
+    drainQueue();
+
+    $step->refresh();
+
+    // The second native attempt ran and failed; only then did the step park — and
+    // the now-stale floating signal was not claimed by it.
+    expect(UnreliablePaymentAction::$calls)->toBe(2)
+        ->and($step->attempts)->toBe(2)
+        ->and($step->queue_attempts_exhausted)->toBeTrue()
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(0);
+});
+
+it('ignores a queued job left over from an earlier retry cycle', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q11')->run();
+    drainQueue();
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(1)
+        ->and(FlakyPaymentAction::$calls)->toBe(2);
+
+    // A job from the cycle before this one: even with the row back at Pending it must
+    // not execute the step again.
+    $step->status = ActionStatus::Pending;
+    $step->save();
+
+    RunActionJob::dispatch($step->id, FlakyPaymentAction::class, 0);
+    drainQueue();
+
+    expect(FlakyPaymentAction::$calls)->toBe(2);
+
+    // A payload written before the generation field existed carries null. It predates
+    // every retry, so it belongs to cycle 0 and must be refused here too — waving it
+    // through would let it run alongside the live cycle's own job.
+    $legacy = unserialize(serialize(new RunActionJob($step->id, FlakyPaymentAction::class)));
+
+    expect($legacy->retryGeneration)->toBeNull();
+
+    $resumes = fn (): int => SagaFlow::findRun($run->id)
+        ->events()
+        ->where('type', FlowEventType::FlowResumed->value)
+        ->count();
+
+    $before = $resumes();
+
+    $legacy->handle(app(ActionDispatcher::class));
+    drainQueue();
+
+    // Refused, but not swallowed: a stale job may be the only wake left if the pass
+    // that rewound the row died before sending the live one.
+    expect(FlakyPaymentAction::$calls)->toBe(2)
+        ->and($resumes())->toBeGreaterThan($before);
+
+    // The job for the live cycle still runs, so the guard is a generation check and
+    // not a blanket refusal.
+    RunActionJob::dispatch($step->id, FlakyPaymentAction::class, 1);
+    drainQueue();
+
+    expect(FlakyPaymentAction::$calls)->toBe(3);
+});
+
+it('does not let a stale job execute a parked step', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q12')->run();
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // A job predating the generation token (null) still must not run a parked step:
+    // only the seam restarts it, and only once the signal lands.
+    RunActionJob::dispatch($step->id, FlakyPaymentAction::class);
+    drainQueue();
+
+    $step->refresh();
+
+    expect(FlakyPaymentAction::$calls)->toBe(1)
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry);
+});
+
+it('leaves a parked step alone in the monitor and the doctor', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.grace_seconds', 0);
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q13')->run();
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // An execution deadline that has already passed: it belongs to running the step,
+    // not to waiting for the signal, whose own deadline lives on the marker.
+    $step->expires_at = now()->subMinute();
+    $step->save();
+
+    expect(app(FlowMonitor::class)->sweep())->toMatchArray(['actions' => 0, 'signals' => 0])
+        ->and(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0);
+
+    drainQueue();
+
+    $step->refresh();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->repair_attempts)->toBe(0)
+        ->and(FlakyPaymentAction::$calls)->toBe(1);
+});
+
+it('does not restart or re-park a parked step while collecting compensations', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q14')->run();
+    drainQueue();
+
+    $before = SagaFlow::findRun($run->id)->signals()->count();
+
+    SagaFlow::loadFlow($run->id)->compensate();
+
+    $final = SagaFlow::findRun($run->id);
+    $step = $final->actions()->where('sequence', 1)->first();
+
+    // Compensation-only planning stops at the parked frontier: the step is not
+    // re-executed, not re-parked, and no second marker is written.
+    expect($final->status)->toBe(FlowStatus::Cancelled)
+        ->and(FlakyPaymentAction::$calls)->toBe(1)
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(0)
+        ->and($final->signals()->count())->toBe($before)
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('runs a job that was queued before the retry generation existed', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q15')->run();
+
+    workUntilStatus($run, 0, ActionStatus::Pending);
+
+    $step = $run->actions()->where('sequence', 0)->first();
+
+    $payload = serialize(new RunActionJob($step->id, MakeValueAction::class));
+
+    // SerializesModels omits any property that equals its class default and restores
+    // it from that default on the way back, so this payload is byte-for-byte what a
+    // worker would have written before the field existed. A promoted constructor
+    // parameter carries no class default: the property would arrive uninitialized and
+    // reading it below would throw, stranding every action queued across a deploy.
+    expect($payload)->not->toContain('retryGeneration');
+
+    $job = unserialize($payload);
+
+    expect($job->retryGeneration)->toBeNull();
+
+    $job->handle(app(ActionDispatcher::class));
+
+    expect($step->fresh()->status)->toBe(ActionStatus::Completed);
+});
+
+it('still owes native attempts to a step on its second retry cycle', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(UnreliableRetryOnSignalWorkflow::class)->withArguments('order-q16')->run();
+    drainQueue();
+
+    $step = $run->actions()->first();
+
+    // Cycle 0 spent both of the action's native attempts before parking.
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->attempts)->toBe(2)
+        ->and($step->retry_signal_attempts)->toBe(0);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    // Stop inside cycle 1, after its first native attempt failed and before the
+    // second one has run. attempts is cumulative, so it now reads 3 — the gate has to
+    // measure it against the whole allowance so far, not against $tries alone.
+    workUntil($run, 0, fn (ActionRun $current): bool => $current->attempts === 3);
+
+    $step->refresh();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->retry_signal_attempts)->toBe(1);
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+
+    $step->refresh();
+
+    // A wake arriving mid-cycle must not park the step or spend another cycle: the
+    // queue still owes it the fourth attempt.
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->retry_signal_attempts)->toBe(1)
+        ->and($run->signals()->where('status', SignalStatus::Waiting)->count())->toBe(0);
+
+    drainQueue();
+
+    $step->refresh();
+
+    // The fourth native attempt ran, and only then did the step park again.
+    expect(UnreliablePaymentAction::$calls)->toBe(4)
+        ->and($step->attempts)->toBe(4)
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry);
+});
+
+it('claims a wait marker only while it is still waiting', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q17')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $marker = $run->signals()->first();
+    $recorder = app(SignalRecorder::class);
+
+    expect($marker->status)->toBe(SignalStatus::Waiting)
+        ->and($recorder->consumeWhileWaiting($run, $marker, 1))->toBeTrue()
+        ->and($marker->fresh()->status)->toBe(SignalStatus::Consumed);
+
+    // A marker that already carries a delivery is left exactly as it is: the caller
+    // must resolve that delivery instead of writing over it.
+    $delivered = $recorder->recordSignalWaiting($run, 'balance-refilled', 1);
+
+    expect($recorder->fulfilWaitingSignal($delivered, ['by' => 'ops']))->not->toBeNull()
+        ->and($recorder->consumeWhileWaiting($run, $delivered, 1))->toBeFalse();
+
+    $delivered->refresh();
+
+    expect($delivered->status)->toBe(SignalStatus::Received)
+        ->and($delivered->payload)->toBe(['by' => 'ops'])
+        ->and($delivered->consumed_at)->toBeNull();
+});
+
+it('keeps a delivery that lost the race for a marker instead of overwriting it', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q18')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $recorder = app(SignalRecorder::class);
+
+    // deliver() reads the open marker, and the seam claims it before deliver() gets
+    // to write. Reproduce that ordering with the model deliver() would be holding.
+    $stale = $run->signals()->first();
+
+    expect($recorder->consumeWhileWaiting($run, clone $stale, 1))->toBeTrue()
+        ->and($recorder->fulfilWaitingSignal($stale, ['by' => 'ops']))->toBeNull();
+
+    // The spent marker stays spent: writing the delivery into it would attach it to a
+    // row that latestForSequence() stops returning after the next park.
+    $marker = $run->signals()->first();
+
+    expect($marker->status)->toBe(SignalStatus::Consumed)
+        ->and($marker->payload)->toBeNull();
+
+    // Through the dispatcher the same loss keeps the delivery alive as a floating row,
+    // where the next park or replay can still claim it.
+    app(SignalDispatcher::class)->deliver($run, 'balance-refilled', ['by' => 'ops']);
+
+    $floating = $run->signals()->where('status', SignalStatus::Received)->get();
+
+    expect($floating)->toHaveCount(1)
+        ->and($floating[0]->wait_sequence)->toBeNull()
+        ->and($floating[0]->payload)->toBe(['by' => 'ops']);
+});
+
+it('reads queue exhaustion off the row rather than off the action class', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(UnreliableRetryOnSignalWorkflow::class)->withArguments('order-q19')->run();
+    drainQueue();
+
+    $step = $run->actions()->first();
+
+    // Baseline: the queue gave up after both native attempts and said so on the row.
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->attempts)->toBe(2)
+        ->and($step->queue_attempts_exhausted)->toBeTrue();
+
+    // A job still in flight whose attempts already outnumber the action's current
+    // $tries — what a deploy that lowered $tries leaves behind. The counter says
+    // "exhausted", the queue has not said so, and the queue is the authority: wait.
+    $step->status = ActionStatus::Failed;
+    $step->attempts = 9;
+    $step->queue_attempts_exhausted = false;
+    $step->save();
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+
+    $step->refresh();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->retry_signal_attempts)->toBe(0);
+
+    // And the mirror case — a deploy that raised $tries, leaving fewer attempts on the
+    // row than the class now allows. The queue is done, so the step parks.
+    $step->attempts = 1;
+    $step->queue_attempts_exhausted = true;
+    $step->save();
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+
+    $step->refresh();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry);
+});
+
+it('reports one consumption per delivered signal when a floating row is handed over', function () {
+    Event::fake([FlowSignalReceived::class, FlowSignalConsumed::class]);
+
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q20')->run();
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id);
+
+    expect($parked->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // One delivery, landing as a floating row because it raced the marker.
+    app(SignalRecorder::class)->storeReceivedSignal($parked, 'balance-refilled', []);
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed);
+
+    // Closing the spent marker is bookkeeping, not a consumption: a listener counting
+    // signals must see exactly one of each for the one signal that was delivered.
+    Event::assertDispatched(FlowSignalReceived::class, 1);
+    Event::assertDispatched(FlowSignalConsumed::class, 1);
+
+    // The full history still records both rows closing, with the spent one marked.
+    $consumed = $final->events()->where('type', FlowEventType::SignalConsumed->value)->get();
+
+    expect($consumed)->toHaveCount(2)
+        ->and($consumed->pluck('payload.superseded')->filter()->count())->toBe(1);
+});
+
+it('adopts an abandoned wait signal instead of recording a second one', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q22')->run();
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    // parkForRetry() writes the wait signal and the AwaitingRetry transition as two
+    // separate commits. Rewind to the state a kill between them leaves behind: the
+    // signal is committed, the step never left Failed.
+    $step->status = ActionStatus::Failed;
+    $step->queue_attempts_exhausted = true;
+    $step->save();
+
+    ResumeWorkflowJob::dispatch($run->id);
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id);
+
+    // Two open signals at one ordinal would strand the run: delivery fulfils the
+    // OLDEST open row for a name, while the seam reads the NEWEST at the ordinal.
+    expect($parked->signals()->where('status', SignalStatus::Waiting)->count())->toBe(1)
+        ->and($parked->actions()->where('sequence', 1)->first()->status)
+        ->toBe(ActionStatus::AwaitingRetry);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Completed);
+});
+
+it('rolls the consumption back when the retry transition fails', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q23')->run();
+    drainQueue();
+
+    // Blowing up on the write that spends the cycle stands in for a process that
+    // dies mid-transition. Spending the signal and spending the cycle it pays for
+    // have to land together or not at all: a consumed signal with the step still
+    // Failed would park again and wait for a second delivery that nobody owes.
+    ActionRun::saved(function (ActionRun $step): void {
+        if ($step->retry_signal_attempts === 1) {
+            throw new RuntimeException('the write exploded');
+        }
+    });
+
+    $retried = 0;
+    $consumed = 0;
+
+    Event::listen(ActionRetried::class, function () use (&$retried): void {
+        $retried++;
+    });
+
+    Event::listen(FlowSignalConsumed::class, function () use (&$consumed): void {
+        $consumed++;
+    });
+
+    try {
+        SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+        drainQueue();
+    } catch (Throwable) {
+        // The explosion is the setup; the rows it leaves behind are the assertion.
+    }
+
+    $signal = SagaFlow::findRun($run->id)->signals()->orderByDesc('id')->first();
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    expect($signal->status)->toBe(SignalStatus::Received)
+        ->and($step->retry_signal_attempts)->toBe(0)
+        // Both events are after-commit, so a listener never reacts to a cycle the
+        // database rolled back.
+        ->and($retried)->toBe(0)
+        ->and($consumed)->toBe(0);
+});
+
+it('leaves a delivered signal alone when the monitor times it out', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q24')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $marker = $run->signals()->firstOrFail();
+
+    $marker->timeout_at = now()->subMinute();
+    $marker->save();
+
+    // The monitor reads a batch of overdue signals and writes them one at a time, so
+    // this is its snapshot from before the delivery landed.
+    $stale = $run->signals()->firstOrFail();
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    expect($marker->fresh()->status)->toBe(SignalStatus::Received);
+
+    // The delivery was acknowledged to whoever sent it; declaring it a timeout now
+    // would turn a signal the caller believes arrived into a rolled-back saga.
+    expect(app(SignalRecorder::class)->timeoutSignal($stale))->toBeFalse()
+        ->and($marker->fresh()->status)->toBe(SignalStatus::Received);
+});
+
+it('ends the policy when the wait times out, even with budget left', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.monitor.expiration.defaults.signal', 60);
+    FlakyPaymentAction::reset(failures: 99);
+
+    // Budget 3, of which the timeout spends none.
+    $run = SagaFlow::create(OptionalRetryOnSignalWorkflow::class)
+        ->withArguments('order-q25', 3)
+        ->run();
+    drainQueue();
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+
+    $this->travel(120)->seconds();
+
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    // The deadline bounds the waiting, not one wait out of many: otherwise an optional
+    // step would fall back, replay and park again on the very next pass.
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->signals()->count())->toBe(1)
+        ->and($final->signals()->first()->status)->toBe(SignalStatus::TimedOut)
+        ->and($final->result['charged'] ?? null)->toBe('unpaid');
+
+    $step = $final->actions()->where('sequence', 0)->first();
+
+    expect($step->status)->toBe(ActionStatus::OptionalFailed)
+        ->and($step->retry_signal_attempts)->toBe(0);
+});
+
+it('reports a broken history contract when an awaitSignal lands on a parked step', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q26')->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+
+    expect($run->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($run->signals()->first()->wait_sequence)->toBe(1);
+
+    // A retry wait-signal is the one signal row that shares an ordinal with an action.
+    // Editing an in-flight workflow so awaitSignal() takes that ordinal must be
+    // reported, not resolved against the retry signal and walked past.
+    expect(fn () => app(HistoryContractGuard::class)->expectSignal($run->id, 1, 'balance-refilled'))
+        ->toThrow(HistoryContractMismatchException::class);
+});
+
+it('hands a delivered signal back with its payload intact', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q27')->run();
+    drainQueue();
+
+    $seen = null;
+
+    Event::listen(FlowSignalReceived::class, function (FlowSignalReceived $event) use (&$seen): void {
+        $seen = $event->signal->payload;
+    });
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled', ['topped_up' => 500]);
+
+    $stored = SagaFlow::findRun($run->id)->signals()->where('name', 'balance-refilled')->first();
+
+    // Filling a claim's own database-ready values back into the model would encode the
+    // payload twice: the row right, every listener seeing a JSON string. And this is
+    // the ordinary awaitSignal delivery path, not just the retry one.
+    expect($stored->payload)->toBe(['topped_up' => 500])
+        ->and($seen)->toBe(['topped_up' => 500]);
+});
+
+it('holds the step to the budget persisted at scheduling time', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 1);
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q28')->run();
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id);
+
+    expect($parked->actions()->where('sequence', 1)->first()->retry_signal_max_attempts)->toBe(1);
+
+    // A redeploy raises the cap while the run is parked. The row still says 1, and so
+    // do the events and saga-flow:show — enforcing anything else would move a limit
+    // the operator is being shown.
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 5);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+    $step = $final->actions()->where('sequence', 1)->first();
+
+    expect($final->status)->toBe(FlowStatus::Failed)
+        ->and($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->retry_signal_attempts)->toBe(1)
+        ->and($step->retry_signal_max_attempts)->toBe(1);
+});
+
+it('settles an optional step whose retry policy was removed mid-flight', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(OptionalFallbackWorkflow::class)->run();
+
+    // Stop after the first pass has scheduled the optional step.
+    workOneJob();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 0)->firstOrFail();
+
+    // The state a rolling deploy leaves: the queue gave up while the row carried a
+    // policy, so the hook left OptionalFailed to the seam — and the deploy meanwhile
+    // removed retryOnSignal(). Nothing will write OptionalFailed and no job is left.
+    $step->status = ActionStatus::Failed;
+    $step->queue_attempts_exhausted = true;
+    $step->retry_signal = 'balance-refilled';
+    $step->save();
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    ResumeWorkflowJob::dispatch($run->id);
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['optional'] ?? null)->toBe('skipped')
+        ->and($final->actions()->where('sequence', 0)->first()->status)
+        ->toBe(ActionStatus::OptionalFailed);
+});
+
+it('keeps retrying a step the queue has not finished with after the policy is removed', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(FailingWorkflow::class)->run();
+
+    // Stop once the first step is scheduled.
+    workOneJob();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 0)->firstOrFail();
+
+    // Mid-native-retries after a deploy removed retryOnSignal(): the row carries the
+    // policy it was scheduled with and the queue still owes an attempt. An early replay
+    // must not read that as a final failure while a job is still coming.
+    $step->status = ActionStatus::Failed;
+    $step->queue_attempts_exhausted = false;
+    $step->retry_signal = 'balance-refilled';
+    $step->save();
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Queued);
+
+    expect(SagaFlow::findRun($run->id)->status)->not->toBe(FlowStatus::Failed);
+});
+
+it('keeps the cap when a step adopts a retry policy it was not scheduled with', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 1);
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q30')->run();
+
+    // Drive until the retry step exists but has not failed yet, then strip the policy
+    // off the row: this is a row an older deploy scheduled, before retryOnSignal() was
+    // added to the workflow.
+    workUntil($run, 1, fn (?ActionRun $step): bool => $step !== null);
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->firstOrFail();
+    $step->retry_signal = null;
+    $step->retry_signal_max_attempts = null;
+    $step->save();
+
+    drainQueue();
+
+    $parked = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->firstOrFail();
+
+    // Parking is where the row adopts the policy, so it has to write the cap it decided
+    // with: from here on the budget is read off the row, and an empty column would
+    // silently mean unbounded.
+    expect($parked->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($parked->retry_signal)->toBe('balance-refilled')
+        ->and($parked->retry_signal_max_attempts)->toBe(1);
+});
+
+it('does not reopen an optional step that already published its give-up', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(OptionalRetryOnSignalWorkflow::class)
+        ->withArguments('order-q31', 3)
+        ->run();
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 0)->firstOrFail();
+
+    // The state a deploy that ADDED retryOnSignal() leaves: the hook finalised the row
+    // while it carried no policy, so listeners already have OptionalActionFailed.
+    $step->status = ActionStatus::OptionalFailed;
+    $step->retry_signal = null;
+    $step->retry_signal_max_attempts = null;
+    $step->save();
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    ResumeWorkflowJob::dispatch($run->id);
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 0)->first()->status)
+        ->toBe(ActionStatus::OptionalFailed);
+});

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -5,6 +5,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -12,6 +13,7 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use Illuminate\Support\Facades\Event;
 
 /**
  * Sync-mode coverage for retryOnSignal(). Waking the run on delivery is switched
@@ -228,4 +230,30 @@ it('rejects a negative configured retry budget', function () {
 
     expect($run->status)->toBe(FlowStatus::Failed)
         ->and($run->exception['message'] ?? '')->toContain('actions.retry_on_signal.max_retries');
+});
+
+it('surfaces a failure that happened before the step could be recorded as failed', function () {
+    FlakyPaymentAction::reset(failures: 0);
+
+    // A listener (or an observer, or an action class that will not resolve) throws
+    // before failAction() ever runs, so there is no Failed row for the seam to read.
+    Event::listen(ActionStarted::class, function (ActionStarted $event): void {
+        if ($event->actionRun->action_class === FlakyPaymentAction::class) {
+            throw new RuntimeException('listener blew up before the step could fail');
+        }
+    });
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-inline')
+        ->runSync();
+
+    // Without the guard the seam replayed a step that never reached Failed, and a
+    // sync run suspended on a job that does not exist: waiting for ever, no signal
+    // to wake it, and the real error swallowed.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RuntimeException::class)
+        ->and($run->signals()->count())->toBe(0);
+
+    // And it rolls back the way it would have without any retry policy.
+    expect(CompensationLog::all())->toBe(['undo:created']);
 });

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+
+/**
+ * Sync-mode coverage for retryOnSignal(). Waking the run on delivery is switched
+ * off here so the signal does not queue a ResumeWorkflowJob: these tests drive the
+ * run again explicitly in RunMode::Sync, which keeps the inline path under test
+ * instead of silently falling through to the queued one (that is covered separately).
+ */
+beforeEach(function () {
+    FlakyPaymentAction::reset();
+    CompensationLog::reset();
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+});
+
+/**
+ * Deliver the retry signal and replay the run inline, the way a resumed job would.
+ */
+function refillAndDrive(FlowRun $run): FlowRun
+{
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    return app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+}
+
+it('parks a failed step on its signal instead of failing the flow', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-1')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $actions = $run->actions()->orderBy('sequence')->get();
+
+    // Only the two steps reached so far exist: parking does not consume a sequence
+    // of its own, and the downstream step has not been scheduled.
+    expect($actions)->toHaveCount(2)
+        ->and($actions[1]->sequence)->toBe(1)
+        ->and($actions[1]->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($actions[1]->retry_signal)->toBe('balance-refilled')
+        ->and($actions[1]->retry_signal_attempts)->toBe(0)
+        ->and($actions[1]->exception['message'] ?? null)->toBe('insufficient balance');
+
+    $marker = $run->signals()->first();
+
+    expect($run->signals()->get())->toHaveCount(1)
+        ->and($marker->status)->toBe(SignalStatus::Waiting)
+        ->and($marker->name)->toBe('balance-refilled')
+        ->and($marker->wait_sequence)->toBe(1);
+
+    // A parked step is not terminal, so nothing has rolled back.
+    expect(CompensationLog::all())->toBe([])
+        ->and($run->events()->pluck('type')->all())->toContain(FlowEventType::ActionAwaitingRetry);
+});
+
+it('retries only the parked step when the signal arrives', function () {
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-2')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $final = refillAndDrive($run);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['charged'] ?? null)->toBe(['charged' => 'order-2', 'calls' => 2]);
+
+    $actions = $final->actions()->orderBy('sequence')->get();
+
+    expect($actions)->toHaveCount(3)
+        ->and($actions[1]->status)->toBe(ActionStatus::Completed)
+        ->and($actions[1]->sequence)->toBe(1)
+        ->and($actions[1]->retry_signal_attempts)->toBe(1)
+        // The step before it was not re-executed, and the step after it still sits
+        // at the sequence it would have had without any retry.
+        ->and($actions[0]->attempts)->toBe(1)
+        ->and($actions[2]->sequence)->toBe(2)
+        ->and($actions[2]->result)->toBe(['label' => 'shipped']);
+
+    $marker = $final->signals()->first();
+
+    expect($final->signals()->get())->toHaveCount(1)
+        ->and($marker->status)->toBe(SignalStatus::Consumed)
+        ->and($marker->wait_sequence)->toBe(1);
+
+    expect(CompensationLog::all())->toBe([])
+        ->and($final->events()->pluck('type')->all())->toContain(FlowEventType::ActionRetried);
+});
+
+it('parks again when the retried step fails once more', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-3')->runSync();
+
+    $again = refillAndDrive($run);
+
+    expect($again->status)->toBe(FlowStatus::Waiting)
+        ->and(FlakyPaymentAction::$calls)->toBe(2);
+
+    $step = $again->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(1);
+
+    // One marker per retry cycle, all at the step's own ordinal: the spent one is
+    // consumed history, the fresh one is the wait we are parked on now.
+    $markers = $again->signals()->orderBy('id')->get();
+
+    expect($markers)->toHaveCount(2)
+        ->and($markers[0]->status)->toBe(SignalStatus::Consumed)
+        ->and($markers[1]->status)->toBe(SignalStatus::Waiting)
+        ->and($markers->pluck('wait_sequence')->all())->toBe([1, 1]);
+
+    expect(CompensationLog::all())->toBe([]);
+});
+
+it('succeeds on the third attempt and carries the saga on', function () {
+    FlakyPaymentAction::reset(failures: 2);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-4')->runSync();
+
+    $run = refillAndDrive($run);
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $final = refillAndDrive($run);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['charged']['calls'] ?? null)->toBe(3);
+
+    $step = $final->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::Completed)
+        ->and($step->retry_signal_attempts)->toBe(2);
+
+    expect($final->actions()->count())->toBe(3)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('fails normally when the failure falls outside only', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-5', null, [LogicException::class])
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(FlakyPaymentAction::$calls)->toBe(1);
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and($run->signals()->count())->toBe(0);
+
+    // The completed step before it rolled back, exactly as it would have without
+    // any retry policy in play.
+    expect(CompensationLog::all())->toBe(['undo:created']);
+});

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -194,3 +194,38 @@ it('writes a retry ceiling only for a step that carries the policy', function ()
     expect($charged->status)->toBe(ActionStatus::AwaitingRetry)
         ->and($charged->retry_signal_max_attempts)->toBe(2);
 });
+
+it('rejects a negative retry budget or wait', function () {
+    // Both columns are unsigned: a negative value is a MySQL error and a step that
+    // silently never parks elsewhere. The seam refuses it up front instead, so the
+    // run fails the same way on every driver, naming the value that is wrong.
+    $budget = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-neg', -1)
+        ->runSync();
+
+    expect($budget->status)->toBe(FlowStatus::Failed)
+        ->and($budget->exception['class'] ?? null)->toBe(InvalidArgumentException::class)
+        ->and($budget->exception['message'] ?? '')->toContain('maxRetries must be zero or greater');
+
+    $wait = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-neg-wait', null, null, -30)
+        ->runSync();
+
+    expect($wait->status)->toBe(FlowStatus::Failed)
+        ->and($wait->exception['message'] ?? '')->toContain('waitSeconds must be zero or greater');
+
+    // Refused before anything was scheduled, so no step carries a negative ceiling.
+    expect($budget->actions()->whereNotNull('retry_signal_max_attempts')->count())->toBe(0);
+});
+
+it('rejects a negative configured retry budget', function () {
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', -5);
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-neg-config')
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['message'] ?? '')->toContain('actions.retry_on_signal.max_retries');
+});

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -10,6 +10,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
 
 /**
@@ -167,4 +168,29 @@ it('fails normally when the failure falls outside only', function () {
     // The completed step before it rolled back, exactly as it would have without
     // any retry policy in play.
     expect(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('writes a retry ceiling only for a step that carries the policy', function () {
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 2);
+    FlakyPaymentAction::reset(failures: 99);
+
+    $plain = SagaFlow::create(OneActionWorkflow::class)->runSync();
+
+    // A configured cap describes the retry policy, not every action ever scheduled.
+    // Left on an ordinary row it becomes an unrelated number that awaitRetry()'s ??=
+    // would later keep in place of the ceiling the seam actually parked on.
+    $step = $plain->actions()->where('sequence', 0)->first();
+
+    expect($step->retry_signal)->toBeNull()
+        ->and($step->retry_signal_max_attempts)->toBeNull();
+
+    $parked = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-cap')
+        ->runSync();
+
+    // The same default still reaches a step that does carry the policy.
+    $charged = $parked->actions()->where('sequence', 1)->first();
+
+    expect($charged->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($charged->retry_signal_max_attempts)->toBe(2);
 });

--- a/tests/Fixtures/FlakyPaymentAction.php
+++ b/tests/Fixtures/FlakyPaymentAction.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use RuntimeException;
+
+/**
+ * A payment step that fails its first $failures calls and then succeeds, so a test
+ * can drive a step through several signal-gated retry cycles. The counters are
+ * static (like SideEffectCounter) because the retries happen across separate
+ * replays — and, in queued mode, separate jobs — of the same run. Reset per test.
+ */
+final class FlakyPaymentAction extends Action
+{
+    public static int $failures = 0;
+
+    public static int $calls = 0;
+
+    public static function reset(int $failures = 0): void
+    {
+        self::$failures = $failures;
+        self::$calls = 0;
+    }
+
+    /**
+     * @return array{charged: string, calls: int}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        if (self::$calls <= self::$failures) {
+            throw new RuntimeException('insufficient balance');
+        }
+
+        return ['charged' => $orderId, 'calls' => self::$calls];
+    }
+}

--- a/tests/Fixtures/OptionalRetryOnSignalWorkflow.php
+++ b/tests/Fixtures/OptionalRetryOnSignalWorkflow.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * An optional step that also carries a retry policy. The fallback must only be
+ * reached once the retry budget is spent — retryOnSignal sits between the queue's
+ * own attempts and continueOnFailure in the layering of failure handling.
+ */
+final class OptionalRetryOnSignalWorkflow extends Workflow
+{
+    /**
+     * @return array{charged: mixed, shipped: array{label: string}}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId, ?int $maxRetries = null): array
+    {
+        $charged = $this->action(FlakyPaymentAction::class, $orderId)
+            ->continueOnFailure()
+            ->fallbackValueOnFail('unpaid')
+            ->retryOnSignal('balance-refilled', maxRetries: $maxRetries)
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['charged' => $charged, 'shipped' => $shipped];
+    }
+}

--- a/tests/Fixtures/RetryBudgetSagaWorkflow.php
+++ b/tests/Fixtures/RetryBudgetSagaWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * Two compensatable steps ahead of a retryOnSignal step that never succeeds, so a
+ * test can watch the give-up after the budget is spent roll the saga back in
+ * reverse order.
+ */
+final class RetryBudgetSagaWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId, ?int $maxRetries = null): mixed
+    {
+        $this->action(MakeValueAction::class, 'reserved')
+            ->compensateWith(UndoAction::class, 'reserved')
+            ->run();
+
+        $this->action(MakeValueAction::class, 'packed')
+            ->compensateWith(UndoAction::class, 'packed')
+            ->run();
+
+        return $this->action(FlakyPaymentAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal('balance-refilled', maxRetries: $maxRetries)
+            ->run();
+    }
+}

--- a/tests/Fixtures/RetryOnSignalSagaGroupWorkflow.php
+++ b/tests/Fixtures/RetryOnSignalSagaGroupWorkflow.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The same three-step saga as RetryOnSignalWorkflow, written as an explicit
+ * saga() group, so a test can prove the SagaStepBuilder mirror of retryOnSignal()
+ * reaches the action builder and parks the middle step exactly the same way.
+ */
+final class RetryOnSignalSagaGroupWorkflow extends Workflow
+{
+    /**
+     * @return list<mixed>
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId, ?int $maxRetries = null): array
+    {
+        return $this->saga()
+            ->step(MakeValueAction::class, 'created')
+            ->compensateWith(UndoAction::class, 'created')
+            ->step(FlakyPaymentAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal('balance-refilled', maxRetries: $maxRetries)
+            ->step(MakeValueAction::class, 'shipped')
+            ->run();
+    }
+}

--- a/tests/Fixtures/RetryOnSignalWorkflow.php
+++ b/tests/Fixtures/RetryOnSignalWorkflow.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A three-step saga whose middle step charges a card and parks on a
+ * 'balance-refilled' signal instead of failing the run. The surrounding steps are
+ * compensatable, so a test can prove that parking rolls nothing back and that a
+ * give-up rolls back only the steps that actually completed.
+ *
+ * $maxRetries, $only and $waitSeconds are workflow arguments (deterministic across
+ * replays) so a single fixture can exercise the budget, the exception filter and
+ * the wait deadline.
+ */
+final class RetryOnSignalWorkflow extends Workflow
+{
+    /**
+     * @param  list<class-string<Throwable>>|null  $only
+     * @return array{created: mixed, charged: mixed, shipped: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(
+        string $orderId,
+        ?int $maxRetries = null,
+        ?array $only = null,
+        ?int $waitSeconds = null,
+    ): array {
+        $created = $this->action(MakeValueAction::class, 'created')
+            ->compensateWith(UndoAction::class, 'created')
+            ->run();
+
+        $charged = $this->action(FlakyPaymentAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal(
+                'balance-refilled',
+                maxRetries: $maxRetries,
+                waitSeconds: $waitSeconds,
+                only: $only,
+            )
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['created' => $created, 'charged' => $charged, 'shipped' => $shipped];
+    }
+}

--- a/tests/Fixtures/UnreliablePaymentAction.php
+++ b/tests/Fixtures/UnreliablePaymentAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use RuntimeException;
+
+/**
+ * A payment step that always fails and asks the queue for two attempts of its own.
+ * Used to prove that a signal-gated retry cycle is not spent while Laravel still
+ * owes the step a native attempt.
+ */
+final class UnreliablePaymentAction extends Action
+{
+    public int $tries = 2;
+
+    public static int $calls = 0;
+
+    public static function reset(): void
+    {
+        self::$calls = 0;
+    }
+
+    /**
+     * @return array{charged: string}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        throw new RuntimeException('insufficient balance');
+    }
+}

--- a/tests/Fixtures/UnreliableRetryOnSignalWorkflow.php
+++ b/tests/Fixtures/UnreliableRetryOnSignalWorkflow.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A single retryOnSignal step whose action carries its own queue $tries, so a test
+ * can drive the run to the state where one native attempt has failed and another is
+ * still owed.
+ */
+final class UnreliableRetryOnSignalWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): mixed
+    {
+        return $this->action(UnreliablePaymentAction::class, $orderId)
+            ->retryOnSignal('balance-refilled')
+            ->run();
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -66,8 +66,12 @@ if (! function_exists('useDatabaseQueue')) {
 
     function drainQueue(): void
     {
+        // --sleep=0 matters more than it looks: Worker::daemon() sleeps BEFORE it
+        // checks stopWhenEmpty, so every drain would otherwise pay the default three
+        // seconds after the queue is already empty.
         Artisan::call('queue:work', [
             '--stop-when-empty' => true,
+            '--sleep' => 0,
             '--no-interaction' => true,
         ]);
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -26,7 +26,22 @@ class TestCase extends Orchestra
 
     protected function defineDatabaseMigrations(): void
     {
-        $migration = include __DIR__.'/../database/migrations/2026_07_02_000000_create_saga_lara_flow_initial_tables.php';
-        $migration->up();
+        // Every shipped migration, in filename order — the package now ships more
+        // than one, and a suite that only ran the first would be missing columns.
+        foreach ($this->packageMigrations() as $path) {
+            (include $path)->up();
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    protected function packageMigrations(): array
+    {
+        $paths = glob(__DIR__.'/../database/migrations/*.php') ?: [];
+
+        sort($paths);
+
+        return array_values($paths);
     }
 }


### PR DESCRIPTION
Closes #9.

A failing saga step took the whole run with it: the saga rolled back and completed work was
undone. That is right for a bug, wrong for a step that failed because the world was not ready
yet — a declined card, a service still provisioning. `retryOnSignal()` parks such a step
instead, and an external signal re-runs **that step alone**.

```php
$this->action(ChargeCard::class, $orderId)
    ->compensateWith(RefundCard::class, $orderId)
    ->retryOnSignal(
        'balance-refilled',
        maxRetries: 3,                                // null = unbounded
        waitSeconds: 86400,                           // how long one wait may last
        only: [InsufficientBalanceException::class],  // null = park on any exception
    )
    ->run();
```

The layers stack: Laravel's `$tries` first, then `retryOnSignal()`, then `continueOnFailure()`,
then hard failure and compensation. When the budget is spent or the wait times out, the step
fails exactly as it would have without the policy — same `ActionFailedException` carrying the
last attempt's message, same rollback. The seam is transparent on the way out; there is no new
exception class to catch. `saga()->step()` mirrors the method.

## Determinism

A retry consumes **no new sequence**. The step keeps its `(flow_run_id, sequence)` ordinal and
reuses the same `action_runs` row for every cycle, and waiting consumes no ordinal at all, so
downstream steps land identically whether the step retried zero times or ten. The wait itself is
an ordinary `flow_signals` row parked at the step's own ordinal — no schema change to
`flow_signals`, and delivery and the monitor reach it through the existing paths.

## Schema

One new migration, `add_retry_on_signal_to_action_runs`, adding `retry_signal`,
`retry_signal_attempts`, `retry_signal_max_attempts` and `queue_attempts_exhausted` to
`action_runs`. The initial migration is untouched — v1.0.5 is already in the wild.

**This migration is not optional.** `scheduleAction()` writes the new columns for *every* action,
not only those carrying a retry policy, so an app that upgrades without `php artisan migrate`
breaks ordinary workflow execution with an unknown-column error. `UPGRADING.md` leads with that.

## Behaviour changes for existing users

Two, both documented in `UPGRADING.md`:

- **`SignalRepository` gained two methods** (`earliestPendingSince`, `latestForSequence`). Shipped
  as a minor because the repository contracts are not a public extension point — they are now
  marked `@internal`, and `config('saga-lara-flow.models.*')` is the supported swap point.
- **Delivering into an open wait and timing a wait out no longer raise Eloquent model events.**
  Both are now single conditional `UPDATE`s — the only form that is atomic on every supported
  driver (`lockForUpdate()` compiles to nothing on SQLite), and what stops a delivery and a
  timeout from both claiming the same wait. An observer on a swapped-in `models.flow_signal` no
  longer sees them; `flow_events` and the package's own Laravel events still record every one.

## Operator surface

`saga-flow:show` gains a **Retry** column (signal, spent budget, live wait deadline);
`saga-flow:list` annotates a parked run with the signal it needs. Two new events,
`ActionAwaitingRetry` and `ActionRetried`, both `ShouldDispatchAfterCommit`.

## Tests

`RetryOnSignalTest`, `RetryOnSignalQueuedTest` and `RetryOnSignalOperatorTest` cover parking,
retrying, re-parking, budget exhaustion, wait timeout, the `only` filter (including subclasses),
interaction with `continueOnFailure()`, the saga-group mirror, ordinal stability across retries,
and the crash and race windows found while reviewing. Every regression test was verified to fail
without its fix.

Suite: 217 passed / 841 assertions. Queue drains now pass `--sleep=0` — `Worker::daemon()` sleeps
*before* it checks `stopWhenEmpty`, which was costing the suite three seconds per drain.

## Docs

New `docs/docs/retry-on-signal.md` plus cross-links from actions, sagas, signals, optional
actions, expiration & monitoring, determinism rules, events and artisan commands; `installation.md`
now describes two migrations; new root `UPGRADING.md`. `CHANGELOG.md` intentionally untouched — it
is generated from release notes.
