### PR TITLE
Claim action and compensation steps atomically

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,206 @@
 # Upgrading
 
+## From 1.1.x to 1.2.0
+
+> ### ⚠️ Run `php artisan migrate` immediately after upgrading
+>
+> Every action and compensation the engine schedules writes the columns added by this release. Deploy
+> the migration together with the code, the same as every other release.
+
+### What's new
+
+`ActionRecorder::startAction()` and `CompensationRecorder::startCompensation()` now claim their row
+atomically instead of writing to it unconditionally, closing a check-then-act race where a stale
+job (a superseded retry cycle, a row the monitor just expired, or a job the doctor sent on top of a
+live one) could execute a step a second time. See [Queues, locks & idempotency](https://sagalaraflow.dev/queues-locks-idempotency)
+for the full picture, and the new **reclaim** section below for the opt-in half.
+
+A companion mechanism, `actions.reclaim.stale_running` / `sagas.reclaim.stale_running`, lets a
+`Running` row be claimed again once its reclaim window has passed — recognising a worker that died
+mid-execution. Off by default; enable it globally or per action/compensation
+(`reclaimStaleAfter()`, `enableStaleReclaim()`, and their `...Compensation...` mirrors on
+`ActionBuilder`/`SagaStepBuilder`).
+
+### 1. A `Running` row is no longer picked up by a redelivered job
+
+This is the one change to be deliberate about, and it applies **whether or not you enable reclaim**.
+
+The claim accepts a row that is `Pending` or `Failed`. A row that is already `Running` is accepted
+only once its reclaim window has passed — and with reclaim off, the default, there is no window, so
+it is never accepted. Previously any redelivered job would simply execute such a row again.
+
+What that buys you: the engine's own machinery can no longer produce a duplicate execution. A job
+left over from a superseded retry cycle, a job racing a row the monitor just expired, and a job the
+doctor dispatched on top of one still running are all now refused. (What no engine can prevent is
+the queue driver's own at-least-once delivery — SQS visibility timeouts, `retry_after` on
+Redis/database — redelivering a job while the first attempt is still alive. That is the documented
+baseline your action code already has to tolerate.)
+
+What it costs you: if a worker is killed mid-execution — an evicted pod, the OOM killer, a `SIGKILL`
+deploy — its row stays `Running`, and with everything at its default nothing brings it back. Replay
+treats a `Running` step as still in flight and parks the run, and `saga-flow:kick` does the same, so
+the run waits indefinitely. Choose one of the two recoveries if that matters to you:
+
+- **`reclaim`** — the row becomes claimable again after its window, and the step **runs again**.
+  Recovery of the work itself. See the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery).
+- **The monitor** — set `monitor.expiration.defaults.action` (or `->expiresAt()`) and schedule
+  `saga-flow:monitor`. The step is marked `Expired` and the run **fails as a business error**
+  instead of hanging. Recovery of the run, not of the work.
+
+They are complementary: reclaim retries, the monitor gives up. Neither runs unless you turn it on.
+
+### 2. The new migration
+
+`add_reclaim_stale_running_columns` adds `reclaim_stale_after_seconds` (the configured window) and
+`reclaim_stale_at` (the absolute deadline the claim derives from it) to both `action_runs` and
+`compensation_runs`, plus an `attempts` counter on `compensation_runs` mirroring the one
+`action_runs` already had. It runs from the package like every other migration — do not
+`vendor:publish` it.
+
+### 3. Six transitions no longer raise Eloquent model events
+
+`startAction()` / `startCompensation()` and the four outcome writes
+(`completeAction()`, `failAction()`, `completeCompensation()`, `failCompensation()`) are now
+conditional `UPDATE` statements, the same shape (and for the same reason — the only form every
+supported driver enforces atomically) as the signal transitions changed in 1.1.0.
+
+The consequence, exactly as documented then: an **observer** registered on a swapped-in
+`models.action_run` or `models.compensation_run` no longer sees `updating`/`updated` for these
+transitions. Nothing is lost, though — each still records its own package event and `flow_events`
+entry whenever it actually writes: `ActionStarted` (`action.started`, unchanged), `ActionCompleted`,
+`ActionFailed`, `CompensationCompleted`, `CompensationFailed`, and the new `CompensationStepStarted`
+(`compensation.step_started` — distinct from `CompensationStarted`, which marks the whole rollback
+beginning once per run, not once per compensation). Listen to those, or read `flow_events`, instead
+of Eloquent hooks.
+
+### 4. A recorded outcome can no longer be overwritten by a superseded worker
+
+Enabling reclaim lets a second worker take over a row whose first worker may be slow rather than
+dead, so both can reach the end of the same step. The outcome writes are therefore fenced against
+the claim that produced them (via `attempts`, which only the claim increments): an executor that has
+been superseded updates no rows, raises no event, and its job does not fail. In practice this means
+a **recorded success is never demoted** — a straggler that fails after the live worker succeeded can
+no longer flip the step to `Failed` and send the saga rolling back over work that actually went
+through.
+
+The fence has a second condition alongside `attempts`: the row must still be `Running`. That guards
+against a settlement that never claimed the row at all — the monitor expiring an overdue step does
+not touch `attempts`. `ActionRecorder::expireAction()` is conditional for the same reason, from the
+other side: a step that completes just before the sweep reaches it is not demoted to `Expired`. It
+now returns `bool`, and the monitor counts and wakes only for an expiry it actually won.
+
+Every quiet path — a lost claim, a rejected outcome, a batch closed early — is logged, since nothing
+else records them. See `logging.anomaly_level` in item 7.
+
+### 5. `ActionRunRepository` gained one method
+
+If you bound your own implementation of `DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository`, it must now also
+implement:
+
+```php
+public function dueForStaleRunningRepair(int $limit, int $maxAttempts): iterable;
+```
+
+As with the 1.1.0 note on `SignalRepository`, the simplest fix is to extend
+`Repositories\EloquentActionRunRepository` rather than implement the interface from scratch — it
+remains `@internal` and not a public extension point.
+
+### 6. `RunCompensationJob` now takes its own queue lock
+
+Compensations previously had no `WithoutOverlapping` protection at all (actions and parallel steps
+always did). A new `locks.compensation_ttl_seconds` (default 900, independent of
+`locks.action_ttl_seconds`) governs it; set `locks.enabled = false` to keep locking off entirely, as
+before.
+
+**If you published the config file before this release**, add the key to your `locks` array —
+package config is merged only at the top level, so your own `locks` array is taken as it stands and
+the new key is not filled in for you. Nothing breaks if you forget: a missing value inherits
+`action_ttl_seconds`, and a zero or missing TTL can never produce a lock without an expiry.
+
+### 7. New: `logging`
+
+```php
+'logging' => [
+    'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'),
+    'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),
+],
+```
+
+The first logging the package has ever done. `Runtime\AnomalyLog` is a second journal beside the
+`flow_events` business history, and it covers exactly the things that are otherwise untraceable:
+
+- `claim_lost` — a claim lost to whoever already owned the row.
+- `outcome_rejected` — an outcome write refused because the row had changed hands.
+- `batch_finished_early` — a parallel step completed after a duplicate delivery had already closed
+  its batch.
+
+All three are normal under at-least-once delivery and none of them fails a job, so without this
+there would be nothing to investigate afterwards. Each line carries the run id, row id, sequence and
+class. Set `anomaly_level` to `null` to silence it, or to `warning` if you want these surfaced by
+your alerting. Writing the line is best-effort: an unusable level is treated as off, and a logger
+that throws is swallowed rather than allowed to fail a job that was deliberately giving up quietly.
+
+### 8. An unfinished compensation now stops a rollback
+
+A compensation left `Pending` or `Running` when its level finishes — its worker died, or its job
+never arrived — is treated the way a failed one is: under the `Stop` policy it halts the rollback,
+and either way it is recorded as the run's secondary cause under `flow_run.exception['compensation']`.
+Previously only `Failed` rows were looked for, so a rollback could finalize with a step silently
+never undone and no trace of it anywhere. A compensation registered with the `Continue` policy still
+does not stop the unwind.
+
+### 9. Three scheduling methods take an `ActionSchedule`
+
+The step's options used to be passed as a long tail of optional arguments. They are now carried by
+`Data\ActionSchedule`, a readonly object with the same names as before:
+
+```php
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
+
+// before
+$dispatcher->dispatch($run, $sequence, ChargeCard::class, [$orderId], true, false, $expiresAt);
+
+// after
+$dispatcher->dispatch($run, $sequence, new ActionSchedule(
+    actionClass: ChargeCard::class,
+    arguments: [$orderId],
+    hasCompensation: true,
+    expiresAt: $expiresAt,
+));
+```
+
+Affected: `ActionDispatcher::dispatch()`, `ActionDispatcher::runInline()`, and
+`ActionRecorder::scheduleAction()`. Nothing in the workflow API changes — this only matters if your
+code calls those runtime classes directly.
+
+### 10. `execute()` reports how far a step got
+
+`ActionDispatcher::execute()`, `CompensationExecutor::execute()` and `ActionDispatcher::runInline()`
+return `Enums\StepExecution` instead of `void`:
+
+- **`Executed`** — the row was claimed, the step ran, and its outcome was recorded.
+- **`ClaimLost`** — the row was already owned or no longer claimable; nothing ran.
+- **`Superseded`** — the step ran, but the row changed hands before its outcome could be written.
+
+The two failing cases look the same from a queued job, which returns quietly either way; call
+`->settled()` if that is all you need. They differ where no competitor is supposed to exist: a
+freshly created row that cannot be claimed is a broken invariant and still raises
+`ActionClaimFailedException`, while being superseded afterwards is an ordinary race — the monitor and
+the doctor act on the rows a sync run creates from their own processes — and replay resolves it from
+whatever the row ended up holding.
+
+### Recommended while you are here
+
+- **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the
+  monitor off means such a run waits forever, which is safe but needs a human.
+- Read the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery) before enabling reclaim in
+  production: it changes which `Running` rows a redelivered job, or the doctor, may re-execute.
+- If you already turned `repair.enabled` on, note that its new R3 rule
+  (`repair.redispatch_stale_running_actions`, default `true`) acts on any row carrying a reclaim
+  window — including one enabled per step via `reclaimStaleAfter()` while
+  `actions.reclaim.stale_running.enabled` is globally `false`, since a per-step override outranks the
+  global switch everywhere else too.
+
 ## From 1.0.x to 1.1.0
 
 > ### ⚠️ Run `php artisan migrate` immediately after upgrading

