### PR TITLE
Stop wrapping a scalar workflow result in an envelope

### DIFF
--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ $run = SagaFlow::create(CheckoutWorkflow::class)
     ->runSync();
 
 $run->status;   // FlowStatus::Completed
-$run->result;   // the array handle() returned
+$run->result;   // the value handle() returned
 ```
 
 The queued and synchronous paths are guaranteed to reach the **same** final database state.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -237,6 +237,37 @@ Tag writing is otherwise unchanged: one value per key per run, last write wins. 
 normalisation now also sits on `Models\FlowTag` as a cast, so a `models.flow_tag` replacement should
 extend that model rather than reimplement it.
 
+### 12. A scalar workflow result is no longer wrapped
+
+`flow_runs.result` is a JSON column, and a workflow returning anything other than an array had that
+value stored as `{"value": ...}`. Nothing reversed the wrapper, so a parent calling
+`$this->child(...)->run()` on a child returning an `int` got `['value' => 42]`, and a host reading
+`$run->result` got the same.
+
+The result is now written the way an action result already was — straight through the serializer,
+with no envelope. A JSON column stores a bare scalar fine, and `Serializer::deserialize()` passes
+non-arrays through untouched, so the child seam resolves the value the child actually returned.
+
+Two things to check:
+
+**Code that unwrapped by hand.** For a run completed on this release, `$run->result['value']` is now
+just `$run->result`. Workflows returning an array are unaffected — those were never wrapped. Runs
+completed before the upgrade are the caveat below.
+
+**Rows completed before the upgrade keep their envelope, permanently.** They are neither migrated nor
+unwrapped on read: a wrapped `42` and a workflow that legitimately returned `['value' => 42]` are
+stored identically, so nothing automatic can tell them apart without corrupting the second case.
+
+That is not a one-off. `$run->result` on a pre-upgrade run returns the wrapper for as long as the row
+exists. And because a parent replays `handle()` from the top on every resume, a parent whose child
+completed before the upgrade resolves that child to the wrapper on **every** replay, not only the
+first one after the deploy.
+
+So while pre-upgrade rows are still being read, code that consumes a scalar result has to accept both
+shapes. Draining the affected parents before upgrading avoids the mixed period entirely. Note also
+that this release does not rescue a parent already parked over such a child and written against the
+unwrapped shape — that parent was failing before the upgrade and still fails after it.
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/docs/docs/child-workflows.md
+++ b/docs/docs/child-workflows.md
@@ -23,7 +23,8 @@ public function handle(): array
 ```
 
 `child(string $workflowClass, array $arguments = [])` takes the child's `handle()` arguments as an
-array. `run()` awaits the child and returns its result.
+array. `run()` awaits the child and returns whatever the child's `handle()` returned, scalars
+included.
 
 ## Close policies
 

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -15,7 +15,7 @@ $run = SagaFlow::create(CheckoutWorkflow::class)
     ->runSync();
 
 $run->status;   // FlowStatus::Completed
