### PR TITLE
Document that deadlines are enforced by the expiration sweep

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,6 +343,11 @@ try {
 }
 ```
 
+A deadline does not enforce itself: the package has no durable timers, so an unanswered wait only
+times out once the expiration sweep notices — see
+[Expiration & monitoring](#expiration--monitoring) below. Until then the wait stays open, however
+long the deadline has been past.
+
 Deliver a signal from anywhere via the handle:
 
 ```php
@@ -527,6 +532,11 @@ Schedule::command('saga-flow:monitor')->everyMinute();
 **Queue looping (opt-in).** Drive the sweep off the queue worker's idle loop by enabling
 `monitor.queue_looping.enabled` (throttled by `throttle_seconds`). Useful when you have no cron but
 always-on workers.
+
+If neither is running, **no deadline is ever enforced** — `queue:work` alone does not check them.
+And because the sweep is the only writer of "this deadline passed", deadlines are approximate: a
+signal delivered after its deadline but before the next sweep is still accepted. Both points are
+expanded in [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring).
 
 For runs whose progress was lost to a *dropped job* (rather than a deadline), the **doctor** can
 re-dispatch missing actions (`repair.redispatch_lost_actions`) and re-wake stuck waits

--- a/docs/docs/actions.md
+++ b/docs/docs/actions.md
@@ -50,6 +50,10 @@ $this->action(ChargeCard::class, $orderId)
 There is no `timeoutAfter()` on an action builder — that method belongs to
 [signals](./signals.md). Action deadlines use `expiresAt()`.
 
+Like every deadline in the package, this one is enforced by the expiration sweep rather than by a
+timer: a step passes its deadline only once `saga-flow:monitor` (or the opt-in queue-looping
+listener) notices. See [Expiration & monitoring](./expiration-and-monitoring.md).
+
 ## Handling failure
 
 `run()` throws when the action ultimately fails (after exhausting `$tries`), so the workflow can

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -51,7 +51,28 @@ Drive the sweep off the queue worker's idle loop instead of cron:
 ```
 
 Useful when you have always-on workers but no scheduler. The sweep is throttled so it runs at most
-once per `throttle_seconds`.
+once per `throttle_seconds`. The listener is registered while the service provider boots, so the
+option has to be set in configuration — flipping it at runtime has no effect.
+
+**If neither is driving the sweep, no deadline in the package is ever enforced.** A run passes its
+`expiresAt`, a step passes its own, a signal wait passes its `timeoutAfter` — and nothing happens.
+`queue:work` on its own does not check deadlines, and neither does delivering a signal.
+
+## Deadlines are approximate
+
+The sweep is the only writer of "this deadline passed", which means a deadline is enforced no sooner
+than the next sweep. With `everyMinute()` that is a window of up to a minute; with queue looping it
+is up to `throttle_seconds`.
+
+The visible consequence: a signal delivered *after* its wait's deadline but *before* the next sweep
+is still accepted, and the workflow carries on as though the wait succeeded. Once the sweep has
+marked the wait `timed_out`, the same delivery arrives too late and the workflow sees
+`AwaitSignalTimeoutException` instead.
+
+This is deliberate. Keeping the sweep the single writer of a wait's status is what makes delivery,
+timeout and the retry seam safe to run concurrently. If your deadline is a hard business boundary
+rather than a safety net, enforce it in the workflow — the payload of a late signal can be checked
+against a deadline you captured with `sideEffect()`.
 
 ## Repair (the doctor)
 

--- a/docs/docs/installation.md
+++ b/docs/docs/installation.md
@@ -44,6 +44,22 @@ try to run **both** the published copy and the package's own and fail with a dup
 Publishing the migration is not part of the install flow.
 :::
 
+## Schedule the monitor
+
+Optional, but required for any deadline to work. The package has no durable timers: `expiresAt()`,
+`timeoutAfter()`, `#[FlowTimeout]` and the `monitor.expiration.defaults` all store a deadline that
+something has to notice.
+
+```php
+use Illuminate\Support\Facades\Schedule;
+
+Schedule::command('saga-flow:monitor')->everyMinute();
+```
+
+Skip it and nothing breaks — deadlines simply never fire. See
+[Expiration & monitoring](./expiration-and-monitoring.md) for the queue-looping alternative and for
+the repair doctor.
+
 ## Requirements
 
 - **PHP `^8.5`**