--- a/config/saga-lara-flow.php
+++ b/config/saga-lara-flow.php
@@ -59,8 +59,34 @@ return [
         'store' => env('SAGA_LARA_FLOW_LOCK_STORE'),
         'workflow_ttl_seconds' => 900,
         'action_ttl_seconds' => 900,
+
+        // Added in 1.2.0. An application that published this file earlier has a
+        // 'locks' array without this key — config merging is shallow, so it is not
+        // filled in for them. Missing/zero falls back to action_ttl_seconds (a
+        // compensation is a step, so the value tuned for steps applies), never to
+        // zero: zero means "no expiry" on Redis, and a lock a killed worker never
+        // releases would wedge the row forever.
+        'compensation_ttl_seconds' => 900,
+
         'block_seconds' => 5,
         'prefix' => 'saga-lara-flow',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Logging
+    |--------------------------------------------------------------------------
+    */
+    'logging' => [
+        // A claim lost to a competing worker, an outcome write rejected because the
+        // row changed hands, a batch already closed by a duplicate delivery: all are
+        // normal under at-least-once delivery — not errors, and none of them fails a
+        // job. This log line is the only trace they leave, so the case can be found
+        // and debugged afterwards. null = silent.
+        'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'),
+
+        // null = the application's default channel.
+        'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),
     ],
 
     /*
@@ -122,6 +148,16 @@ return [
         'redispatch_lost_actions' => true,
         // R2: re-wake flows stuck in the Waiting status after a resume that never fired.
         'wake_stuck_flows' => true,
+        // R3: re-dispatch stuck sequential Running actions past their own
+        // actions.reclaim.stale_running threshold (a worker that died mid-execution).
+        // Has no effect while that mechanism is off (its default) — this only
+        // decides whether the doctor additionally acts on rows it makes claimable.
+        // Parallel actions and compensations are out of scope: recovering them would
+        // mean re-adding a job to their Bus::batch, which needs the batch's id — not
+        // stored anywhere in this package's tables — looked up by name in Laravel's
+        // own job_batches table, a detail of the database batch driver specifically
+        // and not guaranteed for every host.
+        'redispatch_stale_running_actions' => true,
 
         'queue_looping' => ['enabled' => false, 'throttle_seconds' => 60],
     ],
@@ -171,6 +207,27 @@ return [
         'retry_on_signal' => [
             'max_retries' => null,
         ],
+
+        // A step's own atomic claim (see startAction()) accepts a row still Running
+        // only when it has sat that long since started_at — meant to recognize a
+        // worker that died mid-execution, not to interrupt one that is still alive.
+        //
+        // Off by default, and that default has a consequence worth knowing: with no
+        // window configured, a Running row is never claimed again by anything. A
+        // worker killed mid-step therefore leaves it Running for good — replay reads
+        // it as still in flight and parks the run, and saga-flow:kick does the same.
+        // The two ways to get automatic recovery are this setting (the step runs
+        // again) and monitor.expiration.defaults.action with saga-flow:monitor (the
+        // step is marked Expired and the run fails as a business error).
+        //
+        // Distinct from locks.action_ttl_seconds (a cache-lock TTL, a different layer
+        // entirely) — see the reclaim documentation for how the two relate.
+        'reclaim' => [
+            'stale_running' => [
+                'enabled' => false,
+                'after_seconds' => 900,
+            ],
+        ],
     ],
 
     /*
@@ -201,6 +258,17 @@ return [
         // must be idempotent and safe when the step actually did nothing. Override
         // per action/group via compensateStepOnSelfFailure() (precedence action > group > config).
         'compensate_failed_step' => false,
+
+        // Same mechanism as actions.reclaim, independently switched: a compensation
+        // row still Running is claimable again only once it has sat that long since
+        // started_at. Off by default. Compensations have no automatic retry of their
+        // own — this only concerns a worker that died mid-compensation.
+        'reclaim' => [
+            'stale_running' => [
+                'enabled' => false,
+                'after_seconds' => 900,
+            ],
+        ],
     ],
 
     /*

--- a/database/migrations/2026_08_25_000000_add_reclaim_stale_running_columns.php
+++ b/database/migrations/2026_08_25_000000_add_reclaim_stale_running_columns.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'action_runs', function (Blueprint $table): void {
+            $table->unsignedInteger('reclaim_stale_after_seconds')->nullable()->after('started_at');
+
+            $table->timestamp('reclaim_stale_at')->nullable()->after('reclaim_stale_after_seconds');
+
+            $table->index('reclaim_stale_at');
+        });
+
+        $schema->table($this->prefix().'compensation_runs', function (Blueprint $table): void {
+            $table->unsignedInteger('reclaim_stale_after_seconds')->nullable()->after('started_at');
+            $table->timestamp('reclaim_stale_at')->nullable()->after('reclaim_stale_after_seconds');
+
+            $table->unsignedInteger('attempts')->default(0)->after('continue_on_failure');
+
+            $table->index('reclaim_stale_at');
+        });
+    }
+
+    public function down(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'action_runs', function (Blueprint $table): void {
+            $table->dropIndex(['reclaim_stale_at']);
+            $table->dropColumn(['reclaim_stale_after_seconds', 'reclaim_stale_at']);
+        });
+
+        $schema->table($this->prefix().'compensation_runs', function (Blueprint $table): void {
+            $table->dropIndex(['reclaim_stale_at']);
+            $table->dropColumn(['reclaim_stale_after_seconds', 'reclaim_stale_at', 'attempts']);
+        });
+    }
+
+    private function connection(): ?string
+    {
+        return config('saga-lara-flow.database.connection');
+    }
+
+    private function prefix(): string
+    {
+        return (string) config('saga-lara-flow.database.table_prefix', '');
+    }
+};

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -57,6 +57,7 @@ surrounding database transaction commits. Individual runs can override the conne
     'enabled' => true,
     'workflow_ttl_seconds' => 900,
     'action_ttl_seconds' => 900,
+    'compensation_ttl_seconds' => 900,
     'block_seconds' => 5,
     'prefix' => 'saga-lara-flow',
 ],
@@ -70,6 +71,28 @@ run — the idempotency guard. See [Queues, locks & idempotency](./queues-locks-
 `monitor.expiration.defaults` set implicit deadlines (seconds) for `run` / `action` / `signal` —
 `null` means no default. `repair.*` configures the doctor pass that recovers runs whose progress was
 lost to a dropped job. Both are covered in [Expiration & monitoring](./expiration-and-monitoring.md).
+
+## Reclaim
+
+`actions.reclaim.stale_running` and `sagas.reclaim.stale_running` — off by default — let a `Running`
+row be claimed again once it has sat long enough since `started_at` to suspect its worker died. Not
+the same thing as a lock TTL. With it off, a worker killed mid-step leaves that step stuck.
+[Reclaim & recovery](./reclaim-and-recovery.md) covers the mechanism, how it differs from the other
+timing dials, and the full config and per-step override surface.
+
+## Logging
+
+```php
+'logging' => [
+    'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'), // null = off
+    'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),                     // null = app default
+],
+```
+
+The engine's second journal, for the things it absorbs silently: a claim lost to whoever already
+owned the row, an outcome write rejected because the row changed hands, and a batch already closed
+by a duplicate delivery. None of them fails a job, so these lines are the only trace. See
+[Reclaim & recovery](./reclaim-and-recovery.md).
 
 ## Policies
 

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -8,8 +8,7 @@ sidebar_position: 14
 
 Runs, actions, and signal waits can carry deadlines — set explicitly (`->expiresAt(...)`,
 `->timeoutAfter(...)`, `#[FlowTimeout]`) or via the configured defaults in
-`monitor.expiration.defaults`. Something has to *notice* an expired deadline; there are two ways to
-drive the sweep.
+`monitor.expiration.defaults`. Something has to *notice* an expired deadline; there are two ways to drive the sweep.
 
 ## Default deadlines
 
@@ -21,14 +20,14 @@ drive the sweep.
 ],
 ```
 
-All three values are **in seconds** (here: 1 hour for a run, 10 minutes for an action, 24 hours for a
-signal wait). They are applied at write time when no explicit deadline is set: `run` on create,
-`action` on schedule, `signal` on await. `null` = off (no implicit deadline). There is no per-entity
-opt-out flag; to bypass a default for one entity, pass an explicit (far-future) deadline.
+All three values are **in seconds** (here: 1 hour for a run, 10 minutes for an action, 24 hours for a signal wait). They
+are applied at write time when no explicit deadline is set: `run` on create,
+`action` on schedule, `signal` on await. `null` = off (no implicit deadline). There is no per-entity opt-out flag; to
+bypass a default for one entity, pass an explicit (far-future) deadline.
 
-The `signal` default also bounds a [retry-on-signal](./retry-on-signal.md) wait when the call site
-passes no `waitSeconds:`. A step's own `action` deadline does not: an action deadline bounds
-*execution*, and a parked step is not executing.
+The `signal` default also bounds a [retry-on-signal](./retry-on-signal.md) wait when the call site passes no
+`waitSeconds:`. A step's own `action` deadline does not: an action deadline bounds *execution*, and a parked step is not
+executing.
 
 ## Driving the sweep
 
@@ -50,9 +49,9 @@ Drive the sweep off the queue worker's idle loop instead of cron:
 ],
 ```
 
-Useful when you have always-on workers but no scheduler. The sweep is throttled so it runs at most
-once per `throttle_seconds`. The listener is registered while the service provider boots, so the
-option has to be set in configuration — flipping it at runtime has no effect.
+Useful when you have always-on workers but no scheduler. The sweep is throttled so it runs at most once per
+`throttle_seconds`. The listener is registered while the service provider boots, so the option has to be set in
+configuration — flipping it at runtime has no effect.
 
 **If neither is driving the sweep, no deadline in the package is ever enforced.** A run passes its
 `expiresAt`, a step passes its own, a signal wait passes its `timeoutAfter` — and nothing happens.
@@ -60,26 +59,23 @@ option has to be set in configuration — flipping it at runtime has no effect.
 
 ## Deadlines are approximate
 
-The sweep is the only writer of "this deadline passed", which means a deadline is enforced no sooner
-than the next sweep. With `everyMinute()` that is a window of up to a minute; with queue looping it
-is up to `throttle_seconds`.
+The sweep is the only writer of "this deadline passed", which means a deadline is enforced no sooner than the next
+sweep. With `everyMinute()` that is a window of up to a minute; with queue looping it is up to `throttle_seconds`.
 
-The visible consequence: a signal delivered *after* its wait's deadline but *before* the next sweep
-is still accepted, and the workflow carries on as though the wait succeeded. Once the sweep has
-marked the wait `timed_out`, the same delivery arrives too late and the workflow sees
+The visible consequence: a signal delivered *after* its wait's deadline but *before* the next sweep is still accepted,
+and the workflow carries on as though the wait succeeded. Once the sweep has marked the wait `timed_out`, the same
+delivery arrives too late and the workflow sees
 `AwaitSignalTimeoutException` instead.
 
-This is deliberate. Keeping the sweep the single writer of a wait's status is what makes delivery,
-timeout and the retry seam safe to run concurrently. If your deadline is a hard business boundary
-rather than a safety net, enforce it in the workflow — the payload of a late signal can be checked
-against a deadline you captured with `sideEffect()`.
+This is deliberate. Keeping the sweep the single writer of a wait's status is what makes delivery, timeout and the retry
+seam safe to run concurrently. If your deadline is a hard business boundary rather than a safety net, enforce it in the
+workflow — the payload of a late signal can be checked against a deadline you captured with `sideEffect()`.
 
 ## Repair (the doctor)
 
-Separate from expiration: the **doctor** recovers a run whose progress was lost to a *dropped job* —
-an action that never ran, a resume that never fired — rather than one that hit a deadline. It only
-ever re-dispatches existing jobs or re-wakes flows (replay decides the rest); it never creates
-duplicate work.
+Separate from expiration: the **doctor** recovers a run whose progress was lost to a *dropped job* — an action that
+never ran, a resume that never fired — rather than one that hit a deadline. It only ever re-dispatches existing jobs or
+re-wakes flows (replay decides the rest); it never creates duplicate work.
 
 ```php
 'repair' => [
@@ -89,6 +85,7 @@ duplicate work.
     'max_attempts' => 10,
     'backoff' => ['base_seconds' => 10, 'max_seconds' => 300],
     'redispatch_lost_actions' => true,
+    'redispatch_stale_running_actions' => true,
     'wake_stuck_flows' => true,
     'queue_looping' => ['enabled' => false, 'throttle_seconds' => 60],
 ],
@@ -97,29 +94,33 @@ duplicate work.
 Every parameter:
 
 - **`enabled`** — master switch. Off by default; the doctor never runs until you opt in.
-- **`grace_seconds`** — minimum age, **in seconds**, before an entity is even *considered* stuck. This
-  guards against racing a job that is simply still in flight: the doctor ignores anything younger than
-  this, so a slow-but-alive action is left alone. Raise it if your jobs legitimately run long.
+- **`grace_seconds`** — minimum age, **in seconds**, before an entity is even *considered* stuck. This guards against
+  racing a job that is simply still in flight: the doctor ignores anything younger than this, so a slow-but-alive action
+  is left alone. Raise it if your jobs legitimately run long.
 - **`batch_size`** — how many candidate entities one repair pass inspects at most.
-- **`max_attempts`** — per-entity cap. After this many repair attempts the doctor gives up on that
-  entity and leaves it alone (re-drive it by hand with `saga-flow:kick`).
+- **`max_attempts`** — per-entity cap. After this many repair attempts the doctor gives up on that entity and leaves it
+  alone (re-drive it by hand with `saga-flow:kick`).
 - **`backoff`** — exponential backoff between repair attempts for a single entity, clamped between
   `base_seconds` and `max_seconds`. Prevents the doctor from hammering the same stuck entity.
 - **`redispatch_lost_actions`** — enable R1: re-dispatch a lost queue job for a stuck sequential
   `Pending` action (an action whose `RunActionJob` never arrived).
-- **`wake_stuck_flows`** — enable R2: re-wake a flow stuck in the `Waiting` status after a resume that
-  never fired.
-- **`queue_looping`** — drive the repair pass off the queue worker's idle loop instead of cron (same
-  idea as `monitor.queue_looping`). When `enabled`, the pass runs at most once per `throttle_seconds`.
+- **`wake_stuck_flows`** — enable R2: re-wake a flow stuck in the `Waiting` status after a resume that never fired.
+- **`redispatch_stale_running_actions`** — enable R3: re-dispatch a fresh job for a stuck sequential
+  `Running` action past its own **reclaim** deadline (a worker that died mid-execution, rather than a job that never
+  arrived). It acts on any row carrying such a deadline — set globally, or by a single step that opted itself in. With
+  reclaim configured nowhere, no row carries one and the rule is inert. Parallel actions and compensations are out of
+  scope for it. See
+  [Reclaim & recovery](./reclaim-and-recovery.md).
+- **`queue_looping`** — drive the repair pass off the queue worker's idle loop instead of cron (same idea as
+  `monitor.queue_looping`). When `enabled`, the pass runs at most once per `throttle_seconds`.
 
-The doctor only ever re-dispatches existing jobs or re-wakes flows — replay decides the rest, so it
-never creates duplicate work or mutates a business result.
+The doctor only ever re-dispatches existing jobs or re-wakes flows — replay decides the rest, so it never creates
+duplicate work or mutates a business result.
 
 :::tip Turn it on in production
-Any step whose job is committed and then dispatched can lose that job to a dying process — including
-a step restarted by [retry on signal](./retry-on-signal.md), which then sits `Pending` with nothing
-behind it. `redispatch_lost_actions` is exactly the recovery for that, and it does nothing until
-`repair.enabled` is `true`.
+Any step whose job is committed and then dispatched can lose that job to a dying process — including a step restarted
+by [retry on signal](./retry-on-signal.md), which then sits `Pending` with nothing behind it.
+`redispatch_lost_actions` is exactly the recovery for that, and it does nothing until `repair.enabled` is `true`.
 :::
 
 Schedule it, or loop it off the worker (`repair.queue_looping.enabled`):

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -46,22 +46,52 @@ Concurrent drives of the *same* run are serialized by Laravel's `WithoutOverlapp
     'enabled' => true,
     'workflow_ttl_seconds' => 900,
     'action_ttl_seconds' => 900,
+    'compensation_ttl_seconds' => 900,
     'block_seconds' => 5,
     'prefix' => 'saga-lara-flow',
 ],
 ```
 
-This guarantees that two workers can't advance one run at the same time. Each parameter:
+This guarantees that two workers can't advance one run at the same time. It covers workflow drives,
+action steps (sequential and parallel) and compensations, each keyed on its own row. Each parameter:
 
 - **`enabled`** — turn the `WithoutOverlapping` middleware on or off.
 - **`store`** — cache store backing the locks (`null` = the app default). Point it at a dedicated
   store to isolate the locks from your app cache.
-- **`workflow_ttl_seconds`** / **`action_ttl_seconds`** — **in seconds**. The maximum time a lock is
-  held before it auto-expires, so a worker that dies mid-drive can't wedge a run forever. Set them
-  comfortably above your longest workflow/action runtime.
+- **`workflow_ttl_seconds`** / **`action_ttl_seconds`** / **`compensation_ttl_seconds`** — **in
+  seconds**. The maximum time a lock is held before it auto-expires, so a worker that dies mid-drive
+  can't wedge a run forever. Set them comfortably above your longest workflow/action/compensation
+  runtime.
 - **`block_seconds`** — **in seconds**. How long a competing job waits to acquire the lock before
   giving up and letting the queue retry it later.
 - **`prefix`** — string prefix for every lock key (namespacing when the store is shared).
+
+## When a step is quietly skipped
+
+Three things can happen to a worker without failing its job: it loses the claim to whoever already
+owns the row, it finishes but has been superseded meanwhile so its outcome is rejected, or it
+finishes a parallel step whose batch a duplicate had already closed. All three are ordinary
+consequences of at-least-once delivery, and none of them leaves a trace in the run's history — so the
+package keeps a second journal for them:
+
+```php
+'logging' => [
+    'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'), // null = off
+    'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),                     // null = app default
+],
+```
+
+Grep for `claim_lost`, `outcome_rejected` and `batch_finished_early`; each line carries the run id,
+row id, sequence and class. They are not written to `flow_events`, which records the run's business
+history — an abandoned attempt changed nothing in it. See
+[Reclaim & recovery](./reclaim-and-recovery.md) for what each one means and what to do about it.
+
+:::tip A lock TTL is not the same as reclaim
+`action_ttl_seconds` does not answer "when can a stuck `Running` step be retried". It governs a
+**cache key**, not the database row, and stops applying at all when `enabled` is `false`. The
+mechanism for the row itself is `reclaim` — see [Reclaim & recovery](./reclaim-and-recovery.md),
+which compares it against every other "how long before we act" dial in the package.
+:::
 
 ## Determinism is the contract
 

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -1,0 +1,242 @@
+---
+id: reclaim-and-recovery
+title: Reclaim & recovery
+sidebar_position: 15.5
+---
+
+# Reclaim & recovery
+
+**Reclaim** answers one question no other setting in the package does: may a step still marked `Running` be executed
+again? This page covers it in full, and starts by placing it against the three other "how long before we act" dials it
+is easily confused with.
+
+## The four dials, side by side
+
+|                            | Business deadline (`expires_at`)                                             | Lock TTL (`locks.*_ttl_seconds`)                | Repair grace (`repair.grace_seconds`)                               | Reclaim (`reclaim.stale_running`)                                                                                                                              |
+|----------------------------|------------------------------------------------------------------------------|-------------------------------------------------|---------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Answers                    | "Has this taken too long, business-wise?"                                    | "Can the cache lock be considered abandoned?"   | "Has a *Pending* step sat long enough to suspect its job was lost?" | "Has a *Running* row sat long enough to suspect its worker died?"                                                                                              |
+| Lives on                   | `action_runs.expires_at` / `flow_runs.expires_at`                            | A cache key, not a database row                 | Used only inside the doctor, against `created_at`                   | `reclaim_stale_after_seconds` (the configured window) and `reclaim_stale_at` (the deadline the claim derives from it), on `action_runs` / `compensation_runs`   |
+| Default                    | Off (`null`)                                                                 | 900 seconds                                     | 60 seconds                                                          | Off                                                                                                                                                            |
+| Enforced by                | The opt-in monitor sweep (`saga-flow:monitor`)                               | Laravel's `WithoutOverlapping` queue middleware | The opt-in doctor (`repair.enabled`)                                | The claim itself (`ActionRecorder::startAction()` / `CompensationRecorder::startCompensation()`); the doctor can additionally act on it                        |
+| What happens once it fires | The step/run is marked `Expired` — a give-up, surfaced as a business failure | Laravel lets a competing job proceed            | The doctor re-dispatches a fresh job for the same row               | A `Running` row becomes claimable again by the next thing that claims it                                                                                       |
+| Independent of the others? | Yes                                                                          | Yes                                             | Yes                                                                 | Yes                                                                                                                                                            |
+
+## Not the same as a lock TTL
+
+`locks.action_ttl_seconds` is the closest of the three in spirit — "the maximum time a lock is held before it
+auto-expires, so a worker that dies mid-drive can't wedge a run forever" — but it operates at a different layer:
+
+- The lock TTL belongs to a **cache key** (`WithoutOverlapping`), created and read by Laravel's queue middleware. It
+  says nothing about the database row, and it stops existing entirely when `locks.enabled` is `false`.
+- Reclaim's threshold belongs to the **row**, is read by the atomic claim in `ActionRecorder` /
+  `CompensationRecorder`, and applies whether or not locks are enabled.
+
+Turning locks off therefore has no effect on whether stale `Running` rows can be recovered, and vice versa.
+
+## What happens with reclaim off
+
+Reclaim is off by default, and the default has a consequence worth knowing before you leave it there.
+
+The claim accepts a row that is `Pending` — and, for an action, `Failed`, which is what the row shows between two of
+the action's own native `$tries`. A row already `Running` is accepted only once its reclaim deadline has passed, and
+with reclaim off there is no deadline, so it is never accepted. A worker killed mid-execution (an evicted pod, the OOM
+killer, a `SIGKILL` deploy) leaves its row `Running` for good: replay reads a `Running` step as still in flight and
+parks the run, `saga-flow:kick` does the same, and the run waits indefinitely.
+
+What that buys is that the engine never re-executes a step on its own initiative:
+
+| Race                                                            | Who creates the duplicate | Prevented?             |
+|-----------------------------------------------------------------|---------------------------|------------------------|
+| A job left over from a superseded retry cycle                   | the engine                | Yes                    |
+| A job racing a row the monitor just expired                     | the engine                | Yes                    |
+| A job the doctor dispatched on top of a live one                | the engine                | Yes                    |
+| The queue redelivering a job while the first attempt still runs | the queue driver          | No — and no engine can |
+
+The last row is the at-least-once behaviour of SQS visibility timeouts, `retry_after` on Redis/database, and every
+managed queue: a redelivery means the driver decided to retry, never that the first worker is dead. Nothing outside the
+driver can tell those apart, which is why [Queues, locks & idempotency](./queues-locks-idempotency.md) requires action
+code to tolerate running twice.
+
+### Two ways to recover a killed worker's step
+
+Both are opt-in, and they do different things.
+
+- **Reclaim** (this page) — the row becomes claimable again once its deadline passes, and the step **runs again**. This
+  recovers the work.
+- **The monitor** — set `monitor.expiration.defaults.action` (or an explicit `->expiresAt()`) and schedule
+  `saga-flow:monitor`. The stuck step is marked `Expired` and the run **fails as a business error** rather than hanging.
+  This recovers the run, not the work. See [Expiration & monitoring](./expiration-and-monitoring.md).
+
+With both off, the run waits for a human.
+
+## Turning it on
+
+Actions and compensations are switched independently:
+
+```php
+'actions' => [
+    'reclaim' => [
+        'stale_running' => [
+            'enabled' => false,      // off by default — a Running row is never re-claimed
+            'after_seconds' => 900,  // used whenever enabled resolves true, globally or per step
+        ],
+    ],
+],
+
+'sagas' => [
+    'reclaim' => [
+        'stale_running' => [
+            'enabled' => false,
+            'after_seconds' => 900,
+        ],
+    ],
+],
+```
+
+Per-step overrides on `ActionBuilder` (and mirrored on `SagaStepBuilder` for a step inside a `saga()` group):
+
+```php
+$this->action(ChargeCard::class, $orderId)
+    ->reclaimStaleAfter(1200)          // set the threshold for THIS step (and enable it)
+    ->run();
+
+$this->action(SendWelcomeEmail::class, $userId)
+    ->enableStaleReclaim(false)        // force it off for this step, even if config enables it globally
+    ->run();
+
+$this->action(ChargeCard::class, $orderId)
+    ->enableStaleReclaim(true)         // force it on for this step (using config's after_seconds),
+    ->run();                           // even if config disables it globally
+```
+
+The compensation registered on a step gets the identical pair of methods, scoped separately:
+
+```php
+$this->action(ChargeCard::class, $orderId)
+    ->compensateWith(RefundCard::class, $orderId)
+    ->reclaimCompensationStaleAfter(600)
+    ->enableCompensationStaleReclaim(true)
+    ->run();
+```
+
+Precedence, resolved once at schedule time and persisted onto the row (the same shape as `expires_at`'s configured
+defaults):
+
+1. An explicit threshold (`reclaimStaleAfter()` / `reclaimCompensationStaleAfter()`) wins outright, and implies
+   "enabled".
+2. Otherwise, an explicit `enableStaleReclaim(true)` / `enableCompensationStaleReclaim(true)` uses config's
+   `after_seconds`, **regardless of config's own `enabled` value**.
+3. Otherwise, `enableStaleReclaim(false)` forces the row's threshold to `null` (off), regardless of config.
+4. With no override at all, the row inherits config.
+
+## What changes once it's on
+
+A `Running` row becomes claimable again once its deadline passes — but only when something actually *claims* it, which
+means one of two things: a redelivered queue job for that row, or the doctor (next section). Reclaim is otherwise
+passive; it does not go looking for stale rows.
+
+`saga-flow:kick` is not one of those two. It re-wakes the run, and the replay it triggers reads a `Running` step as
+still in flight and parks the run again without reaching the claim. Kick recovers a run whose *resume* was lost, not a
+row whose *worker* was.
+
+## The doctor's active side (R3)
+
+The opt-in doctor (`repair.enabled`) carries a third rule alongside R1 and R2:
+
+```php
+'repair' => [
+    // ...
+    'redispatch_stale_running_actions' => true,  // R3
+],
+```
+
+R3 finds ordinary (non-parallel) `Running` actions past their reclaim deadline and re-dispatches a fresh job for them —
+the same shape as R1 (lost `Pending` actions) for a different cause: a worker that died mid-execution rather than a job
+that never arrived. It needs `repair.enabled`, and it acts on any row carrying a reclaim deadline.
+
+That includes a row enabled **per step** while the global switch is off: a step calling `reclaimStaleAfter()` opts
+itself in, and participates in reclaim fully — there is no passive-only setting. With reclaim configured nowhere, no row
+carries a deadline and R3 has nothing to act on.
+
+**Parallel actions and compensations are out of scope for R3.** Recovering one would mean adding a job back into its
+`Bus::batch`, which needs that batch's id; the package does not store it, and the only way to recover it is to look its
+deterministic name up in Laravel's `job_batches` table — a detail of the *database* batch driver, not something every
+host has. For those two, reclaim stays passive even with the doctor enabled: a redelivery of the row's own job is what
+reclaims them.
+
+## Two live workers, one row
+
+Reclaim exists to let a second worker take over a row whose first worker looks dead, and it cannot verify that it *is*
+dead. Enabling reclaim therefore means two workers may occasionally execute the same step at once — the same property
+at-least-once delivery already has.
+
+Only one of them can record an outcome. Each claim increments the row's `attempts`, and every outcome write is
+conditional on two things: the `attempts` value its own claim produced, and the row still being `Running`. A superseded
+worker's write updates no rows, fires no event, and does not fail its job — it is logged and dropped.
+
+The two conditions guard two different rivals:
+
+- **`attempts`** fences against another executor — the straggler above.
+- **The status** fences against a settlement that never claimed the row at all. The monitor expiring an overdue step
+  does not touch `attempts`, so without it a late worker would overwrite that `Expired` with a `Completed` and leave the
+  run carrying both. The expiry write is conditional in the same way, so a step that completes just before the sweep
+  reaches it is not demoted to `Expired`.
+
+Together they give one guarantee: **a recorded terminal state is never overwritten**. A straggler that eventually throws
+cannot flip a step the live worker already completed to `Failed` and send the saga rolling back over work that
+succeeded — refunding a payment that went through. Nor can a straggler's stale result replace the current one, nor a
+sweep undo a result that beat it by a moment.
+
+Compensations carry the same `attempts` counter and the same fence.
+
+## When a duplicate closes a batch early
+
+Parallel blocks and rollback levels run as a `Bus::batch`, which Laravel closes once every job in it has reported. A
+duplicate delivery breaks that arithmetic: it loses its claim, returns quietly and successfully, and the count reaches
+zero while the live worker is still executing. The batch's callback fires early, and Laravel does not fire it a second
+time — the condition is `(pendingJobs - failedJobs) === 0`, and the next report takes the count to `-1`.
+
+The `WithoutOverlapping` lock prevents this: a duplicate arriving while the first worker holds the lock is released back
+to the queue instead of completing. It is reachable only with `locks.enabled` set to `false`, or after a lock's TTL has
+passed.
+
+The consequence differs by half of the engine:
+
+- **Parallel actions** — the worker that does finish sees the batch already closed, logs `batch_finished_early`, and
+  sends the wake itself. Otherwise the run would park on a step that is `Running` at replay time with no wake left.
+- **Rollback levels** — the level is treated as stopped, as it would be for a compensation whose worker died; from the
+  outside the two are indistinguishable. `CompensationUnfinishedException` reports that the compensation *had not
+  finished when its level ended*, which is what was observed.
+
+## Finding these races in your logs
+
+A lost claim, a rejected outcome and an early-closed batch are all normal and all silent. The package keeps a second
+journal for them — `AnomalyLog`, alongside the `flow_events` business history:
+
+```php
+'logging' => [
+    'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'), // null = off
+    'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),                     // null = app default
+],
+```
+
+Three reason codes to grep for, each carrying the run id, row id, sequence and class:
+
+- **`claim_lost`** — a worker found the row already owned and did not execute the step.
+- **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped.
+- **`batch_finished_early`** — a parallel step completed after a duplicate delivery had closed its batch.
+
+Raise the level to `warning` to surface them in your alerting. A steady stream of any of the three points to a queue
+timeout tuned shorter than the work takes, or to locks being off.
+
+## Observability
+
+Each claim fires a package event and appends a `flow_events` entry:
+
+- `ActionStarted` / `action.started`.
+- `CompensationStepStarted` / `compensation.step_started` — one per compensation row. Distinct from
+  `CompensationStarted` (`compensation.started`), which marks the whole rollback beginning, once per run.
+
+Both claims are written as a single conditional `UPDATE`, the same compare-and-swap shape used for signal delivery, so
+neither raises Eloquent model events on `models.action_run` / `models.compensation_run`. The events above are the
+supported way to observe them. See [Queues, locks & idempotency](./queues-locks-idempotency.md).

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -61,11 +61,27 @@ $this->saga()
 
 `CompensationFailurePolicy`:
 
-- `Stop` (default) — halt the rollback on the first failed compensation.
-- `Continue` — keep rolling back even if one undo fails.
+- `Stop` (default) — halt the rollback on the first compensation that does not complete.
+- `Continue` — keep rolling back even if one undo does not complete.
 
 Precedence is **action > group > config** (`sagas.default_compensation_failure_policy`). If a
 compensation itself fails under `Stop`, a `CompensationFailedException` surfaces.
+
+"Does not complete" covers more than a throw. A compensation whose worker was killed, or whose job
+never arrived, is left `Pending` or `Running` when its level finishes, and `Stop` halts the rollback
+for that too: unwinding further on top of a step that may still stand is what the policy exists to
+prevent. The run records it under `flow_run.exception['compensation']` as a
+`CompensationUnfinishedException` rather than a `CompensationFailedException` — there is no cause to
+report, since it never got far enough to have one. A rollback therefore never finalizes looking
+clean while one step was silently left undone.
+
+The exception states what was observed: the compensation *had not finished when its rollback level
+ended*. Usually it never does. It can also mean an at-least-once queue closed the batch a moment
+before the live worker recorded its success — see
+[Reclaim & recovery](./reclaim-and-recovery.md) for that race and how to spot it in your logs.
+
+To have such a compensation retried rather than only reported, enable `sagas.reclaim.stale_running`
+— see [Reclaim & recovery](./reclaim-and-recovery.md).
 
 ## Manual compensation
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -30,6 +30,7 @@ const sidebars: SidebarsConfig = {
         'tags-and-querying',
         'expiration-and-monitoring',
         'queues-locks-idempotency',
+        'reclaim-and-recovery',
         'synchronous-execution',
         'artisan-commands',
       ],

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -7,16 +7,20 @@ use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
 use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationFailurePolicy;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
@@ -81,6 +85,14 @@ class ActionBuilder
      */
     private ?array $retryOnly = null;
 
