### PR TITLE
Normalize line endings to LF via gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
 # Path-based git attributes
 # https://www.kernel.org/pub/software/scm/git/docs/gitattributes.html
 
+# Normalize line endings: the index is LF, Pint enforces LF, and CI runs on
+# Linux. eol=lf overrides a contributor's core.autocrlf, so a checkout never
+# introduces CRLF and no one sees whole-file diffs that carry no changes.
+* text=auto eol=lf
+
 # Ignore all test and documentation with "export-ignore".
 /.github            export-ignore
 /.gitattributes     export-ignore

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     paths:
       - '**.php'
+      - '.gitattributes'
       - '.github/workflows/run-tests.yml'
       - 'phpunit.xml.dist'
       - 'composer.json'
@@ -11,6 +12,7 @@ on:
   pull_request:
     paths:
       - '**.php'
+      - '.gitattributes'
       - '.github/workflows/run-tests.yml'
       - 'phpunit.xml.dist'
       - 'composer.json'


### PR DESCRIPTION
Adds a single line to `.gitattributes`:

```
* text=auto eol=lf
```

## Why

Every text file in the index is already LF (`git ls-files --eol` reports `i/lf` for all 343 of
them), Pint enforces LF through its `line_ending` fixer, and CI runs the real checks on Linux. The
one thing that could disagree was a contributor's global `core.autocrlf`, which converts LF to CRLF
at checkout time. On a machine with `core.autocrlf=true` this repository checked out with 43 files
as CRLF and 3 with mixed endings, all of which then sat in `git status` permanently as modified
while carrying no changes at all — verified: identical blob hashes, identical sizes and modes, and a
raw `git diff` of zero bytes.

`eol=lf` overrides `core.autocrlf` per repository, so a checkout produces LF regardless of how a
contributor's git is configured, and that class of phantom diff cannot appear again.

## Scope

Nothing but the attribute itself. `git add --renormalize .` stages **only `.gitattributes`**, which
is the proof that no file content changes: the repository was already LF throughout, so there is no
renormalisation commit and no history rewrite.

Binary files are unaffected — `text=auto` detects them, and the five PNG/ICO assets stay `-text`.

No release is needed: `.gitattributes` carries `export-ignore` on itself and never reaches the dist
archive.

## Verified

- `composer test` — 226 passed
- `composer lint` — Pint and PHPStan clean
- working tree stays clean across repeated tooling runs