--- a/docs/docs/signals.md
+++ b/docs/docs/signals.md
@@ -40,6 +40,19 @@ try {
 
 `awaitSignal($name, $timeout)` accepts the timeout as an optional second argument as well.
 
+:::warning A deadline does not enforce itself
+
+The package has no durable timers. A deadline is a value stored on the wait; something has to
+*notice* that it passed. That something is the expiration sweep — either the scheduled
+`saga-flow:monitor` command or the opt-in queue-looping listener. Until a sweep runs, the wait stays
+open and `AwaitSignalTimeoutException` is never thrown, however long the deadline has been past.
+
+If you set no deadline and no `monitor.expiration.defaults.signal`, the wait is unbounded by design.
+
+See [Expiration & monitoring](./expiration-and-monitoring.md) for how to drive the sweep, and
+[Testing](./testing.md#testing-deadlines) for driving it from a test.
+:::
+
 ## Delivering a signal
 
 From anywhere in your app, deliver via the flow handle:

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -42,9 +42,46 @@ expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Completed);
 The package's own suite (`tests/`) is a working reference — see `tests/Helpers.php` for the
 `useDatabaseQueue()` / `drainQueue()` helpers it uses to drive queued flows deterministically.
 
+## Testing deadlines
+
+Deadlines — `timeoutAfter()`, `expiresAt()`, `#[FlowTimeout]`, the `monitor.expiration.defaults` —
+are enforced by the [expiration sweep](./expiration-and-monitoring.md), not by a timer. Draining the
+queue does not advance them, so a test has to run the sweep itself:
+
+```php
+use Illuminate\Support\Facades\Artisan;
+
+$run = SagaFlow::create(ApprovalWorkflow::class)->run();
+drainQueue();
+
+// Parked on awaitSignal('approval', now()->addHour()).
+expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+
+$this->travel(2)->hours();
+
+Artisan::call('saga-flow:monitor'); // flips the overdue wait to timed_out and wakes the run
+drainQueue();                       // the resumed run replays and sees the timeout
+
+expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Completed);
+```
+
+Two steps are easy to miss. **`travel()` alone changes nothing** — moving the clock does not make
+anything look at the deadline. And **the sweep only marks the wait**; the run is resumed as a queued
+job, so a second drain is needed before the workflow has actually replayed and reacted.
+
+`Artisan::call('saga-flow:monitor')` and `app(FlowMonitor::class)->sweep()` are equivalent here; the
+command is the more faithful of the two because it is what production runs.
+
+If you would rather not call the sweep explicitly, enable
+`monitor.queue_looping.enabled` in the test environment and `queue:work` will sweep on its idle
+loop. Set it before the application boots — the listener is registered in the service provider's
+`boot()`, so flipping the config inside the test body is too late.
+
 ## Ageing timestamps
 
-To test expiration/repair without waiting, age a row's timestamps directly rather than sleeping:
+Instead of travelling, you can age a row's timestamps directly. This is what the repair doctor
+reads: its grace period is measured from `updated_at` on a run and from `created_at` on a step, so
+ageing both covers either.
 
 ```php
 FlowRun::query()->whereKey($run->id)->update([

--- a/tests/Feature/MonitorSignalTimeoutTest.php
+++ b/tests/Feature/MonitorSignalTimeoutTest.php
@@ -7,8 +7,10 @@ use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FutureSignalTimeoutWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalTimeoutCaughtWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalTimeoutWorkflow;
+use Illuminate\Support\Facades\Artisan;
 
 beforeEach(fn () => CompensationLog::reset());
 
@@ -59,4 +61,60 @@ it('lets the workflow catch a signal timeout and carry on', function () {
     expect($final->status)->toBe(FlowStatus::Completed)
         ->and($final->result)->toBe(['outcome' => 'timed-out'])
         ->and($final->signals()->first()->status)->toBe(SignalStatus::TimedOut);
+});
+
+/**
+ * A deadline is a stored value, not a timer: nothing notices it until the sweep runs.
+ * Moving the clock past it and draining the queue must therefore change nothing — this
+ * is the behaviour reported in issue #17, and it is by design.
+ */
+it('leaves an overdue wait open until the sweep runs', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(FutureSignalTimeoutWorkflow::class)->run();
+    drainQueue();
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+
+    $this->travel(10)->days();
+    drainQueue();
+
+    $stalled = SagaFlow::findRun($run->id);
+
+    expect($stalled->status)->toBe(FlowStatus::Waiting)
+        ->and($stalled->signals()->first()->status)->toBe(SignalStatus::Waiting);
+
+    // The sweep marks the wait; the run resumes as a queued job, so it takes a
+    // second drain before the workflow has replayed and seen the timeout.
+    Artisan::call('saga-flow:monitor');
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result)->toBe(['value' => false])
+        ->and($final->signals()->first()->status)->toBe(SignalStatus::TimedOut);
+});
+
+/**
+ * The sweep is the only writer of "this deadline passed", so a delivery that beats it
+ * is honoured even though the deadline is already behind us. Documented in
+ * expiration-and-monitoring.md as the price of keeping that writer single.
+ */
+it('accepts a signal delivered after its deadline but before the sweep', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(FutureSignalTimeoutWorkflow::class)->run();
+    drainQueue();
+
+    $this->travel(10)->days();
+
+    SagaFlow::loadFlow($run->id)->signal('approval', ['late' => true]);
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result)->toBe(['value' => true])
+        ->and($final->signals()->first()->status)->toBe(SignalStatus::Consumed);
 });

--- a/tests/Fixtures/FutureSignalTimeoutWorkflow.php
+++ b/tests/Fixtures/FutureSignalTimeoutWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Awaits a signal with a deadline an hour into the future and catches the timeout,
+ * so a test can move the clock past the deadline rather than staging a past one.
+ * Returns whether the signal actually arrived.
+ */
+final class FutureSignalTimeoutWorkflow extends Workflow
+{
+    public function handle(): bool
+    {
+        try {
+            $this->awaitSignal('approval', now()->addHour());
+
+            return true;
+        } catch (AwaitSignalTimeoutException) {
+            return false;
+        }
+    }
+}


### PR DESCRIPTION
Closes #17.

The engine has no durable timers: `expiresAt()`, `timeoutAfter()`, `#[FlowTimeout]` and the
`monitor.expiration.defaults` all store a deadline that the expiration sweep has to notice. That was
only ever stated on the expiration page — the pages where those APIs are introduced said nothing,
and `installation.md` never mentioned scheduling the monitor at all. A user following the signal
docs had no way to learn that `timeoutAfter()` needs `saga-flow:monitor` running.

No engine changes, and no migration.

## Documentation

- `signals.md` / `actions.md` — a deadline does not enforce itself; links to the expiration page and
  to the new testing section.
- `installation.md` — a "Schedule the monitor" step.
- `testing.md` — a "Testing deadlines" section: `travel()` alone changes nothing, the sweep only
  marks the wait, and a second queue drain is needed before the workflow has replayed. Also corrects
  the "Ageing timestamps" note, which implied the repair doctor reads `updated_at` for everything —
  it reads `updated_at` on a run and `created_at` on a step.
- `expiration-and-monitoring.md` — with no sweep running, no deadline is enforced at all; and a new
  "Deadlines are approximate" section documenting that a signal delivered after its deadline but
  before the next sweep is still accepted.
- `README.md` mirrors both points.

## Tests

Two tests covering the reported scenario, so it cannot regress silently:

- an overdue wait stays open across `travel()` + a drain, and resolves only after
  `saga-flow:monitor` plus a second drain;
- a signal delivered after its deadline but before the sweep is accepted.

The second locks in the behaviour now documented as deliberate — the sweep stays the single writer
of a wait's status, which is what makes delivery, timeout and the retry seam safe to run
concurrently. Making deadlines strict is proposed separately as an opt-in for 1.2.