+    private ?int $reclaimStaleAfterSeconds = null;
+
+    private ?bool $reclaimStaleEnabled = null;
+
+    private ?int $compensationReclaimStaleAfterSeconds = null;
+
+    private ?bool $compensationReclaimStaleEnabled = null;
+
     /**
      * @param  array<int, mixed>  $arguments
      */
@@ -107,6 +119,36 @@ class ActionBuilder
     public function onCompensationFailure(CompensationFailurePolicy $policy): static
     {
         $this->actionCompensationFailurePolicy = $policy;
+
+        return $this;
+    }
+
+    /**
+     * Same idea as reclaimStaleAfter(), but for this step's registered compensation
+     * (sagas.reclaim.stale_running): allow a compensation row still Running to be
+     * reclaimed once it has sat this many seconds since started_at.
+     */
+    public function reclaimCompensationStaleAfter(int $seconds): static
+    {
+        if ($seconds < 0) {
+            throw new InvalidArgumentException(
+                "reclaimCompensationStaleAfter() seconds must be zero or greater, got {$seconds}.",
+            );
+        }
+
+        $this->compensationReclaimStaleAfterSeconds = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Force this step's compensation stale-Running reclaim on or off, independently
+     * of sagas.reclaim.stale_running.enabled. See enableStaleReclaim() for the same
+     * idea applied to the step's own execution.
+     */
+    public function enableCompensationStaleReclaim(bool $enabled = true): static
+    {
+        $this->compensationReclaimStaleEnabled = $enabled;
 
         return $this;
     }
@@ -141,6 +183,40 @@ class ActionBuilder
     public function expiresAt(?DateTimeInterface $expiresAt): static
     {
         $this->expiresAt = $expiresAt;
+
+        return $this;
+    }
+
+    /**
+     * Allow this step's own claim to reclaim a row still Running once it has sat
+     * this many seconds since started_at — recognizing a worker that died
+     * mid-execution. Also enables the mechanism for this step regardless of
+     * actions.reclaim.stale_running.enabled. See enableStaleReclaim() to toggle the
+     * mechanism without changing (or without knowing) the threshold.
+     */
+    public function reclaimStaleAfter(int $seconds): static
+    {
+        if ($seconds < 0) {
+            throw new InvalidArgumentException(
+                "reclaimStaleAfter() seconds must be zero or greater, got {$seconds}.",
+            );
+        }
+
+        $this->reclaimStaleAfterSeconds = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Force this step's stale-Running reclaim on or off, independently of
+     * actions.reclaim.stale_running.enabled — in either direction: turn it on for one
+     * step while it stays off globally, or off for one step while it is on globally.
+     * With $enabled = true and no threshold set via reclaimStaleAfter(), the step
+     * uses config's after_seconds.
+     */
+    public function enableStaleReclaim(bool $enabled = true): static
+    {
+        $this->reclaimStaleEnabled = $enabled;
 
         return $this;
     }
@@ -236,73 +312,106 @@ class ActionBuilder
         }
 
         $dispatcher = app(ActionDispatcher::class);
-
-        $hasCompensation = $this->compensation !== null;
-        $continueOnFailure = $this->resolvedContinueOnFailure();
-        $expiresAt = $this->resolvedExpiresAt();
-        $actionName = $this->resolvedActionName();
-        // Only a step that carries the policy gets a ceiling written. Storing the
-        // global default on every action would leave an unrelated number in the
-        // column, and awaitRetry()'s ??= would then keep it instead of the ceiling
-        // the seam actually parked on when a later deploy adds retryOnSignal().
-        $retrySignalMaxAttempts = $this->retrySignal === null ? null : $this->resolvedMaxRetries();
+        $schedule = $this->schedule();
 
         if ($this->runtime->mode() === RunMode::Sync) {
-            try {
-                $dispatcher->runInline(
-                    $flowRun,
-                    $sequence,
-                    $this->actionClass,
-                    $this->arguments,
-                    $hasCompensation,
-                    $continueOnFailure,
-                    expiresAt: $expiresAt,
-                    actionName: $actionName,
-                    retrySignal: $this->retrySignal,
-                    retrySignalMaxAttempts: $retrySignalMaxAttempts,
-                );
-            } catch (Throwable $exception) {
-                // A step with a retry policy is resolved solely on replay: only the
-                // seam knows the only-filter and the budget. Replay so it sees the
-                // Failed row and decides whether to park or to give up — but only
-                // when the row really did fail. A throw from before that (a listener,
-                // an observer, an action class that will not resolve) leaves nothing
-                // for the seam to read, and replaying would suspend a sync run on a
-                // job that does not exist.
-                if ($this->retrySignal !== null && $this->recordedFailure($flowRun->id, $sequence)) {
-                    $suspender->suspendInline('action', $sequence);
-                }
+            $this->runInlineThenSuspend($dispatcher, $schedule, $flowRun, $sequence);
+        }
 
-                // Optional step: no retries inline, so give up now — mark it
-                // OptionalFailed and replay so the seam resolves the fallback.
-                if ($continueOnFailure) {
-                    $this->markOptionalFailed($flowRun->id, $sequence);
+        $dispatcher->dispatch($flowRun, $sequence, $schedule);
 
-                    $suspender->suspendInline('action', $sequence);
-                }
+        $suspender->suspend('action', $sequence);
+    }
 
-                $this->registerFailedStepCompensation($flowRun->id, $sequence);
+    /**
+     * Everything this builder has resolved about the step, in the shape the dispatcher
+     * and the recorder consume. Both transports schedule from the same description.
+     */
+    private function schedule(): ActionSchedule
+    {
+        return new ActionSchedule(
+            actionClass: $this->actionClass,
+            arguments: $this->arguments,
+            hasCompensation: $this->compensation !== null,
+            continueOnFailure: $this->resolvedContinueOnFailure(),
+            expiresAt: $this->resolvedExpiresAt(),
+            actionName: $this->resolvedActionName(),
+            retrySignal: $this->retrySignal,
+            // Only a step that carries the policy gets a ceiling written. Storing the
+            // global default on every action would leave an unrelated number in the
+            // column, and awaitRetry()'s ??= would then keep it instead of the ceiling
+            // the seam actually parked on when a later deploy adds retryOnSignal().
+            retrySignalMaxAttempts: $this->retrySignal === null ? null : $this->resolvedMaxRetries(),
+            reclaimStaleAfterSeconds: $this->reclaimStaleAfterSeconds,
+            reclaimStaleEnabled: $this->reclaimStaleEnabled,
+        );
+    }
 
-                throw $exception;
-            }
+    /**
+     * Sync mode: run the step in this process, then replay. Never returns — every path
+     * out either suspends or rethrows.
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function runInlineThenSuspend(
+        ActionDispatcher $dispatcher,
+        ActionSchedule $schedule,
+        FlowRun $flowRun,
+        int $sequence,
+    ): never {
+        try {
+            // The result needs no branching: a step that ran and one that was
+            // superseded mid-run both resolve on the replay below, from whatever the
+            // row ended up holding.
+            $dispatcher->runInline($flowRun, $sequence, $schedule);
+        } catch (ActionClaimFailedException $exception) {
+            // A broken invariant, not a retryable business failure — nothing was
+            // recorded on the row for the checks below to make sense of.
+            throw $exception;
+        } catch (Throwable $exception) {
+            $this->settleInlineFailure($exception, $schedule, $flowRun, $sequence);
+        }
+
+        app(FlowSuspender::class)->suspendInline('action', $sequence);
+    }
+
+    /**
+     * Decide what an inline throw means, in the order the outcomes exclude each other.
+     * Never returns: it either suspends so replay resolves the step, or rethrows.
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function settleInlineFailure(
+        Throwable $exception,
+        ActionSchedule $schedule,
+        FlowRun $flowRun,
+        int $sequence,
+    ): never {
+        $suspender = app(FlowSuspender::class);
+
+        // A step with a retry policy is resolved solely on replay: only the seam knows
+        // the only-filter and the budget. Replay so it sees the Failed row and decides
+        // whether to park or to give up — but only when the row really did fail. A
+        // throw from before that (a listener, an observer, an action class that will
+        // not resolve) leaves nothing for the seam to read, and replaying would suspend
+        // a sync run on a job that does not exist.
+        if ($this->retrySignal !== null && $this->recordedFailure($flowRun->id, $sequence)) {
+            $suspender->suspendInline('action', $sequence);
+        }
+
+        // Optional step: no retries inline, so give up now — mark it OptionalFailed and
+        // replay so the seam resolves the fallback.
+        if ($schedule->continueOnFailure) {
+            $this->markOptionalFailed($flowRun->id, $sequence);
 
             $suspender->suspendInline('action', $sequence);
         }
 
-        $dispatcher->dispatch(
-            $flowRun,
-            $sequence,
-            $this->actionClass,
-            $this->arguments,
-            $hasCompensation,
-            $continueOnFailure,
-            $expiresAt,
-            $actionName,
-            $this->retrySignal,
-            $retrySignalMaxAttempts,
-        );
+        $this->registerFailedStepCompensation($flowRun->id, $sequence);
 
-        $suspender->suspend('action', $sequence);
+        throw $exception;
     }
 
     /**
@@ -638,7 +747,16 @@ class ActionBuilder
 
         if ($this->runtime->mode() === RunMode::Sync) {
             try {
-                $dispatcher->execute($step);
+                // retryAction() rewound this exact row to Pending in the same call
+                // chain, so nothing else can have taken it before we did: losing the
+                // claim here is a broken invariant. Being superseded afterwards is not
+                // — the monitor and the doctor act on this row from their own
+                // processes — and the replay below resolves whatever they left.
+                if ($dispatcher->execute($step) === StepExecution::ClaimLost) {
+                    throw ActionClaimFailedException::forAction($step->action_class, $sequence);
+                }
+            } catch (ActionClaimFailedException $exception) {
+                throw $exception;
             } catch (Throwable) {
                 // The failure is already persisted on the row; the replay below is
                 // what decides whether to park again or to give up.
@@ -869,6 +987,8 @@ class ActionBuilder
             $this->actionCompensationFailurePolicy,
             $this->groupCompensationFailurePolicy,
             $this->parallelGroupId,
+            $this->compensationReclaimStaleAfterSeconds,
+            $this->compensationReclaimStaleEnabled,
         ));
     }
 

--- a/src/Builders/SagaStepBuilder.php
+++ b/src/Builders/SagaStepBuilder.php
@@ -39,6 +39,14 @@ final class SagaStepBuilder
      */
     private ?array $retryOnly = null;
 
+    private ?int $reclaimStaleAfterSeconds = null;
+
+    private ?bool $reclaimStaleEnabled = null;
+
+    private ?int $compensationReclaimStaleAfterSeconds = null;
+
+    private ?bool $compensationReclaimStaleEnabled = null;
+
     /**
      * @param  array<int, mixed>  $arguments
      */
@@ -92,6 +100,46 @@ final class SagaStepBuilder
         return $this;
     }
 
+    /**
+     * Mirrors ActionBuilder::reclaimStaleAfter() for a step inside a group.
+     */
+    public function reclaimStaleAfter(int $seconds): self
+    {
+        $this->reclaimStaleAfterSeconds = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Mirrors ActionBuilder::enableStaleReclaim() for a step inside a group.
+     */
+    public function enableStaleReclaim(bool $enabled = true): self
+    {
+        $this->reclaimStaleEnabled = $enabled;
+
+        return $this;
+    }
+
+    /**
+     * Mirrors ActionBuilder::reclaimCompensationStaleAfter() for a step inside a group.
+     */
+    public function reclaimCompensationStaleAfter(int $seconds): self
+    {
+        $this->compensationReclaimStaleAfterSeconds = $seconds;
+
+        return $this;
+    }
+
+    /**
+     * Mirrors ActionBuilder::enableCompensationStaleReclaim() for a step inside a group.
+     */
+    public function enableCompensationStaleReclaim(bool $enabled = true): self
+    {
+        $this->compensationReclaimStaleEnabled = $enabled;
+
+        return $this;
+    }
+
     public function step(string $actionClass, mixed ...$arguments): self
     {
         return $this->saga->step($actionClass, ...$arguments);
@@ -140,6 +188,22 @@ final class SagaStepBuilder
                 $this->retryWaitSeconds,
                 $this->retryOnly,
             );
+        }
+
+        if ($this->reclaimStaleAfterSeconds !== null) {
+            $action->reclaimStaleAfter($this->reclaimStaleAfterSeconds);
+        }
+
+        if ($this->reclaimStaleEnabled !== null) {
+            $action->enableStaleReclaim($this->reclaimStaleEnabled);
+        }
+
+        if ($this->compensationReclaimStaleAfterSeconds !== null) {
+            $action->reclaimCompensationStaleAfter($this->compensationReclaimStaleAfterSeconds);
+        }
+
+        if ($this->compensationReclaimStaleEnabled !== null) {
+            $action->enableCompensationStaleReclaim($this->compensationReclaimStaleEnabled);
         }
 
         return $action

--- a/src/Contracts/ActionRunRepository.php
+++ b/src/Contracts/ActionRunRepository.php
@@ -30,4 +30,15 @@ interface ActionRunRepository
      * @return iterable<int, ActionRun>
      */
     public function dueForRepair(int $limit, int $graceSeconds, int $maxAttempts): iterable;
+
+    /**
+     * Sequential Running action steps (parallel_group is null) past their own
+     * reclaim_stale_at, whose repair window is open and attempts are not exhausted,
+     * earliest deadline first, capped at $limit. Used by the doctor to re-dispatch a
+     * step whose worker died mid-execution. Only rows with a reclaim window resolved
+     * onto them carry that deadline, so with reclaim configured nowhere this is empty.
+     *
+     * @return iterable<int, ActionRun>
+     */
+    public function dueForStaleRunningRepair(int $limit, int $maxAttempts): iterable;
 }

--- a/src/Data/ActionSchedule.php
+++ b/src/Data/ActionSchedule.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Data;
+
+use DateTimeInterface;
+
+/**
+ * Everything decided about a step before it exists as a row: which action to run,
+ * with what arguments, and the options resolved for it (precedence already applied
+ * by the builder). It travels unchanged from ActionBuilder / ParallelRunner through
+ * ActionDispatcher to ActionRecorder::scheduleAction(), which writes it out.
+ *
+ * The step's identity — its run and its (flow_run_id, sequence) ordinal — stays out
+ * of it: those are the caller's context, not part of the description of the work.
+ */
+final readonly class ActionSchedule
+{
+    /**
+     * @param  array<int, mixed>  $arguments
+     */
+    public function __construct(
+        public string $actionClass,
+        public array $arguments,
+        public bool $hasCompensation = false,
+        public bool $continueOnFailure = false,
+        public ?int $parallelGroup = null,
+        public ?DateTimeInterface $expiresAt = null,
+        public ?string $actionName = null,
+        public ?string $retrySignal = null,
+        public ?int $retrySignalMaxAttempts = null,
+        public ?int $reclaimStaleAfterSeconds = null,
+        public ?bool $reclaimStaleEnabled = null,
+    ) {}
+}

--- a/src/Enums/FlowEventType.php
+++ b/src/Enums/FlowEventType.php
@@ -32,6 +32,7 @@ enum FlowEventType: string
     case SideEffectReused = 'side_effect.reused';
 
     case CompensationStarted = 'compensation.started';
+    case CompensationStepStarted = 'compensation.step_started';
     case CompensationCompleted = 'compensation.completed';
     case CompensationFailed = 'compensation.failed';
 

--- a/src/Enums/StepExecution.php
+++ b/src/Enums/StepExecution.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Enums;
+
+/**
+ * What an executor managed to do with the row it was handed.
+ *
+ * The two failing cases look the same from the queue — nothing was settled, so the
+ * job returns quietly either way — but they mean opposite things where no competitor
+ * is supposed to exist. Never claiming a freshly created row is a broken invariant;
+ * being superseded after the work ran is an ordinary race that replay resolves.
+ */
+enum StepExecution
+{
+    /** The row was claimed, the step ran, and its outcome was recorded. */
+    case Executed;
+
+    /** The row was already owned or no longer claimable; nothing ran. */
+    case ClaimLost;
+
+    /** The step ran, but the row changed hands before its outcome could be written. */
+    case Superseded;
+
+    /**
+     * Whether this executor settled the row. Callers that only need "is there an
+     * outcome to act on" — the queued jobs — read this and ignore the distinction.
+     */
+    public function settled(): bool
+    {
+        return $this === self::Executed;
+    }
+}

--- a/src/Events/CompensationStepStarted.php
+++ b/src/Events/CompensationStepStarted.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Events;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+
+/**
+ * Fired when one compensation row is claimed and begins running. Distinct from
+ * CompensationStarted, which marks the whole rollback beginning for a run (once per
+ * run, carrying the FlowRun) — this fires once per compensation row, carrying the
+ * CompensationRun itself.
+ */
+final readonly class CompensationStepStarted
+{
+    public function __construct(
+        public CompensationRun $compensationRun,
+    ) {}
+}

--- a/src/Exceptions/ActionClaimFailedException.php
+++ b/src/Exceptions/ActionClaimFailedException.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+/**
+ * Raised when a synchronous claim on an action or compensation row fails
+ * (ActionRecorder::startAction() / CompensationRecorder::startCompensation() return
+ * false). In sync mode there is no competing process between scheduling a step and
+ * running it in the same call — a failed claim there is not a race, it is a broken
+ * invariant. Queued jobs treat the same failure quietly instead: a lost claim there
+ * is the normal outcome of two workers legitimately racing for one row.
+ */
+class ActionClaimFailedException extends FlowException
+{
+    public static function forAction(string $actionClass, int $sequence): self
+    {
+        return new self(sprintf(
+            'Failed to claim action %s at sequence %d for synchronous execution. '
+            .'This should be unreachable in sync mode and indicates a broken invariant.',
+            $actionClass,
+            $sequence,
+        ));
+    }
+
+    public static function forCompensation(string $compensationClass, int $sequence): self
+    {
+        return new self(sprintf(
+            'Failed to claim compensation %s at sequence %d for synchronous execution. '
+            .'This should be unreachable in sync mode and indicates a broken invariant.',
+            $compensationClass,
+            $sequence,
+        ));
+    }
+}

--- a/src/Exceptions/CompensationUnfinishedException.php
+++ b/src/Exceptions/CompensationUnfinishedException.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+
+/**
+ * Surfaces a compensation that had not reached a terminal state when its rollback
+ * level finished, as the secondary cause attached to the run (recorded under
+ * flow_run.exception['compensation']).
+ *
+ * Distinct from CompensationFailedException: that one ran and threw, and its own
+ * exception is recorded alongside. This one has no cause to report — it never got far
+ * enough to have one. Without it the rollback would look complete while one step was
+ * silently never undone.
+ *
+ * The message states what was observed, not what will be. Usually the compensation is
+ * genuinely stranded — its worker died, or its job never arrived — but a duplicate
+ * delivery can also close a batch a moment before the live worker records its success,
+ * and then the compensation reported here does finish, just too late to be seen.
+ */
+class CompensationUnfinishedException extends FlowException
+{
+    public static function for(CompensationRun $compensationRun): self
+    {
+        $label = $compensationRun->compensation_class ?? 'closure';
+
+        return new self(sprintf(
+            'Compensation %s at rollback sequence %d had not finished when its rollback level ended (status: %s).',
+            $label,
+            $compensationRun->sequence,
+            $compensationRun->status->value,
+        ));
+    }
+}

--- a/src/Jobs/RunActionJob.php
+++ b/src/Jobs/RunActionJob.php
@@ -57,27 +57,12 @@ class RunActionJob implements ShouldQueue
             return;
         }
 