-$run->result;   // the array handle() returned
+$run->result;   // the value handle() returned
 ```
 
 The queued and synchronous paths are guaranteed to reach the **same** final database state — the only

--- a/src/Models/ActionRun.php
+++ b/src/Models/ActionRun.php
@@ -23,7 +23,7 @@ use Illuminate\Support\Carbon;
  * @property ?int $retry_signal_max_attempts
  * @property ?int $parallel_group
  * @property ?array<int|string, mixed> $arguments
- * @property ?array<int|string, mixed> $result
+ * @property mixed $result
  * @property ?array<int|string, mixed> $exception
  * @property int $attempts
  * @property bool $queue_attempts_exhausted

--- a/src/Models/CompensationRun.php
+++ b/src/Models/CompensationRun.php
@@ -20,7 +20,7 @@ use Illuminate\Support\Carbon;
  * @property bool $continue_on_failure
  * @property int $attempts
  * @property ?array<int|string, mixed> $arguments
- * @property ?array<int|string, mixed> $result
+ * @property mixed $result
  * @property ?array<int|string, mixed> $exception
  * @property ?Carbon $started_at
  * @property ?int $reclaim_stale_after_seconds

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -18,7 +18,7 @@ use Illuminate\Support\Carbon;
  * @property ?string $workflow_version
  * @property FlowStatus $status
  * @property ?array<int|string, mixed> $arguments
- * @property ?array<int|string, mixed> $result
+ * @property mixed $result
  * @property ?array<int|string, mixed> $exception
  * @property ?array<int|string, mixed> $tenancy_context
  * @property ?string $connection

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -165,7 +165,7 @@ class FlowExecutor
 
     private function completeFlow(FlowRun $flowRun, mixed $result): FlowRun
     {
-        $flowRun->result = $this->normalizeResult($result);
+        $flowRun->result = $this->serializer->serialize($result);
 
         $flowRun->markCompleted();
 
@@ -266,19 +266,5 @@ class FlowExecutor
         return (bool) config('saga-lara-flow.monitor.expiration.enabled')
             && $flowRun->expires_at !== null
             && $flowRun->expires_at->lessThanOrEqualTo(now());
-    }
-
-    /**
-     * @return array<int|string, mixed>|null
-     */
-    private function normalizeResult(mixed $result): ?array
-    {
-        $serialized = $this->serializer->serialize($result);
-
-        if ($serialized === null) {
-            return null;
-        }
-
-        return is_array($serialized) ? $serialized : ['value' => $serialized];
     }
 }

--- a/tests/Feature/ChildScalarResultTest.php
+++ b/tests/Feature/ChildScalarResultTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ChildThenSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ChildValueRelayWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ModelChildParentWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ScalarChildCompensationWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TypedScalarParentWorkflow;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(function () {
+    CompensationLog::reset();
+    // Run dispatched jobs inline on the default sync queue driver.
+    config()->set('saga-lara-flow.queue.after_commit', false);
+});
+
+it('hands a parent the scalar its child returned (sync)', function () {
+    $run = SagaFlow::create(ChildValueRelayWorkflow::class)->withArguments(42)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result['type'])->toBe('int')
+        ->and($run->result['received'])->toBe(42);
+});
+
+it('hands a parent the scalar its child returned over the real queue', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(ChildValueRelayWorkflow::class)->withArguments(42)->run();
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['type'])->toBe('int')
+        ->and($final->result['received'])->toBe(42);
+});
+
+it('lets a parent pass a child result straight into a typed parameter', function () {
+    $run = SagaFlow::create(TypedScalarParentWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result)->toBe('id-42');
+});
+
+it('keeps false, zero, an empty string and null distinguishable across the seam', function (mixed $value, string $type) {
+    $run = SagaFlow::create(ChildValueRelayWorkflow::class)->withArguments($value)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result['type'])->toBe($type)
+        ->and($run->result['received'])->toBe($value);
+})->with([
+    'false' => [false, 'bool'],
+    'true' => [true, 'bool'],
+    'zero' => [0, 'int'],
+    'empty string' => ['', 'string'],
+    'float' => [0.5, 'float'],
+    'null' => [null, 'null'],
+]);
+
+it('stores a scalar workflow result unwrapped on the run itself', function () {
+    $run = SagaFlow::create(TypedScalarParentWorkflow::class)->runSync();
+
+    // Read past the model cast: the column itself must hold the bare JSON value.
+    $stored = DB::table((new FlowRun)->getTable())->where('id', $run->id)->value('result');
+
+    expect($stored)->toBe('"id-42"');
+});
+
+it('resolves the child to the same scalar on the compensation-only replay', function () {
+    $run = SagaFlow::create(ScalarChildCompensationWorkflow::class)->runSync();
+
+    // Parked on awaitSignal('go').
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $compensated = SagaFlow::loadFlow($run->id)->compensate();
+
+    expect($compensated->status)->toBe(FlowStatus::Cancelled)
+        ->and(CompensationLog::all())->toBe(['child:int']);
+});
+
+// Pinning: an array result is stored as it stands, so a child that legitimately
+// returns ['value' => ...] is indistinguishable from a wrapped scalar. Nothing
+// unwraps it, which is why the wrapper was dropped at the write instead.
+it('leaves an array result exactly as the child returned it', function () {
+    $run = SagaFlow::create(ChildValueRelayWorkflow::class)
+        ->withArguments(['value' => 42])
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result['type'])->toBe('array')
+        ->and($run->result['received'])->toBe(['value' => 42]);
+});
+
+// Pinning: models travel as a reference array, a shape the write path never
+// touched and must keep not touching.
+it('rehydrates a model a child returned', function () {
+    $run = SagaFlow::create(ModelChildParentWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and($run->result['type'])->toBe(FlowRun::class);
+});
+
+// Pinning: a row written before the envelope was dropped keeps it, and the seam
+// resolves it as stored on every replay — the behaviour UPGRADING item 12
+// describes. Unwrapping it here would corrupt a child that legitimately
+// returned ['value' => ...].
+it('resolves a child stored with the old envelope exactly as it stands', function () {
+    $run = SagaFlow::create(ChildThenSignalWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $childId = $run->children()->first()->child_flow_run_id;
+
+    // What the write path produced before this release for a scalar result.
+    DB::table((new FlowRun)->getTable())
+        ->where('id', $childId)
+        ->update(['result' => json_encode(['value' => 42])]);
+
+    SagaFlow::loadFlow($run->id)->signal('go');
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->result['type'])->toBe('array')
+        ->and($final->result['received'])->toBe(['value' => 42]);
+});

--- a/tests/Feature/ClaimFencingTest.php
+++ b/tests/Feature/ClaimFencingTest.php
@@ -275,9 +275,8 @@ it('returns the fallback when an optional sync step is expired mid-run', functio
 
     // The whole point of distinguishing the two: an optional step resolves its
     // fallback on replay, which a thrown invariant error would have skipped.
-    // A scalar run result is stored wrapped (FlowExecutor::normalizeResult()).
     expect($run->status)->toBe(FlowStatus::Completed)
-        ->and($run->result)->toBe(['value' => 'fallback']);
+        ->and($run->result)->toBe('fallback');
 });
 
 // --- The claim and its records are one unit ---

--- a/tests/Feature/MonitorSignalTimeoutTest.php
+++ b/tests/Feature/MonitorSignalTimeoutTest.php
@@ -92,7 +92,7 @@ it('leaves an overdue wait open until the sweep runs', function () {
     $final = SagaFlow::findRun($run->id);
 
     expect($final->status)->toBe(FlowStatus::Completed)
-        ->and($final->result)->toBe(['value' => false])
+        ->and($final->result)->toBeFalse()
         ->and($final->signals()->first()->status)->toBe(SignalStatus::TimedOut);
 });
 
@@ -115,6 +115,6 @@ it('accepts a signal delivered after its deadline but before the sweep', functio
     $final = SagaFlow::findRun($run->id);
 
     expect($final->status)->toBe(FlowStatus::Completed)
-        ->and($final->result)->toBe(['value' => true])
+        ->and($final->result)->toBeTrue()
         ->and($final->signals()->first()->status)->toBe(SignalStatus::Consumed);
 });

--- a/tests/Fixtures/ChildThenSignalWorkflow.php
+++ b/tests/Fixtures/ChildThenSignalWorkflow.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Awaits a child, then parks on a signal, so resuming replays the child seam a
+ * second time against whatever the child row holds by then.
+ */
+final class ChildThenSignalWorkflow extends Workflow
+{
+    /**
+     * @return array{type: string, received: mixed}
+     */
+    public function handle(): array
+    {
+        $received = $this->child(EchoValueChildWorkflow::class, [42])->run();
+
+        $this->awaitSignal('go');
+
+        return ['type' => get_debug_type($received), 'received' => $received];
+    }
+}

--- a/tests/Fixtures/ChildValueRelayWorkflow.php
+++ b/tests/Fixtures/ChildValueRelayWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Parent that hands its own argument to a child and reports what came back,
+ * type included, so a test can assert the shape the child seam resolves.
+ */
+final class ChildValueRelayWorkflow extends Workflow
+{
+    /**
+     * @return array{type: string, received: mixed}
+     */
+    public function handle(mixed $value = null): array
+    {
+        $received = $this->child(EchoValueChildWorkflow::class, [$value])->run();
+
+        return ['type' => get_debug_type($received), 'received' => $received];
+    }
+}

--- a/tests/Fixtures/EchoValueChildWorkflow.php
+++ b/tests/Fixtures/EchoValueChildWorkflow.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Child workflow that returns whatever it was given, so a test can drive any
+ * return shape through the child seam from the parent's arguments.
+ */
+final class EchoValueChildWorkflow extends Workflow
+{
+    public function handle(mixed $value = null): mixed
+    {
+        return $value;
+    }
+}

--- a/tests/Fixtures/ModelChildParentWorkflow.php
+++ b/tests/Fixtures/ModelChildParentWorkflow.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Parent awaiting a model-returning child, reporting the class it received.
+ */
+final class ModelChildParentWorkflow extends Workflow
+{
+    /**
+     * @return array{type: string}
+     */
+    public function handle(): array
+    {
+        return ['type' => get_debug_type($this->child(ModelChildWorkflow::class)->run())];
+    }
+}

--- a/tests/Fixtures/ModelChildWorkflow.php
+++ b/tests/Fixtures/ModelChildWorkflow.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Child workflow returning an Eloquent model, which the serializer stores as a
+ * reference array rather than a plain value.
+ */
+final class ModelChildWorkflow extends Workflow
+{
+    public function handle(): FlowRun
+    {
+        $row = new FlowRun;
+        $row->fill(['workflow_class' => 'marker', 'status' => FlowStatus::Pending]);
+        $row->save();
+
+        return $row;
+    }
+}

--- a/tests/Fixtures/RecordChildResultCompensation.php
+++ b/tests/Fixtures/RecordChildResultCompensation.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+
+/**
+ * Compensation that records the type of the value it was registered with, so a
+ * test can see which shape the compensation-only replay resolved a child to.
+ */
+final class RecordChildResultCompensation extends Action
+{
+    /**
+     * @return array{recorded: string}
+     */
+    public function handle(mixed $value): array
+    {
+        CompensationLog::record('child:'.get_debug_type($value));
+
+        return ['recorded' => get_debug_type($value)];
+    }
+}

--- a/tests/Fixtures/ScalarChildCompensationWorkflow.php
+++ b/tests/Fixtures/ScalarChildCompensationWorkflow.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Registers a compensation carrying a completed child's result, then parks. A
+ * manual compensate() rebuilds the stack through the collecting replay, which
+ * resolves the child on its own branch of the seam.
+ */
+final class ScalarChildCompensationWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $value = $this->child(EchoValueChildWorkflow::class, [42])->run();
+
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(RecordChildResultCompensation::class, $value)
+            ->run();
+
+        $this->awaitSignal('go');
+    }
+}

--- a/tests/Fixtures/TypedScalarParentWorkflow.php
+++ b/tests/Fixtures/TypedScalarParentWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Parent that feeds a child's result straight into an int parameter — the shape
+ * an application writes, and the one that raises a TypeError when the seam
+ * hands back a wrapper instead of the scalar.
+ */
+final class TypedScalarParentWorkflow extends Workflow
+{
+    public function handle(): string
+    {
+        $id = $this->child(EchoValueChildWorkflow::class, [42])->run();
+
+        return $this->label($id);
+    }
+
+    private function label(int $id): string
+    {
+        return 'id-'.$id;
+    }
+}


### PR DESCRIPTION
Closes #25

`flow_runs.result` is a JSON column, and a workflow returning anything other than an array had that value stored as `{"value": ...}`. Nothing reversed the wrapper, so a parent calling `$this->child(...)->run()` on a child returning an `int` received `['value' => 42]`, and a host reading `$run->result` got the same. Feeding that straight into a typed parameter raises a `TypeError`.

A workflow result is now written the way an action result already was — through the serializer, with no envelope. A JSON column stores a bare scalar fine, and `Serializer::deserialize()` passes non-arrays through untouched, so both child seams resolve the value the child actually returned and `$run->result` holds it as it stands.

No read-side change was needed, and none was added: a wrapped `42` and a workflow that legitimately returned `['value' => 42]` are stored identically, so unwrapping on read would corrupt the second case. Rows completed before this change therefore keep their envelope; `UPGRADING.md` item 12 covers what that means for an upgrade, and a pinning test holds the behaviour in place.

The `@property` annotation for `result` is widened to `mixed` on `FlowRun`, `ActionRun` and `CompensationRun` — the latter two have stored scalars all along.