-        // Left over from an earlier retry cycle: the row has moved on, so running it
-        // now would execute the step a second time without a signal. The workflow is
-        // still resumed — this job may be the only wake left if the pass that rewound
-        // the row died before sending the live one.
-        if ($action->retry_signal_attempts !== ($this->retryGeneration ?? 0)) {
-            $this->resumeWorkflow($action);
-
-            return;
-        }
-
-        // Skip a step already settled out of band: Completed on an earlier attempt,
-        // Expired by the monitor (a late job must not resurrect an expired step), or
-        // parked on a retry signal (only the seam may restart it, and only once the
-        // signal lands).
-        if (! in_array(
-            $action->status,
-            [ActionStatus::Completed, ActionStatus::Expired, ActionStatus::AwaitingRetry],
-            true,
-        )) {
-            $dispatcher->execute($action);
-        }
+        // The claim inside execute() is the single source of truth for whether this job
+        // may run the step: it folds the row's status and this job's own retry cycle
+        // into one atomic write, so no pre-check is needed here. A lost claim is quiet,
+        // and the workflow is resumed either way — this job may be the only wake left
+        // if whatever rewound the row died before sending the live one.
+        $dispatcher->execute($action, $this->retryGeneration ?? 0);
 
         $this->resumeWorkflow($action);
     }

--- a/src/Jobs/RunCompensationJob.php
+++ b/src/Jobs/RunCompensationJob.php
@@ -4,7 +4,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Jobs;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
-use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Middleware\LockMiddlewareFactory;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Support\TenancyManager;
@@ -48,15 +48,24 @@ class RunCompensationJob implements ShouldQueue
             return;
         }
 
-        if (in_array($compensation->status, [CompensationStatus::Completed, CompensationStatus::Failed], true)) {
-            return;
-        }
+        // No status pre-check: the claim inside execute() is the single source of
+        // truth — a row already settled, or still Running within its reclaim window,
+        // fails the claim and nothing runs. A lost claim is quiet here because the
+        // batch's own ->finally(new AdvanceCompensation(...)) settles the level.
 
         $tenancy->for(
             $flowRun,
             $flowRun->workflow_class,
             fn () => $executor->execute($compensation, $this->definition),
         );
+    }
+
+    /**
+     * @return array<int, object>
+     */
+    public function middleware(): array
+    {
+        return app(LockMiddlewareFactory::class)->compensationMiddleware($this->compensationRunId);
     }
 
     private function resolveCompensation(): ?CompensationRun

--- a/src/Jobs/RunParallelActionJob.php
+++ b/src/Jobs/RunParallelActionJob.php
@@ -8,6 +8,7 @@ use DiscoveryUkraine\SagaLaraFlow\Middleware\LockMiddlewareFactory;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
 use Illuminate\Bus\Batchable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Queue\Queueable;
@@ -58,10 +59,59 @@ class RunParallelActionJob implements ShouldQueue
             return;
         }
 
-        // Skip a step already settled out of band (Completed earlier, or Expired by
-        // the monitor — a late job must not resurrect an expired step).
-        if (! in_array($action->status, [ActionStatus::Completed, ActionStatus::Expired], true)) {
-            $dispatcher->execute($action);
+        // The claim inside execute() (ActionRecorder::startAction()) is the single
+        // source of truth: a step already settled out of band (Completed earlier, or
+        // Expired by the monitor) simply fails the claim and nothing runs. Parallel
+        // steps carry no retry-on-signal cycle today (0 always), but passing it
+        // explicitly keeps the guard correct if that ever changes.
+        if ($dispatcher->execute($action, expectedRetryGeneration: 0)->settled()) {
+            $this->wakeIfTheBatchClosedWithoutUs($action);
+        }
+    }
+
+    /**
+     * A batch cannot normally be finished while one of its own jobs is still inside
+     * handle() — the pending count only drops once this returns. Finding it finished
+     * means a duplicate delivery lost its claim, returned quietly, and drove the count
+     * to zero early. ResumeParallelBlock already fired then, and Laravel will not fire
+     * it again: its condition is (pendingJobs - failedJobs) === 0, and the next
+     * decrement takes the count to -1.
+     *
+     * The join therefore replayed while this step was still Running and parked the run
+     * with no wake left. An extra resume costs a replay that resolves to the same
+     * history; a missing one costs a run that hangs until repair.wake_stuck_flows.
+     */
+    private function wakeIfTheBatchClosedWithoutUs(ActionRun $action): void
+    {
+        $batch = $this->batch();
+
+        if ($batch === null || ! $batch->finished()) {
+            return;
+        }
+
+        app(AnomalyLog::class)->log(AnomalyLog::REASON_BATCH_FINISHED_EARLY, [
+            'entity' => 'parallel_action',
+            'flow_run_id' => $action->flow_run_id,
+            'action_run_id' => $action->id,
+            'sequence' => $action->sequence,
+            'action_class' => $action->action_class,
+            'batch_id' => $batch->id,
+        ]);
+
+        $flowRun = $action->flowRun;
+
+        $job = ResumeWorkflowJob::dispatch($action->flow_run_id);
+
+        if ($flowRun->connection !== null) {
+            $job->onConnection($flowRun->connection);
+        }
+
+        if ($flowRun->queue !== null) {
+            $job->onQueue($flowRun->queue);
+        }
+
+        if (config('saga-lara-flow.queue.after_commit')) {
+            $job->afterCommit();
         }
     }
 

--- a/src/Middleware/LockMiddlewareFactory.php
+++ b/src/Middleware/LockMiddlewareFactory.php
@@ -13,6 +13,11 @@ use Illuminate\Queue\Middleware\WithoutOverlapping;
 class LockMiddlewareFactory
 {
     /**
+     * Used when a configured TTL is missing or non-positive — see build().
+     */
+    private const int FALLBACK_TTL_SECONDS = 900;
+
+    /**
      * @return array<int, object>
      */
     public function workflowMiddleware(string $flowRunId): array
@@ -29,6 +34,22 @@ class LockMiddlewareFactory
     }
 
     /**
+     * Package config is merged only at the top level, so an application that published
+     * this file before compensation_ttl_seconds existed keeps a 'locks' array without
+     * it. Such a host inherits action_ttl_seconds: a compensation is a step, so the
+     * value already tuned for how long a step may run applies to it.
+     *
+     * @return array<int, object>
+     */
+    public function compensationMiddleware(string $compensationRunId): array
+    {
+        $ttl = config('saga-lara-flow.locks.compensation_ttl_seconds')
+            ?? config('saga-lara-flow.locks.action_ttl_seconds');
+
+        return $this->build("compensation:{$compensationRunId}", (int) $ttl);
+    }
+
+    /**
      * @return array<int, object>
      */
     private function build(string $key, int $ttl): array
@@ -39,7 +60,13 @@ class LockMiddlewareFactory
 
         $prefix = config('saga-lara-flow.locks.prefix');
 
-        $middleware = (new WithoutOverlapping("{$prefix}:{$key}"))->expireAfter($ttl);
+        // Zero reaches Redis as SETNX with no expiry at all (RedisLock::acquire()), so
+        // a lock held by a worker that is killed before WithoutOverlapping's finally
+        // runs would never be released, wedging that row for good. A missing or
+        // nonsensical TTL must degrade to a long one, never to an eternal lock.
+        $ttl = $ttl > 0 ? $ttl : self::FALLBACK_TTL_SECONDS;
+
+        $middleware = new WithoutOverlapping("{$prefix}:{$key}")->expireAfter($ttl);
 
         $block = (int) config('saga-lara-flow.locks.block_seconds');
 

--- a/src/Models/ActionRun.php
+++ b/src/Models/ActionRun.php
@@ -28,6 +28,8 @@ use Illuminate\Support\Carbon;
  * @property int $attempts
  * @property bool $queue_attempts_exhausted
  * @property ?Carbon $started_at
+ * @property ?int $reclaim_stale_after_seconds
+ * @property ?Carbon $reclaim_stale_at
  * @property ?Carbon $finished_at
  * @property ?Carbon $expires_at
  * @property int $repair_attempts
@@ -59,6 +61,8 @@ class ActionRun extends Model
             'attempts' => 'integer',
             'queue_attempts_exhausted' => 'boolean',
             'started_at' => 'datetime',
+            'reclaim_stale_after_seconds' => 'integer',
+            'reclaim_stale_at' => 'datetime',
             'finished_at' => 'datetime',
             'expires_at' => 'datetime',
             'repair_attempts' => 'integer',

--- a/src/Models/CompensationRun.php
+++ b/src/Models/CompensationRun.php
@@ -18,10 +18,13 @@ use Illuminate\Support\Carbon;
  * @property ?string $compensation_class
  * @property CompensationStatus $status
  * @property bool $continue_on_failure
+ * @property int $attempts
  * @property ?array<int|string, mixed> $arguments
  * @property ?array<int|string, mixed> $result
  * @property ?array<int|string, mixed> $exception
  * @property ?Carbon $started_at
+ * @property ?int $reclaim_stale_after_seconds
+ * @property ?Carbon $reclaim_stale_at
  * @property ?Carbon $finished_at
  * @property-read FlowRun $flowRun
  */
@@ -40,10 +43,13 @@ class CompensationRun extends Model
             'sequence' => 'integer',
             'status' => CompensationStatus::class,
             'continue_on_failure' => 'boolean',
+            'attempts' => 'integer',
             'arguments' => 'array',
             'result' => 'array',
             'exception' => 'array',
             'started_at' => 'datetime',
+            'reclaim_stale_after_seconds' => 'integer',
+            'reclaim_stale_at' => 'datetime',
             'finished_at' => 'datetime',
         ];
     }

--- a/src/Repositories/EloquentActionRunRepository.php
+++ b/src/Repositories/EloquentActionRunRepository.php
@@ -48,6 +48,33 @@ class EloquentActionRunRepository implements ActionRunRepository
     }
 
     /**
+     * The claim resolves each row's reclaim window into an absolute reclaim_stale_at,
+     * so staleness is one indexed comparison — the same shape as dueForExpiration().
+     * Ordering by the filtered column is what makes the limit safe: a pass can only be
+     * filled with rows that are actually due, so a backlog of not-yet-stale rows can
+     * never crowd out stale ones.
+     */
+    public function dueForStaleRunningRepair(int $limit, int $maxAttempts): iterable
+    {
+        $now = Carbon::now();
+
+        return $this->model()::query()
+            ->where('status', ActionStatus::Running)
+            ->whereNull('parallel_group')
+            ->whereNotNull('reclaim_stale_at')
+            ->where('reclaim_stale_at', '<=', $now)
+            ->where('repair_attempts', '<', $maxAttempts)
+            ->where(function ($query) use ($now): void {
+                $query
+                    ->whereNull('repair_available_at')
+                    ->orWhere('repair_available_at', '<=', $now);
+            })
+            ->orderBy('reclaim_stale_at')
+            ->limit($limit)
+            ->get();
+    }
+
+    /**
      * @return class-string<ActionRun>
      */
     private function model(): string

--- a/src/Runtime/ActionDispatcher.php
+++ b/src/Runtime/ActionDispatcher.php
@@ -2,9 +2,11 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
-use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Concerns\ResolvesMethodDependencies;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\RunActionJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
@@ -29,37 +31,13 @@ class ActionDispatcher
 
     /**
      * Queued mode: persist the pending step and dispatch its job.
-     *
-     * @param  array<int, mixed>  $arguments
      */
-    public function dispatch(
-        FlowRun $flowRun,
-        int $sequence,
-        string $actionClass,
-        array $arguments,
-        bool $hasCompensation = false,
-        bool $continueOnFailure = false,
-        ?DateTimeInterface $expiresAt = null,
-        ?string $actionName = null,
-        ?string $retrySignal = null,
-        ?int $retrySignalMaxAttempts = null,
-    ): ActionRun {
-        $actionRun = $this->recorder->scheduleAction(
-            $flowRun,
-            $sequence,
-            $actionClass,
-            $arguments,
-            $hasCompensation,
-            $continueOnFailure,
-            null,
-            $expiresAt,
-            $actionName,
-            $retrySignal,
-            $retrySignalMaxAttempts,
-        );
+    public function dispatch(FlowRun $flowRun, int $sequence, ActionSchedule $schedule): ActionRun
+    {
+        $actionRun = $this->recorder->scheduleAction($flowRun, $sequence, $schedule);
 
         $this->route(
-            RunActionJob::dispatch($actionRun->id, $actionClass, $actionRun->retry_signal_attempts),
+            RunActionJob::dispatch($actionRun->id, $schedule->actionClass, $actionRun->retry_signal_attempts),
             $flowRun,
         );
 
@@ -105,58 +83,49 @@ class ActionDispatcher
     }
 
     /**
-     * Sync mode: persist the pending step and execute it inline.
-     *
-     * @param  array<int, mixed>  $arguments
+     * Sync mode: persist the pending step and execute it inline. Returns how far the
+     * step got, so the caller can tell a broken invariant from a lost race.
      *
      * @throws Throwable
      */
-    public function runInline(
-        FlowRun $run,
-        int $sequence,
-        string $actionClass,
-        array $arguments,
-        bool $hasCompensation = false,
-        bool $continueOnFailure = false,
-        ?int $parallelGroup = null,
-        ?DateTimeInterface $expiresAt = null,
-        ?string $actionName = null,
-        ?string $retrySignal = null,
-        ?int $retrySignalMaxAttempts = null,
-    ): ActionRun {
-        $actionRun = $this->recorder->scheduleAction(
-            $run,
-            $sequence,
-            $actionClass,
-            $arguments,
-            $hasCompensation,
-            $continueOnFailure,
-            $parallelGroup,
-            $expiresAt,
-            $actionName,
-            $retrySignal,
-            $retrySignalMaxAttempts,
-        );
+    public function runInline(FlowRun $run, int $sequence, ActionSchedule $schedule): StepExecution
+    {
+        $actionRun = $this->recorder->scheduleAction($run, $sequence, $schedule);
 
-        $this->execute($actionRun);
+        $execution = $this->execute($actionRun);
 
-        return $actionRun;
+        // A row created in this very call is not reachable by anyone else yet, so
+        // losing the claim is not a race but a broken invariant. Being superseded
+        // afterwards is a race, and a real one: the monitor and the doctor run in
+        // their own processes against the same rows a sync run creates.
+        if ($execution === StepExecution::ClaimLost) {
+            throw ActionClaimFailedException::forAction($schedule->actionClass, $sequence);
+        }
+
+        return $execution;
     }
 
     /**
-     * Run a persisted action step to completion. Shared by sync inline execution
-     * and the queued RunActionJob. A business failure marks the step Failed and
-     * is rethrown so the workflow can react on replay.
+     * Claim and run a persisted action step to completion. Shared by sync inline
+     * execution and the queued RunActionJob.
+     *
+     * The two non-Executed results are both "someone else is handling this row", never
+     * a failure of the step, but they are not interchangeable: ClaimLost means nothing
+     * ran, while Superseded means the work happened and only its outcome was dropped.
+     * A business failure marks the step Failed and is rethrown so the workflow can
+     * react on replay.
      *
      * @throws Throwable
      */
-    public function execute(ActionRun $actionRun): void
+    public function execute(ActionRun $actionRun, ?int $expectedRetryGeneration = null): StepExecution
     {
-        app(TenancyManager::class)->for(
+        return app(TenancyManager::class)->for(
             $actionRun->flowRun,
             $actionRun->action_class,
-            function () use ($actionRun): void {
-                $this->recorder->startAction($actionRun);
+            function () use ($actionRun, $expectedRetryGeneration): StepExecution {
+                if (! $this->recorder->startAction($actionRun, $expectedRetryGeneration)) {
+                    return StepExecution::ClaimLost;
+                }
 
                 $instance = app()->make($actionRun->action_class);
 
@@ -166,12 +135,20 @@ class ActionDispatcher
                 try {
                     $result = $this->callWithDependencies($instance, 'handle', $arguments);
                 } catch (Throwable $e) {
-                    $this->recorder->failAction($actionRun, $e);
+                    // A rejected outcome means this executor was superseded while it
+                    // ran, so its failure settles nothing. Rethrowing would fail a job
+                    // whose work is already discarded, and RunActionJob::failed() would
+                    // then write queue bookkeeping into a row it no longer owns.
+                    if (! $this->recorder->failAction($actionRun, $e)) {
+                        return StepExecution::Superseded;
+                    }
 
                     throw $e;
                 }
 
-                $this->recorder->completeAction($actionRun, $result);
+                return $this->recorder->completeAction($actionRun, $result)
+                    ? StepExecution::Executed
+                    : StepExecution::Superseded;
             },
         );
     }

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -5,6 +5,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Concerns\NormalizesExceptions;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionAwaitingRetry;
@@ -17,6 +18,7 @@ use DiscoveryUkraine\SagaLaraFlow\Events\OptionalActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Throwable;
 
 /**
@@ -30,28 +32,16 @@ final readonly class ActionRecorder
     public function __construct(
         private EventLog $events,
         private Serializer $serializer,
+        private AnomalyLog $anomalies,
     ) {}
 
     /**
      * Create the pending ActionRun for a scheduled step. The arguments are
      * serialized once here and become the durable source the executing job
      * (or inline run) reads back.
-     *
-     * @param  array<int, mixed>  $arguments
      */
-    public function scheduleAction(
-        FlowRun $flowRun,
-        int $sequence,
-        string $actionClass,
-        array $arguments,
-        bool $hasCompensation = false,
-        bool $continueOnFailure = false,
-        ?int $parallelGroup = null,
-        ?DateTimeInterface $expiresAt = null,
-        ?string $actionName = null,
-        ?string $retrySignal = null,
-        ?int $retrySignalMaxAttempts = null,
-    ): ActionRun {
+    public function scheduleAction(FlowRun $flowRun, int $sequence, ActionSchedule $schedule): ActionRun
+    {
         /** @var class-string<ActionRun> $model */
         $model = config('saga-lara-flow.models.action_run');
 
@@ -60,25 +50,29 @@ final readonly class ActionRecorder
         $actionRun->fill([
             'flow_run_id' => $flowRun->id,
             'sequence' => $sequence,
-            'action_class' => $actionClass,
-            'action_name' => $actionName,
+            'action_class' => $schedule->actionClass,
+            'action_name' => $schedule->actionName,
             'status' => ActionStatus::Pending,
-            'has_compensation' => $hasCompensation,
-            'continue_on_failure' => $continueOnFailure,
-            'parallel_group' => $parallelGroup,
-            'expires_at' => $expiresAt ?? $this->defaultExpiry(),
-            'arguments' => $this->serializer->serialize($arguments),
+            'has_compensation' => $schedule->hasCompensation,
+            'continue_on_failure' => $schedule->continueOnFailure,
+            'parallel_group' => $schedule->parallelGroup,
+            'expires_at' => $schedule->expiresAt ?? $this->defaultExpiry(),
+            'arguments' => $this->serializer->serialize($schedule->arguments),
             'attempts' => 0,
             'queue_attempts_exhausted' => false,
-            'retry_signal' => $retrySignal,
+            'retry_signal' => $schedule->retrySignal,
             'retry_signal_attempts' => 0,
-            'retry_signal_max_attempts' => $retrySignalMaxAttempts,
+            'retry_signal_max_attempts' => $schedule->retrySignalMaxAttempts,
+            'reclaim_stale_after_seconds' => $this->resolveReclaimStaleAfterSeconds(
+                $schedule->reclaimStaleAfterSeconds,
+                $schedule->reclaimStaleEnabled,
+            ),
         ]);
 
         $actionRun->save();
 
         $this->events->record($flowRun, FlowEventType::ActionScheduled, $sequence, $actionRun, [
-            'action_class' => $actionClass,
+            'action_class' => $schedule->actionClass,
         ]);
 
         return $actionRun;
@@ -101,6 +95,33 @@ final readonly class ActionRecorder
     }
 
     /**
+     * Resolve the per-row reclaim-stale threshold at schedule time, mirroring
+     * defaultExpiry()'s "decide once, persist the concrete value" shape. An explicit
+     * builder override wins over config in both directions: enabled === false forces
+     * the mechanism off for this row regardless of config; enabled === true forces it
+     * on using config's after_seconds when no explicit $seconds was also given. With
+     * neither override, the row simply inherits config as it stands.
+     */
+    private function resolveReclaimStaleAfterSeconds(?int $seconds, ?bool $enabled): ?int
+    {
+        if ($enabled === false) {
+            return null;
+        }
+
+        if ($seconds !== null) {
+            return $seconds;
+        }
+
+        if ($enabled === true) {
+            return (int) config('saga-lara-flow.actions.reclaim.stale_running.after_seconds');
+        }
+
+        return config('saga-lara-flow.actions.reclaim.stale_running.enabled')
+            ? (int) config('saga-lara-flow.actions.reclaim.stale_running.after_seconds')
+            : null;
+    }
+
+    /**
      * Record the doctor re-dispatching a stuck Pending action. The
      * action keeps its status/sequence — only a fresh RunActionJob is sent — so an
      * action.redispatched event is appended for visibility without altering history.
@@ -117,29 +138,110 @@ final readonly class ActionRecorder
         event(new ActionRedispatched($actionRun));
     }
 
-    public function startAction(ActionRun $actionRun): void
+    /**
+     * Atomically claim the row and move it to Running, returning false when the row
+     * is no longer claimable and the caller must not execute the step.
+     *
+     * The condition lives in the UPDATE itself — the same compare-and-swap shape as
+     * SignalRecorder::claimWaiting(), the only form every supported driver enforces
+     * atomically (lockForUpdate() compiles to nothing on SQLite). This transition
+     * therefore raises no Eloquent model events; ActionStarted and the action.started
+     * flow_events entry are the supported way to observe it.
+     *
+     * Claimable statuses are Pending, Failed, and Running past its reclaim deadline.
+     * Failed is not terminal here: it is what the row shows between two of the
+     * action's own native $tries, which Laravel redelivers as the very same job.
+     *
+     * `attempts` is incremented by the database, so two racing claims can never
+     * persist the same count, and the value a claim produces identifies it.
+     *
+     * $expectedRetryGeneration constrains retry_signal_attempts, folding a caller's
+     * stale-cycle check into this same atomic write so a cycle change landing after
+     * the row was read still loses the claim. Null imposes no constraint.
+     *
+     * The claim and its two records share one transaction: a listener throwing on
+     * ActionStarted would otherwise leave the row Running with nothing executing it.
+     *
+     * @throws Throwable
+     */
+    public function startAction(ActionRun $actionRun, ?int $expectedRetryGeneration = null): bool
     {
-        $actionRun->status = ActionStatus::Running;
-        $actionRun->attempts = $actionRun->attempts + 1;
-        $actionRun->started_at = Carbon::now();
-        $actionRun->save();
+        return $actionRun->getConnection()->transaction(
+            function () use ($actionRun, $expectedRetryGeneration): bool {
+                $now = Carbon::now();
 
-        $this->events->record(
-            $actionRun->flowRun,
-            FlowEventType::ActionStarted,
-            $actionRun->sequence,
-            $actionRun
+                // Fixed at schedule time and never rewritten, so reading it off the
+                // model is safe — unlike the deadline derived from it, which moves with
+                // every claim and is therefore compared in the database.
+                $staleAfter = $actionRun->reclaim_stale_after_seconds;
+
+                $claimed = $actionRun->newQuery()
+                    ->whereKey($actionRun->getKey())
+                    ->when(
+                        $expectedRetryGeneration !== null,
+                        fn ($query) => $query->where('retry_signal_attempts', $expectedRetryGeneration),
+                    )
+                    ->where(function ($query) use ($now): void {
+                        $query->whereIn('status', [ActionStatus::Pending, ActionStatus::Failed])
+                            ->orWhere(function ($query) use ($now): void {
+                                $query->where('status', ActionStatus::Running)
+                                    ->whereNotNull('reclaim_stale_at')
+                                    ->where('reclaim_stale_at', '<=', $now);
+                            });
+                    })
+                    ->update([
+                        'status' => ActionStatus::Running,
+                        'attempts' => DB::raw('attempts + 1'),
+                        'started_at' => $now,
+                        'reclaim_stale_at' => $staleAfter === null
+                            ? null
+                            : $now->copy()->addSeconds($staleAfter),
+                    ]) === 1;
+
+                if (! $claimed) {
+                    $this->anomalies->log(AnomalyLog::REASON_CLAIM_LOST, [
+                        'entity' => 'action',
+                        'flow_run_id' => $actionRun->flow_run_id,
+                        'action_run_id' => $actionRun->id,
+                        'sequence' => $actionRun->sequence,
+                        'action_class' => $actionRun->action_class,
+                        'expected_retry_generation' => $expectedRetryGeneration,
+                    ]);
+
+                    return false;
+                }
+
+                $actionRun->refresh();
+
+                $this->events->record(
+                    $actionRun->flowRun,
+                    FlowEventType::ActionStarted,
+                    $actionRun->sequence,
+                    $actionRun
+                );
+
+                event(new ActionStarted($actionRun));
+
+                return true;
+            }
         );
-
-        event(new ActionStarted($actionRun));
     }
 
-    public function completeAction(ActionRun $actionRun, mixed $result): void
+    /**
+     * Record the step's result, but only if this executor still owns the row — see
+     * writeOutcome(). Returns whether the outcome was recorded.
+     */
+    public function completeAction(ActionRun $actionRun, mixed $result): bool
     {
+        $claimedAttempts = $actionRun->attempts;
+
         $actionRun->status = ActionStatus::Completed;
         $actionRun->result = $this->serializer->serialize($result);
         $actionRun->finished_at = Carbon::now();
-        $actionRun->save();
+
+        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionCompleted)) {
+            return false;
+        }
 
         $this->events->record(
             $actionRun->flowRun,
@@ -149,16 +251,25 @@ final readonly class ActionRecorder
         );
 
         event(new ActionCompleted($actionRun));
+
+        return true;
     }
 
-    public function failAction(ActionRun $actionRun, Throwable $exception): void
+    /**
+     * Record the step's failure under the same ownership check as completeAction().
+     */
+    public function failAction(ActionRun $actionRun, Throwable $exception): bool
     {
+        $claimedAttempts = $actionRun->attempts;
         $exceptionArray = $this->exceptionToArray($exception);
 
         $actionRun->status = ActionStatus::Failed;
         $actionRun->exception = $exceptionArray;
         $actionRun->finished_at = Carbon::now();
-        $actionRun->save();
+
+        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionFailed)) {
+            return false;
+        }
 
         $this->events->record(
             $actionRun->flowRun,
@@ -171,6 +282,48 @@ final readonly class ActionRecorder
         );
 
         event(new ActionFailed($actionRun, $exception));
+
+        return true;
+    }
+
+    /**
+     * Persist the pending attribute changes as a fenced conditional UPDATE. The values
+     * come from getDirty(), so the model's own casts encode them exactly as save()
+     * would; only the WHERE differs.
+     *
+     * Its two conditions guard two different rivals. `attempts` fences against another
+     * executor: reclaim can hand the row to a second worker while the first is merely
+     * slow, and the superseded one must not overwrite the live one's outcome. The
+     * status check fences against a transition that never claimed the row — the
+     * monitor expires an overdue step without touching `attempts`, so without it a
+     * late worker would overwrite that Expired and leave the run carrying both
+     * action.expired and action.completed.
+     */
+    private function writeOutcome(ActionRun $actionRun, int $claimedAttempts, FlowEventType $outcome): bool
+    {
+        $written = $actionRun->newQuery()
+            ->whereKey($actionRun->getKey())
+            ->where('attempts', $claimedAttempts)
+            ->where('status', ActionStatus::Running)
+            ->update($actionRun->getDirty()) === 1;
+
+        if (! $written) {
+            $this->anomalies->log(AnomalyLog::REASON_OUTCOME_REJECTED, [
+                'entity' => 'action',
+                'flow_run_id' => $actionRun->flow_run_id,
+                'action_run_id' => $actionRun->id,
+                'sequence' => $actionRun->sequence,
+                'action_class' => $actionRun->action_class,
+                'outcome' => $outcome->value,
+                'claimed_attempts' => $claimedAttempts,
+            ]);
+
+            return false;
+        }
+
+        $actionRun->syncOriginal();
+
+        return true;
     }
 
     /**
@@ -275,6 +428,10 @@ final readonly class ActionRecorder
         $actionRun->started_at = null;
         $actionRun->finished_at = null;
 
+        // The deadline is derived from a start that no longer happened; the next
+        // claim recomputes it from its own started_at.
+        $actionRun->reclaim_stale_at = null;
+
         // A fresh job means a fresh native-attempt allowance: the queue has not given
         // up on this cycle yet, whatever it did to the previous one.
         $actionRun->queue_attempts_exhausted = false;
@@ -314,14 +471,40 @@ final readonly class ActionRecorder
      * replay the seam treats Expired as a failure (or, for an optional step, as a
      * give-up returning its fallback).
      *
+     * Conditional, from the other side of the race writeOutcome() guards: the sweep
+     * selects a row and writes to it a moment later, and an executing worker can settle
+     * it in between. An unconditional save() would demote that Completed step to
+     * Expired, failing a run over work that succeeded. Returns whether this call is the
+     * one that expired the row, so the monitor counts and wakes only for a transition
+     * it won.
+     *
      * @param  array<string, mixed>  $exception
      */
-    public function expireAction(ActionRun $actionRun, array $exception): void
+    public function expireAction(ActionRun $actionRun, array $exception): bool
     {
         $actionRun->status = ActionStatus::Expired;
         $actionRun->exception = $exception;
         $actionRun->finished_at = Carbon::now();
-        $actionRun->save();
+
+        $expired = $actionRun->newQuery()
+            ->whereKey($actionRun->getKey())
+            ->whereIn('status', [ActionStatus::Pending, ActionStatus::Running])
+            ->update($actionRun->getDirty()) === 1;
+
+        if (! $expired) {
+            $this->anomalies->log(AnomalyLog::REASON_OUTCOME_REJECTED, [
+                'entity' => 'action',
+                'flow_run_id' => $actionRun->flow_run_id,
+                'action_run_id' => $actionRun->id,
+                'sequence' => $actionRun->sequence,
+                'action_class' => $actionRun->action_class,
+                'outcome' => FlowEventType::ActionExpired->value,
+            ]);
+
+            return false;
+        }
+
+        $actionRun->syncOriginal();
 
         $this->events->record(
             $actionRun->flowRun,
@@ -330,5 +513,7 @@ final readonly class ActionRecorder
             $actionRun,
             ['exception' => $exception],
         );
+
+        return true;
     }
 }

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * The engine's second journal: what it absorbed while running.
+ *
+ * EventLog records what happened to a run in business terms. This records the moments
+ * where the world turned out not to be what the engine assumed — a claim lost to
+ * whoever already owned the row, an outcome write refused because the row had changed
+ * hands, a batch already closed by a duplicate before its own job reported. All are
+ * ordinary consequences of at-least-once delivery, so none of them fails a job.
+ *
+ * Which is why they need a journal of their own: the job succeeds, flow_events stays
+ * silent, and an operator investigating a step that ran twice would have nothing to go
+ * on. They stay out of flow_events because an abandoned attempt changed nothing in the
+ * run's history.
+ */
+final readonly class AnomalyLog
+{
+    public const string REASON_CLAIM_LOST = 'claim_lost';
+
+    public const string REASON_OUTCOME_REJECTED = 'outcome_rejected';
+
+    public const string REASON_BATCH_FINISHED_EARLY = 'batch_finished_early';
+
+    /**
+     * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set
+     * would make Monolog throw on a path whose entire purpose is not to throw.
+     *
+     * @var array<int, string>
+     */
+    private const array LEVELS = ['emergency', 'alert', 'critical', 'error', 'warning', 'notice', 'info', 'debug'];
+
+    /**
+     * Best-effort by construction: every caller absorbs an anomaly without failing its
+     * job, so a misconfigured channel or level must not be what turns an expected race
+     * into a failure. That failure would not stay local either — an exception escaping
+     * a rejected outcome write reaches RunActionJob::failed(), which writes queue
+     * bookkeeping into a row this worker no longer owns.
+     *
+     * @param  array<string, mixed>  $context
+     */
+    public function log(string $reason, array $context): void
+    {
+        try {
+            $level = config('saga-lara-flow.logging.anomaly_level', 'info');
+
+            if (! is_string($level) || ! in_array($level, self::LEVELS, true)) {
+                return;
+            }
+
+            $channel = config('saga-lara-flow.logging.channel');
+
+            $logger = $channel === null ? Log::driver() : Log::channel((string) $channel);
+
+            $logger->log($level, "saga-lara-flow: {$reason}", $context + ['reason' => $reason]);
+        } catch (Throwable) {
+            // Nothing to escalate to: the caller has already decided this attempt is
+            // over, and there is no second logger to report a broken logger through.
+        }
+    }
+}

--- a/src/Runtime/CompensationEntry.php
+++ b/src/Runtime/CompensationEntry.php
@@ -22,6 +22,8 @@ final readonly class CompensationEntry
         public ?CompensationFailurePolicy $actionCompensationFailurePolicy = null,
         public ?CompensationFailurePolicy $groupCompensationFailurePolicy = null,
         public ?int $parallelGroupId = null,
+        public ?int $reclaimStaleAfterSeconds = null,
+        public ?bool $reclaimStaleEnabled = null,
     ) {}
 
     public function effectivePolicy(): CompensationFailurePolicy

--- a/src/Runtime/CompensationExecutor.php
+++ b/src/Runtime/CompensationExecutor.php
@@ -4,6 +4,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
 use DiscoveryUkraine\SagaLaraFlow\Concerns\ResolvesMethodDependencies;
 use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
 use Illuminate\Contracts\Container\BindingResolutionException;
 use ReflectionException;
@@ -25,19 +26,31 @@ class CompensationExecutor
         private readonly CompensationRecorder $recorder,
     ) {}
 
-    public function execute(CompensationRun $compensation, CompensationDefinition $definition): void
+    /**
+     * Mirrors ActionDispatcher::execute(): anything but Executed means someone else is
+     * handling this row, never that the compensation failed. ClaimLost is the row
+     * being unavailable before anything ran; Superseded is the undo having run with
+     * its outcome dropped.
+     *
+     * @throws Throwable
+     */
+    public function execute(CompensationRun $compensation, CompensationDefinition $definition): StepExecution
     {
-        $this->recorder->startCompensation($compensation);
+        if (! $this->recorder->startCompensation($compensation)) {
+            return StepExecution::ClaimLost;
+        }
 
         try {
             $result = $this->run($definition);
         } catch (Throwable $exception) {
-            $this->recorder->failCompensation($compensation, $exception);
-
-            return;
+            return $this->recorder->failCompensation($compensation, $exception)
+                ? StepExecution::Executed
+                : StepExecution::Superseded;
         }
 
-        $this->recorder->completeCompensation($compensation, $result);
+        return $this->recorder->completeCompensation($compensation, $result)
+            ? StepExecution::Executed
+            : StepExecution::Superseded;
     }
 
     /**

--- a/src/Runtime/CompensationRecorder.php
+++ b/src/Runtime/CompensationRecorder.php
@@ -10,9 +10,11 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationCompleted;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationFailed;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStarted;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStepStarted;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Throwable;
 
 /**
@@ -26,6 +28,7 @@ final readonly class CompensationRecorder
     public function __construct(
         private EventLog $events,
         private Serializer $serializer,
+        private AnomalyLog $anomalies,
     ) {}
 
     /**
@@ -64,6 +67,10 @@ final readonly class CompensationRecorder
             'status' => CompensationStatus::Pending,
             'continue_on_failure' => $policy === CompensationFailurePolicy::Continue,
             'arguments' => $definition->isClosure() ? null : $definition->arguments,
+            'reclaim_stale_after_seconds' => $this->resolveReclaimStaleAfterSeconds(
+                $entry->reclaimStaleAfterSeconds,
+                $entry->reclaimStaleEnabled,
+            ),
         ]);
 
         $compensation->save();
@@ -71,19 +78,108 @@ final readonly class CompensationRecorder
         return $compensation;
     }
 
-    public function startCompensation(CompensationRun $compensation): void
+    /**
+     * Same resolution shape as ActionRecorder::resolveReclaimStaleAfterSeconds(), read
+     * against the sagas.reclaim.stale_running config instead — the two mechanisms are
+     * switched independently.
+     */
+    private function resolveReclaimStaleAfterSeconds(?int $seconds, ?bool $enabled): ?int
     {
-        $compensation->status = CompensationStatus::Running;
-        $compensation->started_at = Carbon::now();
-        $compensation->save();
+        if ($enabled === false) {
+            return null;
+        }
+
+        if ($seconds !== null) {
+            return $seconds;
+        }
+
+        if ($enabled === true) {
+            return (int) config('saga-lara-flow.sagas.reclaim.stale_running.after_seconds');
+        }
+
+        return config('saga-lara-flow.sagas.reclaim.stale_running.enabled')
+            ? (int) config('saga-lara-flow.sagas.reclaim.stale_running.after_seconds')
+            : null;
     }
 
-    public function completeCompensation(CompensationRun $compensation, mixed $result): void
+    /**
+     * Atomically claim the row and move it to Running, returning false when the row is
+     * no longer claimable — settled already, or still Running before its reclaim
+     * deadline. Mirrors ActionRecorder::startAction() in every respect: the same
+     * compare-and-swap shape, the same enclosing transaction, the same absence of
+     * Eloquent model events (CompensationStepStarted and the flow_events entry are the
+     * supported way to observe it), and the same attempts counter.
+     *
+     * @throws Throwable
+     */
+    public function startCompensation(CompensationRun $compensation): bool
     {
+        return $compensation->getConnection()->transaction(function () use ($compensation): bool {
+            $now = Carbon::now();
+
+            $staleAfter = $compensation->reclaim_stale_after_seconds;
+
+            $claimed = $compensation->newQuery()
+                ->whereKey($compensation->getKey())
+                ->where(function ($query) use ($now): void {
+                    $query->where('status', CompensationStatus::Pending)
+                        ->orWhere(function ($query) use ($now): void {
+                            $query->where('status', CompensationStatus::Running)
+                                ->whereNotNull('reclaim_stale_at')
+                                ->where('reclaim_stale_at', '<=', $now);
+                        });
+                })
+                ->update([
+                    'status' => CompensationStatus::Running,
+                    'attempts' => DB::raw('attempts + 1'),
+                    'started_at' => $now,
+                    'reclaim_stale_at' => $staleAfter === null
+                        ? null
+                        : $now->copy()->addSeconds($staleAfter),
+                ]) === 1;
+
+            if (! $claimed) {
+                $this->anomalies->log(AnomalyLog::REASON_CLAIM_LOST, [
+                    'entity' => 'compensation',
+                    'flow_run_id' => $compensation->flow_run_id,
+                    'compensation_run_id' => $compensation->id,
+                    'sequence' => $compensation->sequence,
+                    'compensation_class' => $compensation->compensation_class,
+                ]);
+
+                return false;
+            }
+
+            $compensation->refresh();
+
+            $this->events->record(
+                $compensation->flowRun,
+                FlowEventType::CompensationStepStarted,
+                $compensation->sequence,
+                $compensation,
+            );
+
+            event(new CompensationStepStarted($compensation));
+
+            return true;
+        });
+    }
+
+    /**
+     * Record the compensation's result, fenced against the claim that produced it —
+     * see ActionRecorder::completeAction() for why. Returns whether it was recorded.
+     */
+    public function completeCompensation(CompensationRun $compensation, mixed $result): bool
+    {
+        $claimedAttempts = $compensation->attempts;
+
         $compensation->status = CompensationStatus::Completed;
         $compensation->result = $this->serializer->serialize($result);
         $compensation->finished_at = Carbon::now();
-        $compensation->save();
+
+        if (! $this->writeOutcome($compensation, $claimedAttempts, FlowEventType::CompensationCompleted)) {
+            return false;
+        }
 
         $this->events->record(
             $compensation->flowRun,
@@ -93,16 +189,22 @@ final readonly class CompensationRecorder
         );
 
         event(new CompensationCompleted($compensation));
+
+        return true;
     }
 
-    public function failCompensation(CompensationRun $compensation, Throwable $exception): void
+    public function failCompensation(CompensationRun $compensation, Throwable $exception): bool
     {
+        $claimedAttempts = $compensation->attempts;
         $exceptionArray = $this->exceptionToArray($exception);
 
         $compensation->status = CompensationStatus::Failed;
         $compensation->exception = $exceptionArray;
         $compensation->finished_at = Carbon::now();
-        $compensation->save();
+
+        if (! $this->writeOutcome($compensation, $claimedAttempts, FlowEventType::CompensationFailed)) {
+            return false;
+        }
 
         $this->events->record(
             $compensation->flowRun,
@@ -113,6 +215,45 @@ final readonly class CompensationRecorder
         );
 
         event(new CompensationFailed($compensation, $exception));
+
+        return true;
+    }
+
+    /**
+     * @see ActionRecorder::writeOutcome()
+     *
+     * Compensations have no expiry sweep, so the status condition guards nothing today;
+     * it holds the invariant locally rather than depending on no such writer ever
+     * being added.
+     */
+    private function writeOutcome(
+        CompensationRun $compensation,
+        int $claimedAttempts,
+        FlowEventType $outcome
+    ): bool {
+        $written = $compensation->newQuery()
+            ->whereKey($compensation->getKey())
+            ->where('attempts', $claimedAttempts)
+            ->where('status', CompensationStatus::Running)
+            ->update($compensation->getDirty()) === 1;
+
+        if (! $written) {
+            $this->anomalies->log(AnomalyLog::REASON_OUTCOME_REJECTED, [
+                'entity' => 'compensation',
+                'flow_run_id' => $compensation->flow_run_id,
+                'compensation_run_id' => $compensation->id,
+                'sequence' => $compensation->sequence,
+                'compensation_class' => $compensation->compensation_class,
+                'outcome' => $outcome->value,
+                'claimed_attempts' => $claimedAttempts,
+            ]);
+
+            return false;
+        }
+
+        $compensation->syncOriginal();
+
+        return true;
     }
 
     private function nextSequence(FlowRun $flowRun): int

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -2,6 +2,7 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
+use Closure;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
@@ -30,11 +31,17 @@ use Throwable;
  *   R1  a stuck sequential Pending action (its RunActionJob was lost) → re-dispatch.
  *   R2  a stuck Waiting run with nothing in flight (its resume was lost) → re-wake;
  *       replay then advances it or parks it again.
+ *   R3  a stuck sequential Running action past its own reclaim window (opt-in via
+ *       actions.reclaim.stale_running — a worker died mid-execution) → re-dispatch.
  *
  * Each repaired entity carries repair_attempts + repair_available_at so a pass is
  * throttled per entity (exponential backoff) and gives up after max_attempts —
  * saga-flow:kick is the manual escape hatch. Batch-bound work (compensations,
- * parallel actions) and automatic Running re-drive are deliberately out of scope.
+ * parallel actions) is out of scope even for R3: recovering them would mean
+ * adding a job back into their Bus::batch, which needs the batch's id — not stored
+ * anywhere in this package's tables, only recoverable by looking its deterministic
+ * name up in Laravel's own job_batches table, a detail of the database batch driver
+ * specifically and not guaranteed for every host.
  */
 final readonly class FlowDoctor
 {
@@ -60,23 +67,55 @@ final readonly class FlowDoctor
         $grace = (int) config('saga-lara-flow.repair.grace_seconds', 60);
         $maxAttempts = (int) config('saga-lara-flow.repair.max_attempts', 10);
 
-        $redispatchedActions = 0;
-        $rewokenFlows = 0;
+        [$lostActions, $skippedLost] = $this->applyRule(
+            'redispatch_lost_actions',
+            fn (): iterable => $this->actionRunRepository->dueForRepair($limit, $grace, $maxAttempts),
+            fn (ActionRun $action): bool => $this->redispatchAction($action, $maxAttempts),
+        );
+
+        [$staleActions, $skippedStale] = $this->applyRule(
+            'redispatch_stale_running_actions',
+            fn (): iterable => $this->actionRunRepository->dueForStaleRunningRepair($limit, $maxAttempts),
+            fn (ActionRun $action): bool => $this->redispatchStaleRunningAction($action, $maxAttempts),
+        );
+
+        [$rewokenFlows, $skippedFlows] = $this->applyRule(
+            'wake_stuck_flows',
+            fn (): iterable => $this->flowRepository->dueForRepair($limit, $grace, $maxAttempts),
+            fn (FlowRun $run): bool => $this->wakeWaiting($run, $maxAttempts),
+        );
+
+        return new FlowRepairReport(
+            $lostActions + $staleActions,
+            $rewokenFlows,
+            $skippedLost + $skippedStale + $skippedFlows,
+        );
+    }
+
+    /**
+     * Run one repair rule if its config switch is on, returning [repaired, skipped].
+     * Candidates come from a closure so a disabled rule never queries for them.
+     *
+     * @template TEntity of ActionRun|FlowRun
+     *
+     * @param  Closure(): iterable<TEntity>  $candidates
+     * @param  Closure(TEntity): bool  $repair
+     * @return array{int, int}
+     */
+    private function applyRule(string $switch, Closure $candidates, Closure $repair): array
+    {
+        if (! config("saga-lara-flow.repair.{$switch}")) {
+            return [0, 0];
+        }
+
+        $repaired = 0;
         $skipped = 0;
 
-        if (config('saga-lara-flow.repair.redispatch_lost_actions')) {
-            foreach ($this->actionRunRepository->dueForRepair($limit, $grace, $maxAttempts) as $action) {
-                $this->redispatchAction($action, $maxAttempts) ? $redispatchedActions++ : $skipped++;
-            }
+        foreach ($candidates() as $entity) {
+            $repair($entity) ? $repaired++ : $skipped++;
         }
 
-        if (config('saga-lara-flow.repair.wake_stuck_flows')) {
-            foreach ($this->flowRepository->dueForRepair($limit, $grace, $maxAttempts) as $run) {
-                $this->wakeWaiting($run, $maxAttempts) ? $rewokenFlows++ : $skipped++;
-            }
-        }
-
-        return new FlowRepairReport($redispatchedActions, $rewokenFlows, $skipped);
+        return [$repaired, $skipped];
     }
 
     /**
@@ -95,6 +134,54 @@ final readonly class FlowDoctor
                 $lockedAction === null
                 || $lockedAction->status !== ActionStatus::Pending
                 || $lockedAction->parallel_group !== null
+                || $lockedAction->repair_attempts >= $maxAttempts
+                || ! $this->repairWindowOpen($lockedAction->repair_available_at)
+            ) {
+                return false;
+            }
+
+            $flow = $lockedAction->flowRun;
+
+            // Never resurrect a step whose run is finished or rolling back.
+            if ($flow->isTerminal() || $flow->status === FlowStatus::Cancelling) {
+                return false;
+            }
+
+            $this->bumpThrottle($lockedAction);
+
+            $this->actionRecorder->actionRedispatched($lockedAction);
+
+            return true;
+        });
+
+        if ($confirmed) {
+            $this->dispatchActionJob($action->fresh() ?? $action);
+        }
+
+        return $confirmed;
+    }
+
+    /**
+     * R3: re-dispatch a fresh RunActionJob for a stuck sequential Running action past
+     * its own reclaim window (actions.reclaim.stale_running). Re-verifies staleness
+     * under a row lock — the row may have been reclaimed and restarted since the
+     * candidate was read — bumps the throttle, records the intervention, then
+     * dispatches after the transaction commits. Like R1 it only sends a job: the fresh
+     * job's own claim decides whether it wins the row.
+     *
+     * @throws Throwable
+     */
+    private function redispatchStaleRunningAction(ActionRun $action, int $maxAttempts): bool
+    {
+        $confirmed = $this->connection()->transaction(function () use ($action, $maxAttempts): bool {
+            $lockedAction = $this->lockAction($action->id);
+
+            if (
+                $lockedAction === null
+                || $lockedAction->status !== ActionStatus::Running
+                || $lockedAction->parallel_group !== null
+                || $lockedAction->reclaim_stale_at === null
+                || $lockedAction->reclaim_stale_at->isAfter(now())
                 || $lockedAction->repair_attempts >= $maxAttempts
                 || ! $this->repairWindowOpen($lockedAction->repair_available_at)
             ) {

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -166,10 +166,17 @@ final readonly class FlowMonitor
             return false;
         }
 
-        $this->actionRecorder->expireAction(
+        // A worker can settle the step between this sweep's select and its write, and
+        // the expiry refuses to overwrite that. Nothing was expired then, so there is
+        // nothing to count and no marker for a woken replay to resolve.
+        $expired = $this->actionRecorder->expireAction(
             $action,
             $this->exceptionToArray(FlowExpiredException::forAction($action->action_class, $action->sequence)),
         );
+
+        if (! $expired) {
+            return false;
+        }
 
         $this->wake($run);
 

--- a/src/Runtime/ParallelRunner.php
+++ b/src/Runtime/ParallelRunner.php
@@ -5,6 +5,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 use DiscoveryUkraine\SagaLaraFlow\Builders\ParallelStepBuilder;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ParallelFailurePolicy;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
@@ -98,12 +99,7 @@ final readonly class ParallelRunner
                 $this->dispatcher->runInline(
                     $flowRun,
                     $slot['sequence'],
-                    $step->actionClass(),
-                    $step->arguments(),
-                    $step->compensation() !== null,
-                    $step->isOptional(),
-                    $groupId,
-                    $step->expiry(),
+                    $this->scheduleFor($step, $groupId),
                 );
             } catch (Throwable $exception) {
                 // Optional inline failure (no retries inline): give up now and keep going.
@@ -145,12 +141,7 @@ final readonly class ParallelRunner
             $actionRun = $this->recorder->scheduleAction(
                 $flowRun,
                 $slot['sequence'],
-                $step->actionClass(),
-                $step->arguments(),
-                $step->compensation() !== null,
-                $step->isOptional(),
-                $groupId,
-                $step->expiry(),
+                $this->scheduleFor($step, $groupId),
             );
 
             $jobs[] = new RunParallelActionJob($actionRun->id, $step->actionClass(), $policy);
@@ -291,6 +282,22 @@ final readonly class ParallelRunner
     {
         return $step->compensateOnSelfFailure()
             ?? (bool) config('saga-lara-flow.sagas.compensate_failed_step');
+    }
+
+    /**
+     * A parallel step carries no retry-on-signal policy and no reclaim override; both
+     * paths of the block schedule it the same way, differing only in transport.
+     */
+    private function scheduleFor(ParallelStepBuilder $step, int $groupId): ActionSchedule
+    {
+        return new ActionSchedule(
+            actionClass: $step->actionClass(),
+            arguments: $step->arguments(),
+            hasCompensation: $step->compensation() !== null,
+            continueOnFailure: $step->isOptional(),
+            parallelGroup: $groupId,
+            expiresAt: $step->expiry(),
+        );
     }
 
     private function markOptionalFailed(string $flowRunId, int $sequence): void

--- a/src/Runtime/SagaRunner.php
+++ b/src/Runtime/SagaRunner.php
@@ -7,7 +7,10 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CompensationFailedException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CompensationUnfinishedException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\RunCompensationJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
@@ -112,6 +115,8 @@ class SagaRunner
     /**
      * @param  list<CompensationEntry>  $level
      * @return bool whether a Stop-policy compensation failed (rollback must halt)
+     *
+     * @throws Throwable
      */
     private function runLevelSync(FlowRun $flowRun, array $level): bool
     {
@@ -122,7 +127,17 @@ class SagaRunner
 
             $compensationIds[] = $compensation->id;
 
-            $this->executor->execute($compensation, $entry->definition);
+            // The row was just created above, in this same call: nothing else can have
+            // taken it, so losing the claim is a broken invariant rather than a race.
+            // Nothing supersedes a compensation mid-run either — they carry no expiry
+            // sweep and the doctor leaves them alone — but the two are kept apart here
+            // so this stays an invariant guard and not a catch-all.
+            if ($this->executor->execute($compensation, $entry->definition) === StepExecution::ClaimLost) {
+                throw ActionClaimFailedException::forCompensation(
+                    $entry->definition->class ?? $entry->definition->type,
+                    $compensation->sequence,
+                );
+            }
         }
 
         return $this->levelStopped($compensationIds);
@@ -185,6 +200,12 @@ class SagaRunner
         if ($failed !== null) {
             $exception['compensation'] = $this->exceptionToArray(CompensationFailedException::for($failed))
                 + ['cause' => $failed->exception];
+        } elseif (($unfinished = $this->firstUnfinishedCompensation($flowRun)) !== null) {
+            // Recorded in the same place a failure would be, so a run that did not
+            // fully unwind never looks like one that did.
+            $exception['compensation'] = $this->exceptionToArray(
+                CompensationUnfinishedException::for($unfinished)
+            );
         }
 
         // A monitor-enforced expiration that rolled back lands in Expired, not Failed:
@@ -249,6 +270,12 @@ class SagaRunner
     }
 
     /**
+     * Whether a Stop-policy compensation on the level did not complete.
+     *
+     * Wider than "failed": a compensation still Pending or Running when its level
+     * finishes is one whose job was lost or whose worker died, and unwinding further
+     * on top of a step that may never have been undone is what Stop exists to prevent.
+     *
      * @param  list<string>  $compensationIds
      */
     private function levelStopped(array $compensationIds): bool
@@ -259,7 +286,7 @@ class SagaRunner
 
         return $this->compensationModel()->newQuery()
             ->whereIn('id', $compensationIds)
-            ->where('status', CompensationStatus::Failed)
+            ->whereNot('status', CompensationStatus::Completed)
             ->where('continue_on_failure', false)
             ->exists();
     }
@@ -269,6 +296,20 @@ class SagaRunner
         return $this->compensationModel()->newQuery()
             ->where('flow_run_id', $flowRun->id)
             ->where('status', CompensationStatus::Failed)
+            ->orderBy('sequence')
+            ->first();
+    }
+
+    /**
+     * The earliest compensation that never reached a terminal state. Reported only
+     * when no compensation actually failed — a real failure carries its own cause and
+     * is the more useful thing to surface.
+     */
+    private function firstUnfinishedCompensation(FlowRun $flowRun): ?CompensationRun
+    {
+        return $this->compensationModel()->newQuery()
+            ->where('flow_run_id', $flowRun->id)
+            ->whereIn('status', [CompensationStatus::Pending, CompensationStatus::Running])
             ->orderBy('sequence')
             ->first();
     }

--- a/src/SagaLaraFlowServiceProvider.php
+++ b/src/SagaLaraFlowServiceProvider.php
@@ -46,6 +46,7 @@ class SagaLaraFlowServiceProvider extends PackageServiceProvider
             ->hasConfigFile()
             ->hasMigration('2026_07_02_000000_create_saga_lara_flow_initial_tables')
             ->hasMigration('2026_08_21_000000_add_retry_on_signal_to_action_runs')
+            ->hasMigration('2026_08_25_000000_add_reclaim_stale_running_columns')
             ->runsMigrations()
             ->hasCommands([
                 MakeWorkflowCommand::class,

--- a/tests/Feature/AnomalyLoggingTest.php
+++ b/tests/Feature/AnomalyLoggingTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+
+/**
+ * Every path AnomalyLog records — a claim lost to whoever already owns the row, an
+ * outcome write rejected because the row changed hands, a batch closed early by a
+ * duplicate — deliberately does not fail the job. The log line is therefore the only
+ * evidence they happened, and the only way to find out afterwards why a step ran
+ * twice, why a result went missing, or why a run woke one time too many.
+ *
+ * Asserted against a real log file rather than a mocked logger, so what is checked
+ * is what an operator would actually be able to grep for.
+ */
+function anomalyLogPath(): string
+{
+    $path = sys_get_temp_dir().'/saga-anomaly-'.uniqid().'.log';
+
+    logToFile($path);
+
+    return $path;
+}
+
+function claimedRow(): ActionRun
+{
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+
+    return ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Completed,
+        'attempts' => 1,
+    ]);
+}
+
+it('logs a lost claim with enough context to find the step again', function () {
+    $path = anomalyLogPath();
+
+    $action = claimedRow();
+
+    expect(app(ActionRecorder::class)->startAction($action))->toBeFalse();
+
+    $log = file_get_contents($path);
+
+    // Monolog JSON-encodes the context, so the class name appears with its
+    // backslashes escaped.
+    expect($log)->toContain('claim_lost')
+        ->and($log)->toContain($action->id)
+        ->and($log)->toContain('MakeValueAction');
+});
+
+it('logs a rejected outcome write', function () {
+    $path = anomalyLogPath();
+
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Running,
+        'attempts' => 1,
+    ]);
+
+    // Somebody else claimed the row after this executor did.
+    ActionRun::query()->whereKey($action->id)->update(['attempts' => 2]);
+
+    expect(app(ActionRecorder::class)->completeAction($action, ['label' => 'stale']))->toBeFalse();
+
+    expect(file_get_contents($path))->toContain('outcome_rejected');
+});
+
+it('writes nothing when anomaly logging is switched off', function () {
+    $path = anomalyLogPath();
+    config()->set('saga-lara-flow.logging.anomaly_level', null);
+
+    expect(app(ActionRecorder::class)->startAction(claimedRow()))->toBeFalse();
+
+    expect(file_exists($path))->toBeFalse();
+});
+
+it('honours the configured level', function () {
+    $path = anomalyLogPath();
+    config()->set('saga-lara-flow.logging.anomaly_level', 'warning');
+
+    expect(app(ActionRecorder::class)->startAction(claimedRow()))->toBeFalse();
+
+    expect(file_get_contents($path))->toContain('WARNING');
+});
+
+// --- A broken logger must not be what fails the job ---
+//
+// These paths exist precisely so a normal at-least-once anomaly does not fail
+// anything. If the log line could throw, a misconfigured logger would turn every such
+// anomaly into a failed job — and worse, an exception escaping a rejected outcome
+// write reaches RunActionJob::failed(), which writes queue bookkeeping into a row this
+// worker no longer owns. So anomaly logging is best-effort in both directions: the
+// level is validated before it reaches Monolog, and anything the write itself throws
+// is swallowed.
+//
+// A channel name that does not exist is deliberately not among the cases: Laravel's
+// LogManager already falls back to an emergency logger rather than throwing.
+
+it('still abandons the claim quietly when the configured level is nonsense', function () {
+    $path = anomalyLogPath();
+    config()->set('saga-lara-flow.logging.anomaly_level', 'shout');
+
+    expect(app(ActionRecorder::class)->startAction(claimedRow()))->toBeFalse();
+
+    // An unusable level is treated as "off" rather than handed to Monolog, which
+    // rejects it with an InvalidArgumentException.
+    expect(file_exists($path))->toBeFalse();
+});
+
+it('still rejects an outcome quietly when the log channel cannot be written to', function () {
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Running,
+        'attempts' => 1,
+    ]);
+
+    // Somebody else claimed the row after this executor did.
+    ActionRun::query()->whereKey($action->id)->update(['attempts' => 2]);
+
+    // A path no process can open: the handler throws when the line is written, which
+    // is the shape of every "the log backend is down" failure.
+    logToFile('/proc/self/no/such/place/anomaly.log');
+
+    expect(app(ActionRecorder::class)->completeAction($action, ['label' => 'stale']))->toBeFalse()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running);
+});

--- a/tests/Feature/AtomicClaimRegressionTest.php
+++ b/tests/Feature/AtomicClaimRegressionTest.php
@@ -1,0 +1,214 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStarted;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStepStarted;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * Issue #13: RunActionJob (and RunCompensationJob) had no atomic claim between
+ * reading a step and executing it. These tests exercise ActionRecorder::startAction()
+ * and CompensationRecorder::startCompensation() directly — the same style already
+ * used in RetryOnSignalQueuedTest for SignalRecorder's compare-and-swap — rather than
+ * spinning up real concurrency, to force each race deterministically.
+ */
+function stagedFlowRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+}
+
+it('fails to claim an action whose retry cycle has moved on since the job was dispatched', function () {
+    $run = stagedFlowRun();
+
+    // The row has already been rewound to cycle 1 (e.g. a signal arrived and
+    // retryAction() ran) by the time this call happens.
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Failed,
+        'retry_signal_attempts' => 1,
+        'attempts' => 1,
+    ]);
+
+    // A stale job, dispatched for cycle 0 before the rewind, tries to claim it.
+    $claimed = app(ActionRecorder::class)->startAction($action, expectedRetryGeneration: 0);
+
+    expect($claimed)->toBeFalse()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Failed)
+        ->and($action->fresh()->attempts)->toBe(1)
+        ->and($action->fresh()->retry_signal_attempts)->toBe(1);
+});
+
+it('claims an action normally when the retry cycle still matches what the job was dispatched for', function () {
+    $run = stagedFlowRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'retry_signal_attempts' => 1,
+        'attempts' => 0,
+    ]);
+
+    $claimed = app(ActionRecorder::class)->startAction($action, expectedRetryGeneration: 1);
+
+    expect($claimed)->toBeTrue()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($action->fresh()->attempts)->toBe(1);
+});
+
+it('fails to claim an action the monitor has already marked Expired', function () {
+    $run = stagedFlowRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Expired,
+        'attempts' => 1,
+    ]);
+
+    $claimed = app(ActionDispatcher::class)->execute($action);
+
+    expect($claimed)->toBe(StepExecution::ClaimLost)
+        ->and($action->fresh()->status)->toBe(ActionStatus::Expired)
+        ->and($action->fresh()->attempts)->toBe(1);
+});
+
+it('still lets a job reclaim a Failed row within the same cycle for Laravel\'s own native $tries', function () {
+    // Failed is not terminal here: it is what the row shows between two of the
+    // action's own native attempts. Laravel redelivers the very same job (same
+    // generation) until $tries is exhausted, and each redelivery must still be able
+    // to claim the row — this must NOT regress back to treating Failed as off-limits.
+    $run = stagedFlowRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Failed,
+        'retry_signal_attempts' => 0,
+        'attempts' => 1,
+    ]);
+
+    $claimed = app(ActionRecorder::class)->startAction($action, expectedRetryGeneration: 0);
+
+    expect($claimed)->toBeTrue()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($action->fresh()->attempts)->toBe(2);
+});
+
+it('never fires ActionStarted or records action.started when the claim fails', function () {
+    $run = stagedFlowRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Completed,
+        'attempts' => 1,
+    ]);
+
+    Event::fake();
+
+    expect(app(ActionRecorder::class)->startAction($action))->toBeFalse();
+
+    Event::assertNotDispatched(ActionStarted::class);
+    expect($run->events()->where('type', 'action.started')->count())->toBe(0);
+});
+
+// The sync-mode throw in ActionDispatcher::runInline() / ActionBuilder::startRetriedStep()
+// (ActionClaimFailedException — see tests/Unit/ActionClaimFailedExceptionTest.php for the
+// exception's own message) guards a branch that is unreachable through the public API by
+// construction: both callers claim a row they just scheduled or just rewound to Pending in
+// the very same call, so nothing else can race it. Provable by inspection rather than by a
+// test that would need to fabricate an otherwise-impossible database state.
+
+// --- Compensations: the identical bug in CompensationRecorder::startCompensation() ---
+
+it('fails to claim a compensation already settled (Completed) elsewhere', function () {
+    $run = stagedFlowRun();
+
+    $compensation = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Completed,
+        'arguments' => ['x'],
+    ]);
+
+    $claimed = app(CompensationRecorder::class)->startCompensation($compensation);
+
+    expect($claimed)->toBeFalse()
+        ->and($compensation->fresh()->status)->toBe(CompensationStatus::Completed);
+});
+
+it('claims a Pending compensation and fires CompensationStepStarted, distinct from the once-per-run CompensationStarted', function () {
+    $run = stagedFlowRun();
+
+    $compensation = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Pending,
+        'arguments' => ['x'],
+    ]);
+
+    Event::fake();
+
+    $claimed = app(CompensationRecorder::class)->startCompensation($compensation);
+
+    expect($claimed)->toBeTrue()
+        ->and($compensation->fresh()->status)->toBe(CompensationStatus::Running)
+        ->and($run->events()->where('type', 'compensation.step_started')->count())->toBe(1);
+
+    Event::assertDispatched(CompensationStepStarted::class);
+    Event::assertNotDispatched(CompensationStarted::class);
+});
+
+it('runs the compensation body through CompensationExecutor only when the claim succeeds', function () {
+    CompensationLog::reset();
+
+    $run = stagedFlowRun();
+
+    $completed = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Completed,
+        'arguments' => ['x'],
+    ]);
+
+    $definition = CompensationDefinition::forClass(UndoAction::class, ['x']);
+
+    $ran = app(CompensationExecutor::class)->execute($completed, $definition);
+
+    expect($ran)->toBe(StepExecution::ClaimLost)
+        ->and(CompensationLog::all())->toBe([]);
+});

--- a/tests/Feature/ClaimFencingTest.php
+++ b/tests/Feature/ClaimFencingTest.php
@@ -1,0 +1,309 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionCompleted;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationCompleted;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ExpiredMidRunWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalExpiredMidRunWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ReclaimedMidRunAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * The claim decides who may START a step; these tests cover who may FINISH one.
+ *
+ * Reclaim deliberately allows a second worker to take over a row whose first worker
+ * may be slow rather than dead — the queue driver can redeliver a job while the
+ * original attempt is still alive, and no engine can prevent that. What it can
+ * prevent is the superseded executor writing its outcome over the live one's, which
+ * would record the opposite result and send the workflow down the wrong branch.
+ * `attempts` is incremented by the claim and nothing else, so it identifies the
+ * claim that an outcome write must still belong to.
+ */
+function fencedRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+}
+
+/**
+ * A row already claimed once, with its reclaim deadline in the past so a second
+ * claim is legal — the state reclaim exists to recover from.
+ */
+function reclaimableAction(FlowRun $run, string $actionClass = MakeValueAction::class): ActionRun
+{
+    return ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => $actionClass,
+        'status' => ActionStatus::Pending,
+        'reclaim_stale_after_seconds' => 900,
+        'attempts' => 0,
+    ]);
+}
+
+it('refuses an outcome write from an executor whose row was reclaimed', function () {
+    $run = fencedRun();
+    $recorder = app(ActionRecorder::class);
+
+    $workerA = reclaimableAction($run);
+
+    expect($recorder->startAction($workerA))->toBeTrue()
+        ->and($workerA->attempts)->toBe(1);
+
+    // The reclaim window passes and worker B takes the row over.
+    ActionRun::query()->whereKey($workerA->id)->update(['reclaim_stale_at' => now()->subMinute()]);
+
+    $workerB = ActionRun::query()->findOrFail($workerA->id);
+
+    expect($recorder->startAction($workerB))->toBeTrue()
+        ->and($workerB->attempts)->toBe(2);
+
+    // Worker A finally finishes. Its result belongs to a claim that is over.
+    Event::fake([ActionCompleted::class]);
+
+    expect($recorder->completeAction($workerA, ['label' => 'stale']))->toBeFalse()
+        ->and($workerA->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($workerA->fresh()->result)->toBeNull();
+
+    Event::assertNotDispatched(ActionCompleted::class);
+});
+
+it('never lets a superseded failure overwrite the live worker\'s success', function () {
+    $run = fencedRun();
+    $recorder = app(ActionRecorder::class);
+
+    $workerA = reclaimableAction($run);
+    $recorder->startAction($workerA);
+
+    ActionRun::query()->whereKey($workerA->id)->update(['reclaim_stale_at' => now()->subMinute()]);
+
+    $workerB = ActionRun::query()->findOrFail($workerA->id);
+    $recorder->startAction($workerB);
+
+    // B is the current owner and succeeds.
+    expect($recorder->completeAction($workerB, ['label' => 'real']))->toBeTrue();
+
+    // A, still alive but superseded, then throws. Without fencing this would demote
+    // a completed step to Failed and roll the saga back over a step that succeeded.
+    Event::fake([ActionFailed::class]);
+
+    expect($recorder->failAction($workerA, new RuntimeException('zombie')))->toBeFalse()
+        ->and($workerA->fresh()->status)->toBe(ActionStatus::Completed)
+        ->and($workerA->fresh()->result)->toBe(['label' => 'real'])
+        ->and($workerA->fresh()->exception)->toBeNull();
+
+    Event::assertNotDispatched(ActionFailed::class);
+});
+
+it('lets the current owner record its outcome normally', function () {
+    $run = fencedRun();
+    $recorder = app(ActionRecorder::class);
+
+    $action = reclaimableAction($run);
+
+    expect($recorder->startAction($action))->toBeTrue()
+        ->and($recorder->completeAction($action, ['label' => 'ok']))->toBeTrue()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Completed)
+        ->and($action->fresh()->result)->toBe(['label' => 'ok']);
+});
+
+it('reports a reclaimed row as not executed rather than throwing, when the step succeeded', function () {
+    $run = fencedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => ReclaimedMidRunAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    $action->arguments = app(Serializer::class)
+        ->serialize([$action->id, false]);
+    $action->save();
+
+    Event::fake([ActionCompleted::class]);
+
+    // Superseded, not ClaimLost: this executor did own the row and did run the step —
+    // only its result was refused.
+    expect(app(ActionDispatcher::class)->execute($action))->toBe(StepExecution::Superseded)
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running);
+
+    Event::assertNotDispatched(ActionCompleted::class);
+});
+
+it('swallows the exception of a reclaimed row rather than failing the job', function () {
+    $run = fencedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => ReclaimedMidRunAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    $action->arguments = app(Serializer::class)
+        ->serialize([$action->id, true]);
+    $action->save();
+
+    // Rethrowing would fail a job whose work was already discarded, and
+    // RunActionJob::failed() would then write queue bookkeeping into a row owned by
+    // somebody else.
+    expect(app(ActionDispatcher::class)->execute($action))->toBe(StepExecution::Superseded)
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($action->fresh()->exception)->toBeNull();
+});
+
+it('fences a compensation outcome the same way', function () {
+    $run = fencedRun();
+    $recorder = app(CompensationRecorder::class);
+
+    $workerA = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Pending,
+        'reclaim_stale_after_seconds' => 900,
+        'attempts' => 0,
+    ]);
+
+    expect($recorder->startCompensation($workerA))->toBeTrue()
+        ->and($workerA->attempts)->toBe(1);
+
+    CompensationRun::query()->whereKey($workerA->id)->update(['reclaim_stale_at' => now()->subMinute()]);
+
+    $workerB = CompensationRun::query()->findOrFail($workerA->id);
+
+    expect($recorder->startCompensation($workerB))->toBeTrue()
+        ->and($workerB->attempts)->toBe(2);
+
+    Event::fake([CompensationCompleted::class]);
+
+    expect($recorder->completeCompensation($workerA, 'stale'))->toBeFalse()
+        ->and($workerA->fresh()->status)->toBe(CompensationStatus::Running);
+
+    Event::assertNotDispatched(CompensationCompleted::class);
+});
+
+// --- The other rival: a settlement that never claimed the row ---
+//
+// The monitor expires an overdue step without ever claiming it, so it does not touch
+// `attempts` and the fence alone cannot see it. Both orders of that race have to be
+// covered: the sweep landing first, and the worker landing first.
+
+it('refuses an outcome write onto a row the monitor already expired', function () {
+    $run = fencedRun();
+    $recorder = app(ActionRecorder::class);
+
+    $action = reclaimableAction($run);
+    $recorder->startAction($action);
+
+    // The sweep settles the overdue step while this worker is still executing. It
+    // claims nothing, so `attempts` is untouched and still matches the worker's.
+    expect($recorder->expireAction($action->fresh(), ['message' => 'deadline']))->toBeTrue();
+
+    Event::fake([ActionCompleted::class]);
+
+    expect($recorder->completeAction($action, ['label' => 'late']))->toBeFalse()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Expired)
+        ->and($action->fresh()->result)->toBeNull();
+
+    Event::assertNotDispatched(ActionCompleted::class);
+});
+
+it('refuses to expire a step that finished just before the sweep reached it', function () {
+    $run = fencedRun();
+    $recorder = app(ActionRecorder::class);
+
+    $action = reclaimableAction($run);
+    $recorder->startAction($action);
+
+    // What the sweep read a moment ago: still Running, deadline passed.
+    $sweepView = ActionRun::query()->findOrFail($action->id);
+
+    expect($recorder->completeAction($action, ['label' => 'just in time']))->toBeTrue();
+
+    // Demoting this to Expired would fail a run over work that actually succeeded.
+    expect($recorder->expireAction($sweepView, ['message' => 'deadline']))->toBeFalse()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Completed)
+        ->and($action->fresh()->result)->toBe(['label' => 'just in time'])
+        ->and($action->fresh()->exception)->toBeNull();
+});
+
+// --- Being superseded is not the same as never having the row ---
+//
+// Sync execution has no competitor between scheduling a step and starting it, so a
+// lost claim there is a broken invariant and says so loudly. Losing the row *after*
+// the work ran is a different thing entirely — the monitor and the doctor sweep the
+// rows a sync run creates from their own processes — and replay resolves it.
+
+it('lets replay resolve a sync step the monitor expired mid-run', function () {
+    $run = SagaFlow::create(ExpiredMidRunWorkflow::class)->runSync();
+
+    // Not ActionClaimFailedException: the run fails on the expiry the monitor
+    // recorded, exactly as it would had the sweep landed a moment earlier.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'])->toBe(FlowExpiredException::class)
+        ->and($run->actions()->first()->status)->toBe(ActionStatus::Expired);
+});
+
+it('returns the fallback when an optional sync step is expired mid-run', function () {
+    $run = SagaFlow::create(OptionalExpiredMidRunWorkflow::class)->runSync();
+
+    // The whole point of distinguishing the two: an optional step resolves its
+    // fallback on replay, which a thrown invariant error would have skipped.
+    // A scalar run result is stored wrapped (FlowExecutor::normalizeResult()).
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result)->toBe(['value' => 'fallback']);
+});
+
+// --- The claim and its records are one unit ---
+
+it('releases the row when a listener throws while the claim is being recorded', function () {
+    $run = fencedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    Event::listen(ActionStarted::class, function (): void {
+        throw new RuntimeException('listener boom');
+    });
+
+    // Without the enclosing transaction the UPDATE would already be committed here,
+    // leaving a Running row that nothing ever executes and — with reclaim off, the
+    // default — nothing can ever pick up again.
+    expect(fn () => app(ActionRecorder::class)->startAction($action))
+        ->toThrow(RuntimeException::class, 'listener boom');
+
+    expect($action->fresh()->status)->toBe(ActionStatus::Pending)
+        ->and($action->fresh()->attempts)->toBe(0)
+        ->and($action->fresh()->started_at)->toBeNull();
+});

--- a/tests/Feature/ClaimTimestampsTest.php
+++ b/tests/Feature/ClaimTimestampsTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+
+/**
+ * The claim and the outcome writes are conditional UPDATEs rather than save(), which
+ * is a fair place to wonder whether updated_at still moves. It does: they go through
+ * an Eloquent builder, whose update() adds the timestamp column for a model that uses
+ * timestamps. These tests pin that, so the row's "last written" never silently
+ * freezes if one of them is ever rewritten against the base query builder.
+ */
+function timestampRun(): string
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ])->id;
+}
+
+it('moves updated_at when a step is claimed and its outcome recorded', function () {
+    $recorder = app(ActionRecorder::class);
+
+    $action = ActionRun::create([
+        'flow_run_id' => timestampRun(),
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    ActionRun::query()->whereKey($action->id)->update(['updated_at' => now()->subDay()]);
+    $stale = ActionRun::query()->findOrFail($action->id)->updated_at;
+
+    expect($recorder->startAction($action->fresh()))->toBeTrue()
+        ->and(ActionRun::query()->findOrFail($action->id)->updated_at->isAfter($stale))->toBeTrue();
+
+    $claimed = ActionRun::query()->findOrFail($action->id);
+    ActionRun::query()->whereKey($action->id)->update(['updated_at' => now()->subDay()]);
+
+    expect($recorder->completeAction($claimed, ['label' => 'ok']))->toBeTrue()
+        ->and(ActionRun::query()->findOrFail($action->id)->updated_at->isAfter($stale))->toBeTrue();
+});
+
+it('moves updated_at when the monitor expires a step', function () {
+    $recorder = app(ActionRecorder::class);
+
+    $action = ActionRun::create([
+        'flow_run_id' => timestampRun(),
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    ActionRun::query()->whereKey($action->id)->update(['updated_at' => now()->subDay()]);
+    $stale = ActionRun::query()->findOrFail($action->id)->updated_at;
+
+    expect($recorder->expireAction($action->fresh(), ['message' => 'deadline']))->toBeTrue()
+        ->and(ActionRun::query()->findOrFail($action->id)->updated_at->isAfter($stale))->toBeTrue();
+});
+
+it('moves updated_at when a compensation is claimed and settled', function () {
+    $recorder = app(CompensationRecorder::class);
+
+    $compensation = CompensationRun::create([
+        'flow_run_id' => timestampRun(),
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    CompensationRun::query()->whereKey($compensation->id)->update(['updated_at' => now()->subDay()]);
+    $stale = CompensationRun::query()->findOrFail($compensation->id)->updated_at;
+
+    expect($recorder->startCompensation($compensation->fresh()))->toBeTrue()
+        ->and(CompensationRun::query()->findOrFail($compensation->id)->updated_at->isAfter($stale))->toBeTrue();
+
+    $claimed = CompensationRun::query()->findOrFail($compensation->id);
+    CompensationRun::query()->whereKey($compensation->id)->update(['updated_at' => now()->subDay()]);
+
+    expect($recorder->completeCompensation($claimed, 'undone'))->toBeTrue()
+        ->and(CompensationRun::query()->findOrFail($compensation->id)->updated_at->isAfter($stale))->toBeTrue();
+});

--- a/tests/Feature/ParallelEarlyBatchCloseTest.php
+++ b/tests/Feature/ParallelEarlyBatchCloseTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ParallelFailurePolicy;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\RunParallelActionJob;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParallelEchoWorkflow;
+use Illuminate\Bus\BatchRepository;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A parallel block is woken exactly once, by its batch's finally callback. That is
+ * safe only while the batch cannot finish before its own jobs do — and an
+ * at-least-once queue can break that: a duplicate delivery that loses its claim
+ * returns quietly and drives the pending count to zero while the live worker is still
+ * executing. The callback fires then, the join replays against a step still Running
+ * and parks the run, and Laravel will not fire the callback again — its condition is
+ * (pendingJobs - failedJobs) === 0, and the next decrement takes the count to -1.
+ *
+ * The live worker's own completion is therefore the last chance anyone has to notice.
+ */
+function closedBatchId(): string
+{
+    $batch = Bus::batch([])->name('parallel:test')->allowFailures()->dispatch();
+
+    app(BatchRepository::class)->markAsFinished($batch->id);
+
+    return $batch->id;
+}
+
+function parallelStep(): ActionRun
+{
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => ParallelEchoWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+
+    return ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'parallel_group' => 1,
+        'attempts' => 0,
+        'arguments' => app(Serializer::class)->serialize(['value']),
+    ]);
+}
+
+function queuedResumeCount(): int
+{
+    return DB::connection('testing')->table('jobs')
+        ->where('payload', 'like', '%ResumeWorkflowJob%')
+        ->count();
+}
+
+it('wakes the run itself when the batch was already closed by someone else', function () {
+    useDatabaseQueue();
+
+    $action = parallelStep();
+
+    $job = new RunParallelActionJob($action->id, MakeValueAction::class, ParallelFailurePolicy::FailFast);
+    $job->withBatchId(closedBatchId());
+
+    $job->handle(app(ActionDispatcher::class));
+
+    // The step really did run and record its result — this is not a lost claim.
+    expect($action->fresh()->status)->toBe(ActionStatus::Completed)
+        // Without the extra wake this result would sit here with nothing left to
+        // notice it: the join already replayed and parked the run.
+        ->and(queuedResumeCount())->toBe(1);
+});
+
+it('does not wake the run while the batch is still open', function () {
+    useDatabaseQueue();
+
+    $action = parallelStep();
+
+    $batch = Bus::batch([])->name('parallel:test')->allowFailures()->dispatch();
+
+    // Not marked finished: the ordinary case, where this job's own completion is what
+    // will close the batch and ResumeParallelBlock is the single wake.
+    $job = new RunParallelActionJob($action->id, MakeValueAction::class, ParallelFailurePolicy::FailFast);
+    $job->withBatchId($batch->id);
+
+    $job->handle(app(ActionDispatcher::class));
+
+    expect($action->fresh()->status)->toBe(ActionStatus::Completed)
+        ->and(queuedResumeCount())->toBe(0);
+});
+
+it('does not wake the run when this worker never had the claim', function () {
+    useDatabaseQueue();
+
+    $action = parallelStep();
+
+    // Somebody else already completed the step; this delivery loses the claim and has
+    // no result of its own for anyone to miss.
+    $action->status = ActionStatus::Completed;
+    $action->save();
+
+    $job = new RunParallelActionJob($action->id, MakeValueAction::class, ParallelFailurePolicy::FailFast);
+    $job->withBatchId(closedBatchId());
+
+    $job->handle(app(ActionDispatcher::class));
+
+    expect(queuedResumeCount())->toBe(0);
+});
+
+it('records the early close in the anomaly log', function () {
+    useDatabaseQueue();
+
+    $path = sys_get_temp_dir().'/saga-early-batch-'.uniqid().'.log';
+    logToFile($path);
+
+    $action = parallelStep();
+
+    $job = new RunParallelActionJob($action->id, MakeValueAction::class, ParallelFailurePolicy::FailFast);
+    $job->withBatchId(closedBatchId());
+
+    $job->handle(app(ActionDispatcher::class));
+
+    // The only signature this class of failure leaves. A steady stream of it means the
+    // queue is redelivering faster than the work completes, or locks are off.
+    expect(file_get_contents($path))->toContain('batch_finished_early')
+        ->and(file_get_contents($path))->toContain($action->id);
+});

--- a/tests/Feature/ReclaimStaleRunningTest.php
+++ b/tests/Feature/ReclaimStaleRunningTest.php
@@ -1,0 +1,355 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Middleware\LockMiddlewareFactory;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ReclaimOverrideWorkflow;
+use Illuminate\Queue\Middleware\WithoutOverlapping;
+
+/**
+ * Issue #13's `actions.reclaim.stale_running` / `sagas.reclaim.stale_running`: an
+ * opt-in, off-by-default mechanism that lets a Running row be claimed again once it
+ * has sat at least its own reclaim_stale_after_seconds since started_at. Every test
+ * here that touches ActionRecorder::startAction() directly mirrors the style already
+ * used for SignalRecorder's compare-and-swap in RetryOnSignalQueuedTest.
+ */
+function stagedRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+}
+
+it('does not let a Running action be reclaimed by default (mechanism off)', function () {
+    $run = stagedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subDay(),
+        'attempts' => 1,
+        // reclaim_stale_after_seconds left null — today's behaviour, unchanged.
+    ]);
+
+    expect(app(ActionRecorder::class)->startAction($action))->toBeFalse();
+});
+
+it('does not reclaim a Running action before its own threshold has elapsed', function () {
+    $run = stagedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(10),
+        'reclaim_stale_after_seconds' => 900,
+        // Claimed 10s ago: the deadline is still 890s away.
+        'reclaim_stale_at' => now()->subSeconds(10)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    expect(app(ActionRecorder::class)->startAction($action))->toBeFalse();
+});
+
+it('reclaims a Running action once its own threshold has elapsed', function () {
+    $run = stagedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(1000),
+        'reclaim_stale_after_seconds' => 900,
+        // What the claim would have written 1000s ago: started_at + threshold, so
+        // the deadline is 100s in the past and the row is due for reclaim.
+        'reclaim_stale_at' => now()->subSeconds(1000)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    expect(app(ActionRecorder::class)->startAction($action))->toBeTrue()
+        ->and($action->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($action->fresh()->attempts)->toBe(2);
+});
+
+it('leaves reclaim_stale_after_seconds null on a freshly scheduled action when config is off (default)', function () {
+    $run = stagedRun();
+
+    $action = app(ActionRecorder::class)->scheduleAction($run, 0, new ActionSchedule(MakeValueAction::class, ['x']));
+
+    expect($action->reclaim_stale_after_seconds)->toBeNull();
+});
+
+it('resolves reclaim_stale_after_seconds from config once the mechanism is globally enabled', function () {
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.after_seconds', 123);
+
+    $run = stagedRun();
+
+    $action = app(ActionRecorder::class)->scheduleAction($run, 0, new ActionSchedule(MakeValueAction::class, ['x']));
+
+    expect($action->reclaim_stale_after_seconds)->toBe(123);
+});
+
+it('lets a per-action explicit threshold win regardless of the enabled flags', function () {
+    $run = SagaFlow::create(ReclaimOverrideWorkflow::class)
+        ->withArguments(42)
+        ->runSync();
+
+    expect($run->actions()->first()->reclaim_stale_after_seconds)->toBe(42);
+});
+
+it('lets a per-action override force-enable reclaim (config default seconds) even when config is off', function () {
+    $run = SagaFlow::create(ReclaimOverrideWorkflow::class)
+        ->withArguments(null, true)
+        ->runSync();
+
+    expect($run->actions()->first()->reclaim_stale_after_seconds)
+        ->toBe((int) config('saga-lara-flow.actions.reclaim.stale_running.after_seconds'));
+});
+
+it('lets a per-action override force-disable reclaim even when config is globally on', function () {
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+
+    $run = SagaFlow::create(ReclaimOverrideWorkflow::class)
+        ->withArguments(null, false)
+        ->runSync();
+
+    expect($run->actions()->first()->reclaim_stale_after_seconds)->toBeNull();
+});
+
+it('resolves the compensation-side reclaim threshold independently of the action-side one', function () {
+    // The second step in ReclaimOverrideWorkflow always fails, forcing a real
+    // rollback so the registered compensation gets its own CompensationRun row.
+    $run = SagaFlow::create(ReclaimOverrideWorkflow::class)
+        ->withArguments(42, null, 77)
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->actions()->first()->reclaim_stale_after_seconds)->toBe(42)
+        ->and($run->compensations()->first()->reclaim_stale_after_seconds)->toBe(77);
+});
+
+it('gives RunCompensationJob its own WithoutOverlapping lock, independent of the action lock', function () {
+    $middleware = app(LockMiddlewareFactory::class)->compensationMiddleware('comp-run-id');
+
+    expect($middleware)->toHaveCount(1)
+        ->and($middleware[0])->toBeInstanceOf(WithoutOverlapping::class);
+
+    $actionMiddleware = app(LockMiddlewareFactory::class)->actionMiddleware('comp-run-id');
+
+    // Same raw id, different lock key prefix ("action:" vs "compensation:"), so the
+    // two locks never collide even if called for the same underlying id by mistake.
+    expect($middleware[0])->not->toEqual($actionMiddleware[0]);
+});
+
+it('returns no lock middleware for compensations when locking is disabled', function () {
+    config()->set('saga-lara-flow.locks.enabled', false);
+
+    expect(app(LockMiddlewareFactory::class)->compensationMiddleware('comp-run-id'))->toBe([]);
+});
+
+it('inherits the action TTL when an application published its config before compensation_ttl_seconds existed', function () {
+    // Exactly what shallow config merging leaves behind: the host's own 'locks'
+    // array, tuned for long steps, with no key for the one added in 1.2.0.
+    config()->set('saga-lara-flow.locks.compensation_ttl_seconds', null);
+    config()->set('saga-lara-flow.locks.action_ttl_seconds', 3600);
+
+    $middleware = app(LockMiddlewareFactory::class)->compensationMiddleware('comp-run-id');
+
+    expect($middleware[0]->expiresAfter)->toBe(3600);
+});
+
+it('never turns a missing or zero TTL into a lock that outlives the worker', function () {
+    // Zero reaches Redis as SETNX with no expiry, so a worker killed before
+    // WithoutOverlapping's finally runs would wedge the row for good.
+    config()->set('saga-lara-flow.locks.compensation_ttl_seconds', 0);
+    config()->set('saga-lara-flow.locks.action_ttl_seconds', 0);
+
+    $middleware = app(LockMiddlewareFactory::class)->compensationMiddleware('comp-run-id');
+
+    expect($middleware[0]->expiresAfter)->toBeGreaterThan(0);
+});
+
+it('redispatches a stale Running action enabled per step while reclaim is globally off', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', false);
+
+    $run = stagedRun();
+
+    // A step that opted itself in via ->reclaimStaleAfter()/->enableStaleReclaim():
+    // the per-step override wins over the global switch, here as everywhere else.
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(1000),
+        'reclaim_stale_after_seconds' => 900,
+        'reclaim_stale_at' => now()->subSeconds(1000)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(1);
+
+    drainQueue();
+
+    expect($action->fresh()->status)->toBe(ActionStatus::Completed);
+});
+
+it('reaches a due row that a backlog of not-yet-due rows would otherwise hide', function () {
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.batch_size', 2);
+
+    $run = stagedRun();
+
+    // Older rows with long windows that have NOT elapsed. Ordered by started_at they
+    // sit ahead of the due row below, so a candidate window filtered afterwards in
+    // PHP would be filled entirely with them, pass after pass.
+    foreach (range(0, 9) as $i) {
+        ActionRun::create([
+            'flow_run_id' => $run->id,
+            'sequence' => $i + 1,
+            'action_class' => MakeValueAction::class,
+            'arguments' => ['x'],
+            'status' => ActionStatus::Running,
+            'started_at' => now()->subSeconds(5000 + $i),
+            'reclaim_stale_after_seconds' => 86400,
+            'reclaim_stale_at' => now()->addSeconds(80000),
+            'attempts' => 1,
+        ]);
+    }
+
+    // Newer, short window, already elapsed — the row that actually needs recovering.
+    $due = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(60),
+        'reclaim_stale_after_seconds' => 30,
+        'reclaim_stale_at' => now()->subSeconds(30),
+        'attempts' => 1,
+    ]);
+
+    $candidates = collect(app(ActionRunRepository::class)->dueForStaleRunningRepair(2, 10));
+
+    expect($candidates->pluck('id'))->toContain($due->id);
+});
+
+// --- FlowDoctor R3: active recovery for a stuck sequential Running action ---
+
+it('redispatches a stuck sequential Running action once past its own reclaim window', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+
+    $run = stagedRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(1000),
+        'reclaim_stale_after_seconds' => 900,
+        // What the claim would have written 1000s ago: started_at + threshold, so
+        // the deadline is 100s in the past and the row is due for reclaim.
+        'reclaim_stale_at' => now()->subSeconds(1000)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(1);
+
+    drainQueue();
+
+    expect($action->fresh()->status)->toBe(ActionStatus::Completed);
+});
+
+it('does not touch a Running action still inside its reclaim window', function () {
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+
+    $run = stagedRun();
+
+    ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(10),
+        'reclaim_stale_after_seconds' => 900,
+        // Claimed 10s ago: the deadline is still 890s away.
+        'reclaim_stale_at' => now()->subSeconds(10)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0);
+});
+
+it('never touches a stale Running action when redispatch_stale_running_actions is off', function () {
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+    config()->set('saga-lara-flow.repair.redispatch_stale_running_actions', false);
+
+    $run = stagedRun();
+
+    ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(1000),
+        'reclaim_stale_after_seconds' => 900,
+        // What the claim would have written 1000s ago: started_at + threshold, so
+        // the deadline is 100s in the past and the row is due for reclaim.
+        'reclaim_stale_at' => now()->subSeconds(1000)->addSeconds(900),
+        'attempts' => 1,
+    ]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0);
+});
+
+it('never touches a stale Running action belonging to a parallel block', function () {
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+
+    $run = stagedRun();
+
+    ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'arguments' => ['x'],
+        'status' => ActionStatus::Running,
+        'started_at' => now()->subSeconds(1000),
+        'reclaim_stale_after_seconds' => 900,
+        'parallel_group' => 1,
+        'attempts' => 1,
+    ]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0);
+});

--- a/tests/Feature/UnfinishedCompensationTest.php
+++ b/tests/Feature/UnfinishedCompensationTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Data\CompensationDefinition;
+use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationEntry;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\SagaRunner;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+
+/**
+ * A compensation whose worker died leaves its row non-terminal. Nothing used to
+ * notice: the level's outcome was read by looking for Failed rows only, so the
+ * rollback carried on and finalized, and the run ended up looking exactly like one
+ * that had unwound cleanly — while one step was never undone and no record of that
+ * existed anywhere.
+ *
+ * Unwinding further on top of a step that may still stand is precisely what the Stop
+ * policy exists to prevent, so an unfinished compensation now halts the rollback on
+ * the same terms a failed one does, and is reported the same way.
+ */
+function rollbackRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Running,
+        'arguments' => [],
+    ]);
+}
+
+function strandedCompensation(FlowRun $run, bool $continueOnFailure = false): CompensationRun
+{
+    return CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Running,
+        'continue_on_failure' => $continueOnFailure,
+        'attempts' => 1,
+    ]);
+}
+
+it('halts a Stop-policy rollback when a compensation never reached a terminal state', function () {
+    $run = rollbackRun();
+    $stuck = strandedCompensation($run);
+
+    $remaining = [[new CompensationEntry(
+        actionRunId: 'unused',
+        sequence: 1,
+        definition: CompensationDefinition::forClass(UndoAction::class, ['later']),
+    )]];
+
+    app(SagaRunner::class)->advance($run->id, $remaining, null, FlowStatus::Failed, [$stuck->id]);
+
+    // The next level must never have been dispatched: its compensation row would
+    // have been registered by dispatchLevel() before the batch went out.
+    expect($run->fresh()->compensations()->count())->toBe(1)
+        ->and($run->fresh()->status)->toBe(FlowStatus::Failed);
+});
+
+it('records the unfinished compensation as the run\'s secondary cause', function () {
+    $run = rollbackRun();
+    $stuck = strandedCompensation($run);
+
+    app(SagaRunner::class)->advance($run->id, [], null, FlowStatus::Failed, [$stuck->id]);
+
+    $exception = $run->fresh()->exception;
+
+    expect($exception['compensation']['message'] ?? null)
+        ->toContain('had not finished when its rollback level ended')
+        ->and($exception['compensation']['message'])->toContain('running');
+});
+
+it('lets a Continue-policy rollback carry on past an unfinished compensation', function () {
+    useDatabaseQueue();
+
+    $run = rollbackRun();
+    $stuck = strandedCompensation($run, continueOnFailure: true);
+
+    $remaining = [[new CompensationEntry(
+        actionRunId: 'unused',
+        sequence: 1,
+        definition: CompensationDefinition::forClass(UndoAction::class, ['later']),
+    )]];
+
+    app(SagaRunner::class)->advance($run->id, $remaining, null, FlowStatus::Failed, [$stuck->id]);
+
+    // Continue means the level's outcome does not stop the unwind, so the next
+    // level's compensation row was registered and dispatched.
+    expect($run->fresh()->compensations()->count())->toBe(2);
+});
+
+it('still prefers a real failure over an unfinished compensation as the cause', function () {
+    $run = rollbackRun();
+
+    $failed = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Failed,
+        'exception' => ['message' => 'undo blew up'],
+        'continue_on_failure' => false,
+        'attempts' => 1,
+    ]);
+
+    strandedCompensation($run)->update(['sequence' => 1]);
+
+    app(SagaRunner::class)->advance($run->id, [], null, FlowStatus::Failed, [$failed->id]);
+
+    // A failure carries its own cause, which is the more useful thing to surface.
+    expect($run->fresh()->exception['compensation']['message'] ?? null)->toContain('failed')
+        ->and($run->fresh()->exception['compensation']['cause']['message'] ?? null)->toBe('undo blew up');
+});

--- a/tests/Fixtures/ExpiredMidRunAction.php
+++ b/tests/Fixtures/ExpiredMidRunAction.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+
+/**
+ * Action whose row the monitor expires while it is still running.
+ *
+ * The monitor is a separate process sweeping the same rows a sync run creates, so
+ * this race reaches inline execution too. The write below is what
+ * ActionRecorder::expireAction() performs, reproduced in one process — and unlike a
+ * rival claim it leaves `attempts` alone, which is why the outcome fence needs its
+ * status condition and not just the attempt counter.
+ *
+ * The step executing right now is the only Running row there is, so it needs no
+ * argument to find itself.
+ */
+final class ExpiredMidRunAction extends Action
+{
+    public function handle(): string
+    {
+        ActionRun::query()
+            ->where('status', ActionStatus::Running)
+            ->update([
+                'status' => ActionStatus::Expired,
+                'exception' => json_encode(['message' => 'deadline passed']),
+                'finished_at' => now(),
+            ]);
+
+        return 'too late';
+    }
+}

--- a/tests/Fixtures/ExpiredMidRunWorkflow.php
+++ b/tests/Fixtures/ExpiredMidRunWorkflow.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Sync workflow whose only step is expired by the monitor while it runs. The step is
+ * required, so replay must surface the expiry as a business failure.
+ */
+final class ExpiredMidRunWorkflow extends Workflow
+{
+    public function handle(): string
+    {
+        return $this->action(ExpiredMidRunAction::class)->run();
+    }
+}

--- a/tests/Fixtures/OptionalExpiredMidRunWorkflow.php
+++ b/tests/Fixtures/OptionalExpiredMidRunWorkflow.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * The optional twin of ExpiredMidRunWorkflow: replay must resolve the expiry into the
+ * step's fallback rather than failing the run.
+ */
+final class OptionalExpiredMidRunWorkflow extends Workflow
+{
+    public function handle(): string
+    {
+        return $this->action(ExpiredMidRunAction::class)
+            ->continueOnFailure()
+            ->fallbackValueOnFail('fallback')
+            ->run();
+    }
+}

--- a/tests/Fixtures/ReclaimOverrideWorkflow.php
+++ b/tests/Fixtures/ReclaimOverrideWorkflow.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Exercises the per-action and per-compensation reclaim overrides
+ * (reclaimStaleAfter()/enableStaleReclaim() and their compensation-side mirrors) so
+ * a test can inspect the resolved reclaim_stale_after_seconds column without
+ * reaching into the builder's private state. The second step always fails, forcing
+ * a real rollback so the registered compensation actually gets its own
+ * CompensationRun row to inspect — merely registering it (a completed step that is
+ * never rolled back) never creates one.
+ */
+final class ReclaimOverrideWorkflow extends Workflow
+{
+    public function handle(
+        ?int $seconds = null,
+        ?bool $enabled = null,
+        ?int $compensationSeconds = null,
+        ?bool $compensationEnabled = null,
+    ): void {
+        $action = $this->action(MakeValueAction::class, 'x')
+            ->compensateWith(UndoAction::class, 'x');
+
+        if ($seconds !== null) {
+            $action->reclaimStaleAfter($seconds);
+        }
+
+        if ($enabled !== null) {
+            $action->enableStaleReclaim($enabled);
+        }
+
+        if ($compensationSeconds !== null) {
+            $action->reclaimCompensationStaleAfter($compensationSeconds);
+        }
+
+        if ($compensationEnabled !== null) {
+            $action->enableCompensationStaleReclaim($compensationEnabled);
+        }
+
+        $action->run();
+
+        $this->action(ThrowingAction::class)->run();
+    }
+}

--- a/tests/Fixtures/ReclaimedMidRunAction.php
+++ b/tests/Fixtures/ReclaimedMidRunAction.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use RuntimeException;
+
+/**
+ * Action that loses its row to a competing worker while it is still running.
+ *
+ * Bumping `attempts` is exactly what a rival claim does, so this reproduces the
+ * reclaim race — worker B takes over a row worker A is still executing — inside a
+ * single process, without real concurrency. Whatever this action then returns (or
+ * throws) belongs to an executor that no longer owns the row.
+ */
+final class ReclaimedMidRunAction extends Action
+{
+    public function handle(string $actionRunId, bool $throw = false): string
+    {
+        $current = ActionRun::query()->findOrFail($actionRunId);
+
+        ActionRun::query()
+            ->whereKey($actionRunId)
+            ->update(['attempts' => $current->attempts + 1]);
+
+        if ($throw) {
+            throw new RuntimeException('zombie failure');
+        }
+
+        return 'zombie result';
+    }
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -99,3 +99,20 @@ if (! function_exists('useDatabaseQueue')) {
         return ['status' => $run->status, 'actions' => $actions];
     }
 }
+
+if (! function_exists('logToFile')) {
+    /**
+     * Point the package's anomaly log at a real single-file channel. The project uses
+     * no mocks, so the assertions read the file an operator would actually grep.
+     */
+    function logToFile(string $path): void
+    {
+        config()->set('logging.channels.saga_test', [
+            'driver' => 'single',
+            'path' => $path,
+            'level' => 'debug',
+        ]);
+
+        config()->set('saga-lara-flow.logging.channel', 'saga_test');
+    }
+}

--- a/tests/Unit/ActionClaimFailedExceptionTest.php
+++ b/tests/Unit/ActionClaimFailedExceptionTest.php
@@ -1,0 +1,21 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
+
+it('builds a clear message for a failed synchronous action claim', function () {
+    $exception = ActionClaimFailedException::forAction('App\\Actions\\ChargeCard', 2);
+
+    expect($exception->getMessage())
+        ->toContain('App\\Actions\\ChargeCard')
+        ->toContain('sequence 2')
+        ->toContain('broken invariant');
+});
+
+it('builds a clear message for a failed synchronous compensation claim', function () {
+    $exception = ActionClaimFailedException::forCompensation('App\\Actions\\RefundCard', 1);
+
+    expect($exception->getMessage())
+        ->toContain('App\\Actions\\RefundCard')
+        ->toContain('sequence 1')
+        ->toContain('broken invariant');
+});


### PR DESCRIPTION
Closes #13.

`RunActionJob` read an `ActionRun`, checked its status in PHP, and then called `ActionRecorder::startAction()`, which saved unconditionally. Between the read and the write the row could change hands — the doctor re-dispatched it, the monitor expired it, the queue redelivered the job — and the save overwrote that. `CompensationRecorder::startCompensation()` had the same shape against `compensation_runs`.

## The claim

Both transitions are now a single conditional `UPDATE`, the compare-and-swap already used by `SignalRecorder::claimWaiting()` — the only form every supported driver enforces atomically, since `lockForUpdate()` compiles to nothing on SQLite. The claim returns whether it won the row; a caller that loses it does not execute the step.

Claimable statuses are `Pending`, `Failed`, and `Running` past its reclaim deadline. `retry_signal_attempts` moved into the same `WHERE`, so a job from a superseded retry cycle loses the claim even when the cycle changed after its row was read — the scenario the issue describes. The status pre-checks in `RunActionJob` and `RunParallelActionJob` are gone; the claim is the single source of truth, which also removes the drift between those two lists.

The claim and its two records (`flow_events`, the Laravel event) share one transaction, so a listener throwing on `ActionStarted` cannot leave a row `Running` with nothing executing it.

## Reclaim

A `Running` row is claimable again only once its reclaim deadline has passed. The mechanism is opt-in and off by default, switched separately for actions (`actions.reclaim.stale_running`) and compensations (`sagas.reclaim.stale_running`), with per-step overrides on `ActionBuilder` and `SagaStepBuilder`.

The window resolves once at schedule time into `reclaim_stale_after_seconds`, and each claim derives an absolute `reclaim_stale_at` from it — the same "store the moment, not the interval" shape as `expires_at`. That keeps the comparison to one indexed, portable predicate, and lets the doctor order by the column it filters on.

**With reclaim off, a worker killed mid-execution leaves its row `Running` for good.** Replay reads it as still in flight and parks the run; `saga-flow:kick` does the same. That was true before this change too, but it was never documented; the reclaim guide and `UPGRADING.md` now state it and name the two ways to get automatic recovery.

## Fencing the outcome

Reclaim can hand a row to a second worker while the first is merely slow, so both may reach the outcome write. Every outcome write is now conditional on two things: the `attempts` value its own claim produced (the database increments it, so racing claims cannot collide), and the row still being `Running`.

The second condition guards a different rival: the monitor expires an overdue step without claiming it, so the fence alone would let a late worker overwrite that `Expired` with a `Completed`. `expireAction()` is conditional from the other side and now returns `bool`, so a step that completes just before the sweep reaches it is not demoted. Together: a recorded terminal state is never overwritten.

`compensation_runs` gained `attempts` for the same purpose.

## Recovery and visibility

- **Doctor rule R3** (`repair.redispatch_stale_running_actions`) actively re-dispatches sequential `Running` actions past their reclaim deadline. Batch-bound work stays out of scope: re-adding a job needs the batch id, which only Laravel's `job_batches` holds.
- **`RunCompensationJob` gained a `WithoutOverlapping` lock**, governed by `locks.compensation_ttl_seconds`. A missing key inherits `action_ttl_seconds`, and a zero or missing TTL can never produce a lock without an expiry — on Redis that would wedge the row permanently.
- **A compensation left unfinished when its level ends now stops the rollback** under the `Stop` policy and is recorded as the run's secondary cause. Previously only `Failed` rows were looked for, so a rollback could finalize with one step silently never undone.
- **`Runtime\AnomalyLog`** is a second journal beside `flow_events`, for the three things the engine absorbs silently: `claim_lost`, `outcome_rejected`, `batch_finished_early`. Configured via `logging.anomaly_level`; writing a line is best-effort so a misconfigured logger cannot fail a job that was giving up quietly.
- **`CompensationStepStarted`** / `compensation.step_started` — the per-row claim had no event at all before, and the CAS raises no Eloquent ones.

## Refactors carried along

`Data\ActionSchedule` replaces the tail of optional arguments that `ActionDispatcher::dispatch()`, `runInline()` and `ActionRecorder::scheduleAction()` passed between them. `ActionBuilder::run()` and `FlowDoctor::repair()` were split to bring their cognitive complexity down.

## Verification

278 tests / 1013 assertions; Pint (301 files) and PHPStan level 5 clean; docs build with no broken links. Every regression test was checked to fail without its fix.

Two rounds of adversarial review ran against this diff; the findings and the reasoning behind each decision are in the branch history rather than here.
