### PR TITLE
[Improvement/Breaking] Bulk retry signaling + different logic for "signal" vs "signalRetry" method families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to `saga-lara-flow` will be documented in this file.
 
 ## Unreleased
 
+### Atomic signalable guard on deliver
+
+`SignalDispatcher::deliver()` asserts the run is still Pending/Running/Waiting with a
+conditional `flow_runs` UPDATE inside the same transaction as the signal write, so a stale
+handle from `handles()` cannot persist a wake on a run that has already finished.
+
 ### `FlowQuery::whereId()`
 
 Filter by one or more run ids without dropping to `builder()`: `->whereId(...$runIds)`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to `saga-lara-flow` will be documented in this file.
 
+## Unreleased
+
+### `FlowQuery::whereId()`
+
+Filter by one or more run ids without dropping to `builder()`: `->whereId(...$runIds)`.
+
+### `signal` / `signalRetry` family split (breaking)
+
+`signal()` / `signalIfRunning()` reject a name that is a `retryOnSignal()` policy on the run
+(`CannotSignalRetryException`). Wake those steps with `signalRetry()` /
+`signalRetryIfRunning()` (optional name; no payload), or `php artisan saga-flow:signal-retry`.
+
+- Name omitted → must have an `awaiting_retry` step (`NoAwaitingRetrySignalException`).
+- Name given → must be a declared retry policy on the run (`InvalidRetrySignalException`), including
+  early delivery before the step parks.
+
+Replace `->signal('balance-refilled')` (and CLI `saga-flow:signal … balance-refilled`) with
+`->signalRetry('balance-refilled')` / `saga-flow:signal-retry`.
+
 ## v1.1.1 - 2026-08-24
 
 ### Documentation: deadlines and the expiration sweep

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ SagaFlow::loadFlow($runId)->signal('approval', ['approved' => true]);
 SagaFlow::loadFlow($runId)->signalIfRunning('approval', ['approved' => true]);
 ```
 
+`signal()` is for `awaitSignal()` waits (optional payload). A `retryOnSignal()` wake uses
+`signalRetry()` / `signalRetryIfRunning()` instead — `signal()` rejects those names. See
+[Retry on signal](#retry-on-signal) below.
+
 No `$runId`? Find the run by workflow and tag, then signal it. Use `signalable()` (alias `active()`),
 **not** `running()` — a flow parked on `awaitSignal()` is `Waiting`, not `Running`:
 
@@ -388,8 +392,10 @@ $this->action(ChargeCard::class, $orderId)
     ->run();
 ```
 
-Deliver `balance-refilled` the way you deliver any other signal and `ChargeCard` runs again, alone;
-earlier steps stay completed and un-compensated. The layers stack: Laravel's `$tries` first, then
+Deliver `balance-refilled` with `signalRetry()` (not `signal()` — that family rejects retry policy
+names) and `ChargeCard` runs again, alone; earlier steps stay completed and un-compensated. When you
+do not know which retry wake is open, omit the name on `signalRetry()` / `signalRetryIfRunning()`.
+The layers stack: Laravel's `$tries` first, then
 `retryOnSignal()`, then `continueOnFailure()`, then hard failure and compensation. When the budget is
 spent or the wait times out, the step fails exactly as it would have without the policy — same
 `ActionFailedException`, same rollback.
@@ -522,6 +528,9 @@ SagaFlow::query()->whereAwaitingSignal('approval')->get();
 
 // runs holding a step parked by retryOnSignal()
 SagaFlow::query()->whereAwaitingRetrySignal('balance-refilled')->handles();
+
+// narrow to known run ids without builder()
+SagaFlow::query()->whereId(...$runIds)->get();
 ```
 
 Status shortcuts: `running()`, `waiting()`, `completed()`, `failed()`, plus `active()` /

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,25 @@
 # Upgrading
 
+## Unreleased
+
+### `signal` vs `signalRetry` (breaking)
+
+Retry wakes no longer go through `signal()`. A name that matches a `retryOnSignal()` policy on the
+run raises `CannotSignalRetryException`. Use:
+
+```php
+SagaFlow::loadFlow($runId)->signalRetry('balance-refilled');
+// or omit the name when a step is awaiting_retry:
+SagaFlow::loadFlow($runId)->signalRetry();
+```
+
+```bash
+php artisan saga-flow:signal-retry {run} [name]
+```
+
+`saga-flow:signal` still delivers ordinary awaits (with optional `--payload`); it refuses retry
+names and points at `saga-flow:signal-retry`.
+
 ## From 1.1.x to 1.2.0
 
 > ### ⚠️ Run `php artisan migrate` immediately after upgrading

--- a/docs/docs/artisan-commands.md
+++ b/docs/docs/artisan-commands.md
@@ -14,6 +14,7 @@ routes** — everything is done through Artisan or the `SagaFlow` facade.
 | `saga-flow:list {--status=} {--tag=} {--workflow=} {--limit=50}` | List runs, newest first, with filters. |
 | `saga-flow:show {run} {--compact}` | Inspect a run: header, actions, signals, compensations, history. |
 | `saga-flow:signal {run} {name} {--payload=}` | Deliver a JSON-payload signal and wake the run. |
+| `saga-flow:signal-retry {run} {name?}` | Deliver a `retryOnSignal()` wake (no payload). |
 | `saga-flow:cancel {run} {--compensate}` | Cancel a non-terminal run; `--compensate` rolls back first. |
 | `saga-flow:kick {run}` | Manually re-drive a stuck run. |
 | `saga-flow:monitor` | Expire overdue runs/actions and time out waits. |
@@ -43,7 +44,8 @@ php artisan saga-flow:kick 01JABCDEF...
 
 A run parked by [retry on signal](./retry-on-signal.md) shows up as `waiting` in `saga-flow:list`,
 annotated with the signal it needs; `saga-flow:show` adds a **Retry** column with the signal, the
-spent budget, and the wait deadline. `saga-flow:signal` delivers the signal that restarts the step.
+spent budget, and the wait deadline. `saga-flow:signal-retry` delivers the wake that restarts the
+step (`saga-flow:signal` refuses retry policy names).
 
 Schedule `saga-flow:monitor` and `saga-flow:repair` for background maintenance — see
 [Expiration & monitoring](./expiration-and-monitoring.md).

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -45,8 +45,8 @@ alone; if it succeeds, the workflow continues to `ShipOrder` as if nothing had h
 )
 ```
 
-- **`$signal`** — the signal name to wait for. An ordinary signal: deliver it exactly the way you
-  deliver any other (see [Signals](./signals.md)).
+- **`$signal`** — the retry wake name. Deliver it with `signalRetry()` /
+  `saga-flow:signal-retry`, not `signal()` (see [Signals](./signals.md)).
 - **`$maxRetries`** — how many signal-gated retry cycles this step may spend. `null` falls back to
   `actions.retry_on_signal.max_retries` in the config, and then to unbounded.
 - **`$waitSeconds`** — how long *one* wait may last before the monitor gives up on it. A duration,
@@ -131,16 +131,21 @@ $this->saga()
     ->run();
 ```
 
-## Delivering the signal
+## Delivering the wake
 
-Nothing special — it is an ordinary signal:
+Retry wakes are **not** ordinary signals. Use `signalRetry()` / `signalRetryIfRunning()` —
+`signal()` rejects a name that is a `retryOnSignal()` policy on the run. For the full comparison
+(payload, exceptions, CLI), see [`signal()` vs `signalRetry()`](./signals.md#signal-vs-signalretry).
 
 ```php
-SagaFlow::loadFlow($runId)->signal('balance-refilled');
+SagaFlow::loadFlow($runId)->signalRetry();                  // whatever is awaiting_retry
+SagaFlow::loadFlow($runId)->signalRetry('balance-refilled'); // named policy (incl. early delivery)
+SagaFlow::loadFlow($runId)->signalRetryIfRunning();         // false on a terminal run
 ```
 
 ```bash
-php artisan saga-flow:signal 01JABCDEF... balance-refilled
+php artisan saga-flow:signal-retry 01JABCDEF...
+php artisan saga-flow:signal-retry 01JABCDEF... balance-refilled
 ```
 
 Usually you do not have the run id at hand. Query for it with `whereAwaitingRetrySignal()`, and
@@ -150,19 +155,41 @@ filter with `signalable()` (a parked run is `Waiting`, never `Running`):
 SagaFlow::query()
     ->whereWorkflow(CheckoutWorkflow::class)
     ->whereTag('customer', $customerId)
-    ->whereAwaitingRetrySignal('balance-refilled')
+    ->whereAwaitingRetrySignal() // any retry signal — or pass a name to narrow
     ->signalable()
     ->handles()
-    ->first()
-    ?->signal('balance-refilled');
+    ->each(fn ($handle) => $handle->signalRetry());
 ```
+
+### Bulk wake without knowing the signal names
+
+Several runs may be parked on different retry policies at once — `balance-refilled` on one,
+`stock-replenished` on another. To wake a known set of runs, each on whatever it is waiting for,
+combine `whereAwaitingRetrySignal()` (no name), `whereId(...)`, and nameless `signalRetry()`:
+
+```php
+$runIds = [/* … */];
+
+SagaFlow::query()
+    ->whereWorkflow(CheckoutWorkflow::class)
+    ->whereTag('tenant', $tenantId)
+    ->whereAwaitingRetrySignal()
+    ->signalable()
+    ->whereId(...$runIds)
+    ->handles()
+    ->each(fn ($handle) => $handle->signalRetry());
+```
+
+`whereAwaitingRetrySignal()` matches every parked retry; `signalRetry()` reads each run’s
+`retry_signal` and delivers it. Pass a name to either only when you intend to target one policy
+and leave the others parked.
 
 `whereAwaitingSignal()` is the wider filter: it also matches a run parked by `awaitSignal()` on that
 name. See [Tags & querying](./tags-and-querying.md#waits-and-parked-steps).
 
-The signal's **payload is not passed to the action**. Action arguments must stay identical across
-replays, so the retried step runs with the arguments it was given originally; the payload is stored
-on the signal row for auditing. If the retry needs new data, read it inside the action.
+A retry wake carries **no payload**. It only re-runs the parked step with the arguments it was
+scheduled with, so replay stays deterministic. If the step needs fresh data after the world
+changed, read it inside the action on the new attempt.
 
 ## Observing parked runs
 

--- a/docs/docs/signals.md
+++ b/docs/docs/signals.md
@@ -74,6 +74,42 @@ $delivered = SagaFlow::loadFlow($runId)->signalIfRunning('approval', ['approved'
 `signalIfRunning()` means *"unless the run has already finished"* — it delivers to **any
 non-terminal run**, not only a `Running` one.
 
+### `signal()` vs `signalRetry()`
+
+Two different seams, two delivery methods. Mixing them throws.
+
+| | `signal()` / `signalIfRunning()` | `signalRetry()` / `signalRetryIfRunning()` |
+|---|---|---|
+| **Use when** | The workflow is (or will be) on `awaitSignal('name')` | A step used `retryOnSignal('name')` and you want to wake / early-deliver that policy |
+| **Payload** | Yes — returned from `awaitSignal()` | No — wake only; the action re-runs with its original arguments |
+| **Name** | Required | Optional: omit to wake whatever is `awaiting_retry`; pass a name to target a declared policy |
+| **Wrong family** | `CannotSignalRetryException` if `$name` is a `retryOnSignal()` policy on the run | `InvalidRetrySignalException` if `$name` is not a retry policy on the run |
+| **CLI** | `saga-flow:signal {run} {name} [--payload=]` | `saga-flow:signal-retry {run} [name]` |
+
+```php
+// ordinary await
+SagaFlow::loadFlow($runId)->signal('approval', ['approved' => true]);
+
+// retry-on-signal wake (not signal('balance-refilled'))
+SagaFlow::loadFlow($runId)->signalRetry('balance-refilled');
+SagaFlow::loadFlow($runId)->signalRetry(); // any awaiting_retry step
+```
+
+Bulk wake for a set of parked runs (signal names may differ or be unknown):
+
+```php
+SagaFlow::query()
+    ->whereAwaitingRetrySignal()
+    ->signalable()
+    ->whereId(...$runIds)
+    ->handles()
+    ->each(fn ($handle) => $handle->signalRetry());
+```
+
+See [Bulk wake without knowing the signal names](./retry-on-signal.md#bulk-wake-without-knowing-the-signal-names).
+
+Full retry behaviour: [Retry on signal](./retry-on-signal.md).
+
 ### Finding the run to signal
 
 Often you do not have the `$runId` on hand — you know the workflow and a tag. Query for it:
@@ -95,13 +131,12 @@ trying to wake.
 
 ## Reviving a failed step
 
-A signal can also restart a step that already failed, instead of being awaited at a point in
-`handle()`. `->retryOnSignal('balance-refilled')` on an action parks it when it fails and re-runs it
-when that signal is delivered — using the same delivery API as everything above. See
-[Retry on signal](./retry-on-signal.md).
+That is `signalRetry()`, not `signal()` — see [`signal()` vs `signalRetry()`](#signal-vs-signalretry)
+above and [Retry on signal](./retry-on-signal.md).
 
 You can also deliver from the CLI — see [Artisan commands](./artisan-commands.md):
 
 ```bash
 php artisan saga-flow:signal {run} approval --payload='{"approved":true}'
+php artisan saga-flow:signal-retry {run} balance-refilled
 ```

--- a/docs/docs/tags-and-querying.md
+++ b/docs/docs/tags-and-querying.md
@@ -80,6 +80,7 @@ $stuck = SagaFlow::query()
   or `Waiting`. Use this to find a run to deliver a signal to: a flow parked on `awaitSignal()` is
   `Waiting`, not `Running`, so `running()` would miss it.
 - `whereWorkflow(string $workflowClass)`
+- `whereId(string ...$ids)` — one or more run ids
 - `whereAwaitingSignal(?string $name = null)` — runs whose wait for a signal is still open,
   whichever seam opened it (`awaitSignal()` or `retryOnSignal()`). A null `$name` matches any.
 - `whereAwaitingRetrySignal(?string $signal = null)` — runs holding a step parked by
@@ -92,7 +93,17 @@ SagaFlow::query()->whereAwaitingSignal('approval')->get();
 
 // only steps that failed and parked
 SagaFlow::query()->whereAwaitingRetrySignal('balance-refilled')->handles();
+
+// bulk wake: every parked retry among these ids, whatever each signal name is
+SagaFlow::query()
+    ->whereAwaitingRetrySignal()
+    ->signalable()
+    ->whereId(...$runIds)
+    ->handles()
+    ->each(fn ($handle) => $handle->signalRetry());
 ```
+
+See [Bulk wake without knowing the signal names](./retry-on-signal.md#bulk-wake-without-knowing-the-signal-names).
 
 ### Waits and parked steps
 

--- a/src/Console/Commands/FlowSignalCommand.php
+++ b/src/Console/Commands/FlowSignalCommand.php
@@ -2,6 +2,7 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Console\Commands;
 
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalRetryException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
 use DiscoveryUkraine\SagaLaraFlow\FlowManager;
@@ -9,7 +10,8 @@ use Illuminate\Console\Command;
 
 /**
  * Delivers an external signal to a run and wakes it. An optional --payload is a
- * JSON-encoded object/array passed to the waiting handle().
+ * JSON-encoded object/array passed to the waiting handle(). Retry-on-signal
+ * wakes use saga-flow:signal-retry instead.
  */
 class FlowSignalCommand extends Command
 {
@@ -52,6 +54,11 @@ class FlowSignalCommand extends Command
             $this->warn("Flow run [{$handle->id()}] is terminal; signal [$name] not delivered.");
 
             return self::SUCCESS;
+        } catch (CannotSignalRetryException $exception) {
+            $this->error($exception->getMessage());
+            $this->line('Use saga-flow:signal-retry for retryOnSignal() wakes.');
+
+            return self::FAILURE;
         }
 
         $this->info("Signal [$name] delivered to flow run [{$handle->id()}].");

--- a/src/Console/Commands/FlowSignalRetryCommand.php
+++ b/src/Console/Commands/FlowSignalRetryCommand.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Console\Commands;
+
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\NoAwaitingRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\FlowManager;
+use Illuminate\Console\Command;
+
+/**
+ * Delivers a retryOnSignal() wake to a run. Optional {name} targets a declared
+ * retry policy; omit it to wake whatever step is awaiting_retry.
+ */
+class FlowSignalRetryCommand extends Command
+{
+    protected $signature = 'saga-flow:signal-retry
+        {run : The flow run id}
+        {name? : The retry signal name (omit to wake any awaiting_retry step)}';
+
+    protected $description = 'Deliver a retry-on-signal wake to a saga flow run.';
+
+    public function handle(FlowManager $manager): int
+    {
+        try {
+            $handle = $manager->loadFlow((string) $this->argument('run'));
+        } catch (FlowNotFoundException) {
+            $this->error("Flow run [{$this->argument('run')}] not found.");
+
+            return self::FAILURE;
+        }
+
+        $name = $this->argument('name');
+        $name = is_string($name) && $name !== '' ? $name : null;
+
+        try {
+            $handle->signalRetry($name);
+        } catch (CannotSignalTerminalFlowException) {
+            $this->warn("Flow run [{$handle->id()}] is terminal; retry signal not delivered.");
+
+            return self::SUCCESS;
+        } catch (NoAwaitingRetrySignalException|InvalidRetrySignalException $exception) {
+            $this->error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $label = $name ?? 'awaiting retry';
+        $this->info("Retry signal [$label] delivered to flow run [{$handle->id()}].");
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Exceptions/CannotSignalRetryException.php
+++ b/src/Exceptions/CannotSignalRetryException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * Raised when signal() / signalIfRunning() is used with a name that is a
+ * retryOnSignal() policy on this run. Deliver those with signalRetry().
+ */
+class CannotSignalRetryException extends FlowException
+{
+    public static function for(FlowRun $flowRun, string $name): self
+    {
+        return new self(
+            "Flow run [{$flowRun->id}] treats [{$name}] as a retry signal; use signalRetry() instead of signal()."
+        );
+    }
+}

--- a/src/Exceptions/InvalidRetrySignalException.php
+++ b/src/Exceptions/InvalidRetrySignalException.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * Raised when signalRetry() is given a name that is not a retryOnSignal()
+ * policy on this run. Ordinary awaits use signal().
+ */
+class InvalidRetrySignalException extends FlowException
+{
+    public static function for(FlowRun $flowRun, string $name): self
+    {
+        return new self(
+            "Flow run [{$flowRun->id}] has no retryOnSignal() policy named [{$name}]; use signal() for ordinary awaits."
+        );
+    }
+}

--- a/src/Exceptions/NoAwaitingRetrySignalException.php
+++ b/src/Exceptions/NoAwaitingRetrySignalException.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+class NoAwaitingRetrySignalException extends FlowException
+{
+    public static function for(FlowRun $flowRun): self
+    {
+        return new self(
+            "Flow run [{$flowRun->id}] has no step awaiting a retry signal."
+        );
+    }
+}

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -6,8 +6,11 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotCancelTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalRetryException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\NoAwaitingRetrySignalException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ChildWorkflowManager;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -92,14 +95,21 @@ readonly class FlowHandle
     }
 
     /**
-     * Deliver an external signal to this run and wake it. Throws on a terminal run.
+     * Deliver an external signal to this run and wake it. Throws on a terminal
+     * run, or when $name is a retryOnSignal() policy on this run — those go
+     * through signalRetry() (no payload; wake-only).
      *
      * @param  array<int|string, mixed>  $payload
      *
      * @throws CannotSignalTerminalFlowException
+     * @throws CannotSignalRetryException
      */
     public function signal(string $name, array $payload = []): FlowRun
     {
+        if ($this->flowRun->actions()->whereRetrySignal($name)->exists()) {
+            throw CannotSignalRetryException::for($this->flowRun, $name);
+        }
+
         app(SignalDispatcher::class)->deliver($this->flowRun, $name, $payload);
 
         return $this->flowRun;
@@ -111,9 +121,12 @@ readonly class FlowHandle
      * already finished" — a signal reaches any non-terminal run (Pending, Running,
      * or Waiting, e.g. one parked on awaitSignal()), not only a Running one. (A
      * missing run cannot reach here — loadFlow() throws FlowNotFoundException before
-     * a handle is created.)
+     * a handle is created.) Still throws CannotSignalRetryException — that is the
+     * wrong delivery method, not a finished run.
      *
      * @param  array<int|string, mixed>  $payload
+     *
+     * @throws CannotSignalRetryException
      */
     public function signalIfRunning(string $name, array $payload = []): bool
     {
@@ -124,6 +137,72 @@ readonly class FlowHandle
         } catch (CannotSignalTerminalFlowException) {
             return false;
         }
+    }
+
+    /**
+     * Deliver a retryOnSignal() wake. Omit $name to wake whatever step is
+     * awaiting_retry; pass $name to target a declared retry policy (including
+     * early delivery before the step parks). No payload — a retry only re-runs
+     * the step with its original arguments.
+     *
+     * @throws CannotSignalTerminalFlowException
+     * @throws NoAwaitingRetrySignalException
+     * @throws InvalidRetrySignalException
+     */
+    public function signalRetry(?string $name = null): FlowRun
+    {
+        app(SignalDispatcher::class)->deliver(
+            $this->flowRun,
+            $this->resolveRetrySignal($name),
+            [],
+        );
+
+        return $this->flowRun;
+    }
+
+    /**
+     * Safe variant of signalRetry(): swallows the terminal-run rejection and
+     * reports whether the signal was delivered. Still throws when nothing is
+     * awaiting a retry (name omitted) or when $name is not a retry policy on
+     * this run — those are the wrong run / wrong method, not a finished one.
+     *
+     * @throws NoAwaitingRetrySignalException
+     * @throws InvalidRetrySignalException
+     */
+    public function signalRetryIfRunning(?string $name = null): bool
+    {
+        try {
+            $this->signalRetry($name);
+
+            return true;
+        } catch (CannotSignalTerminalFlowException) {
+            return false;
+        }
+    }
+
+    /**
+     * @throws NoAwaitingRetrySignalException
+     * @throws InvalidRetrySignalException
+     */
+    private function resolveRetrySignal(?string $name): string
+    {
+        if ($name !== null && ! $this->flowRun->actions()->whereRetrySignal($name)->exists()) {
+            throw InvalidRetrySignalException::for($this->flowRun, $name);
+        }
+
+        if ($name !== null) {
+            return $name;
+        }
+
+        $resolved = $this->flowRun->actions()
+            ->whereAwaitingRetrySignal()
+            ->value('retry_signal');
+
+        if (! is_string($resolved)) {
+            throw NoAwaitingRetrySignalException::for($this->flowRun);
+        }
+
+        return $resolved;
     }
 
     /**

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -163,8 +163,8 @@ readonly class FlowHandle
     /**
      * Safe variant of signalRetry(): swallows the terminal-run rejection and
      * reports whether the signal was delivered. Still throws when nothing is
-     * awaiting a retry (name omitted) or when $name is not a retry policy on
-     * this run — those are the wrong run / wrong method, not a finished one.
+     * awaiting a retry on a signalable run, or when $name is not a retry policy
+     * on this run — those are the wrong run / wrong method, not a finished one.
      *
      * @throws NoAwaitingRetrySignalException
      * @throws InvalidRetrySignalException
@@ -183,9 +183,14 @@ readonly class FlowHandle
     /**
      * @throws NoAwaitingRetrySignalException
      * @throws InvalidRetrySignalException
+     * @throws CannotSignalTerminalFlowException
      */
     private function resolveRetrySignal(?string $name): string
     {
+        if ($this->flowRun->isTerminal()) {
+            throw CannotSignalTerminalFlowException::for($this->flowRun);
+        }
+
         if ($name !== null && ! $this->flowRun->actions()->whereRetrySignal($name)->exists()) {
             throw InvalidRetrySignalException::for($this->flowRun, $name);
         }
@@ -194,15 +199,15 @@ readonly class FlowHandle
             return $name;
         }
 
-        $resolved = $this->flowRun->actions()
+        $retrySignal = $this->flowRun->actions()
             ->whereAwaitingRetrySignal()
             ->value('retry_signal');
 
-        if (! is_string($resolved)) {
-            throw NoAwaitingRetrySignalException::for($this->flowRun);
+        if (is_string($retrySignal)) {
+            return $retrySignal;
         }
 
-        return $resolved;
+        throw NoAwaitingRetrySignalException::for($this->flowRun);
     }
 
     /**

--- a/src/Models/ActionRun.php
+++ b/src/Models/ActionRun.php
@@ -4,6 +4,8 @@ namespace DiscoveryUkraine\SagaLaraFlow\Models;
 
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\Concerns\UsesSagaFlowConnection;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -68,6 +70,27 @@ class ActionRun extends Model
             'repair_attempts' => 'integer',
             'repair_available_at' => 'datetime',
         ];
+    }
+
+    #[Scope]
+    protected function whereRetrySignal(Builder $query, ?string $name = null): void
+    {
+        $query->where(function (Builder $query) use ($name) {
+            if ($name === null) {
+                $query->whereNotNull('retry_signal');
+
+                return;
+            }
+
+            $query->where('retry_signal', '=', $name);
+        });
+    }
+
+    #[Scope]
+    protected function whereAwaitingRetrySignal(Builder $query, ?string $name = null): void
+    {
+        $query->where('status', ActionStatus::AwaitingRetry)
+            ->whereRetrySignal($name);
     }
 
     public function flowRun(): BelongsTo

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -5,6 +5,8 @@ namespace DiscoveryUkraine\SagaLaraFlow\Models;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\Concerns\UsesSagaFlowConnection;
+use Illuminate\Database\Eloquent\Attributes\Scope;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -60,6 +62,12 @@ class FlowRun extends Model
             'repair_attempts' => 'integer',
             'repair_available_at' => 'datetime',
         ];
+    }
+
+    #[Scope]
+    protected function whereSignalable(Builder $query): void
+    {
+        $query->whereIn('status', FlowStatus::signalable());
     }
 
     public function actions(): HasMany

--- a/src/Queries/FlowQuery.php
+++ b/src/Queries/FlowQuery.php
@@ -60,6 +60,13 @@ readonly class FlowQuery
         return $this;
     }
 
+    public function whereId(string ...$ids): static
+    {
+        $this->builder->whereIn('id', $ids);
+
+        return $this;
+    }
+
     /**
      * Runs whose wait for a signal is still open, whichever seam opened it: an
      * explicit awaitSignal(), or a step parked by retryOnSignal(). A null $name

--- a/src/Runtime/SignalDispatcher.php
+++ b/src/Runtime/SignalDispatcher.php
@@ -3,18 +3,27 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 
 /**
  * Delivers an external signal into a run and wakes it. If the run is parked on a
  * matching awaitSignal, the open wait-signal is fulfilled in place; otherwise the
  * signal is stored as a floating Received row for a future awaitSignal to consume
- * (FIFO). Delivery runs outside the queue and holds no lock, so filling a signal is
- * a conditional write that falls back to the floating row when it loses.
- * Terminal runs reject signals.
+ * (FIFO).
+ *
+ * The run must still be signalable at write time: deliver() asserts that with a
+ * conditional UPDATE on flow_runs (same portable pattern as claiming a wait-signal)
+ * inside a transaction that also writes the signal row, so a stale in-memory
+ * FlowRun cannot store a wake on a run that has already finished. Filling a wait
+ * marker remains a conditional write that falls back to a floating row when it
+ * loses. Wake is dispatched after the transaction commits.
  */
 readonly class SignalDispatcher
 {
@@ -30,26 +39,58 @@ readonly class SignalDispatcher
      */
     public function deliver(FlowRun $flowRun, string $name, array $payload): FlowSignal
     {
-        if ($flowRun->isTerminal()) {
-            throw CannotSignalTerminalFlowException::for($flowRun);
-        }
+        $signal = $this->connection()->transaction(function () use ($flowRun, $name, $payload): FlowSignal {
+            $this->assertCanAcceptSignal($flowRun);
 
-        $waitingSignal = $this->repository->earliestWaiting($flowRun->id, $name);
+            $waitingSignal = $this->repository->earliestWaiting($flowRun->id, $name);
 
-        $signal = $waitingSignal === null
-            ? null
-            : $this->recorder->fulfilWaitingSignal($waitingSignal, $payload);
+            $signal = $waitingSignal === null
+                ? null
+                : $this->recorder->fulfilWaitingSignal($waitingSignal, $payload);
 
-        // No open wait-signal, or the one we found was claimed by a retry seam while
-        // we were writing: keep the delivery as a floating Received row rather than
-        // attaching it to a spent signal, where nothing would look for it again.
-        $signal ??= $this->recorder->storeReceivedSignal($flowRun, $name, $payload);
+            // No open wait-signal, or the one we found was claimed by a retry seam while
+            // we were writing: keep the delivery as a floating Received row rather than
+            // attaching it to a spent signal, where nothing would look for it again.
+            return $signal ?? $this->recorder->storeReceivedSignal($flowRun, $name, $payload);
+        });
 
         if (config('saga-lara-flow.signals.wake_workflow_on_signal')) {
             $this->wake($flowRun);
         }
 
         return $signal;
+    }
+
+    /**
+     * Assert the run is still Pending/Running/Waiting in the database. The
+     * conditional UPDATE is the atomic check (and row lock until commit); the
+     * updated_at touch is only so the UPDATE has a column to write.
+     *
+     * @throws CannotSignalTerminalFlowException
+     */
+    private function assertCanAcceptSignal(FlowRun $flowRun): void
+    {
+        $signalable = array_map(
+            static fn (FlowStatus $status): string => $status->value,
+            FlowStatus::signalable(),
+        );
+
+        $attributes = $flowRun->newInstance()
+            ->forceFill(['updated_at' => Carbon::now()])
+            ->getAttributes();
+
+        $alive = $flowRun->newQuery()
+            ->whereKey($flowRun->getKey())
+            ->whereIn('status', $signalable)
+            ->update($attributes) === 1;
+
+        $flowRun->refresh();
+
+        if ($alive) {
+            return;
+        }
+
+        throw CannotSignalTerminalFlowException::for($flowRun);
     }
 
     private function wake(FlowRun $flowRun): void
@@ -67,5 +108,10 @@ readonly class SignalDispatcher
         if (config('saga-lara-flow.queue.after_commit')) {
             $job->afterCommit();
         }
+    }
+
+    private function connection(): ConnectionInterface
+    {
+        return DB::connection(config('saga-lara-flow.database.connection') ?: null);
     }
 }

--- a/src/Runtime/SignalDispatcher.php
+++ b/src/Runtime/SignalDispatcher.php
@@ -3,7 +3,6 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
-use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
@@ -70,18 +69,13 @@ readonly class SignalDispatcher
      */
     private function assertCanAcceptSignal(FlowRun $flowRun): void
     {
-        $signalable = array_map(
-            static fn (FlowStatus $status): string => $status->value,
-            FlowStatus::signalable(),
-        );
-
         $attributes = $flowRun->newInstance()
             ->forceFill(['updated_at' => Carbon::now()])
             ->getAttributes();
 
         $alive = $flowRun->newQuery()
             ->whereKey($flowRun->getKey())
-            ->whereIn('status', $signalable)
+            ->whereSignalable()
             ->update($attributes) === 1;
 
         $flowRun->refresh();

--- a/src/SagaLaraFlowServiceProvider.php
+++ b/src/SagaLaraFlowServiceProvider.php
@@ -10,6 +10,7 @@ use DiscoveryUkraine\SagaLaraFlow\Console\Commands\FlowPruneCommand;
 use DiscoveryUkraine\SagaLaraFlow\Console\Commands\FlowRepairCommand;
 use DiscoveryUkraine\SagaLaraFlow\Console\Commands\FlowShowCommand;
 use DiscoveryUkraine\SagaLaraFlow\Console\Commands\FlowSignalCommand;
+use DiscoveryUkraine\SagaLaraFlow\Console\Commands\FlowSignalRetryCommand;
 use DiscoveryUkraine\SagaLaraFlow\Console\Commands\MakeActionCommand;
 use DiscoveryUkraine\SagaLaraFlow\Console\Commands\MakeWorkflowCommand;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
@@ -57,6 +58,7 @@ class SagaLaraFlowServiceProvider extends PackageServiceProvider
                 FlowShowCommand::class,
                 FlowCancelCommand::class,
                 FlowSignalCommand::class,
+                FlowSignalRetryCommand::class,
                 FlowPruneCommand::class,
                 FlowMonitorCommand::class,
                 FlowRepairCommand::class,

--- a/tests/Feature/QueryFilterTest.php
+++ b/tests/Feature/QueryFilterTest.php
@@ -65,6 +65,14 @@ it('filters by workflow class', function () {
         ->toBe([$this->completed->id]);
 });
 
+it('filters by run id', function () {
+    expect(SagaFlow::query()->whereId($this->running->id)->get()->pluck('id')->all())
+        ->toBe([$this->running->id]);
+
+    expect(SagaFlow::query()->whereId($this->running->id, $this->failed->id)->get()->pluck('id')->all())
+        ->toEqualCanonicalizing([$this->running->id, $this->failed->id]);
+});
+
 it('filters by tag key and value', function () {
     expect(SagaFlow::query()->whereTag('order', '1')->get()->pluck('id')->all())
         ->toEqualCanonicalizing([$this->running->id, $this->completed->id]);

--- a/tests/Feature/RetryOnSignalOperatorTest.php
+++ b/tests/Feature/RetryOnSignalOperatorTest.php
@@ -6,6 +6,10 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionAwaitingRetry;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalRetryException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\NoAwaitingRetrySignalException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -40,7 +44,7 @@ beforeEach(function () {
  */
 function driveAfterSignal(FlowRun $run): FlowRun
 {
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     return app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
 }
@@ -317,14 +321,14 @@ it('finds a parked run through the query API', function () {
         ->and(SagaFlow::query()->active()->count())->toBe(1);
 });
 
-it('drives a parked run to completion through saga-flow:signal', function () {
+it('drives a parked run to completion through saga-flow:signal-retry', function () {
     $run = parkedQueuedRun();
 
     expect($run->status)->toBe(FlowStatus::Waiting)
         ->and($run->actions()->where('sequence', 1)->first()->status)
         ->toBe(ActionStatus::AwaitingRetry);
 
-    Artisan::call('saga-flow:signal', ['run' => $run->id, 'name' => 'balance-refilled']);
+    Artisan::call('saga-flow:signal-retry', ['run' => $run->id, 'name' => 'balance-refilled']);
 
     drainQueue();
 
@@ -335,25 +339,90 @@ it('drives a parked run to completion through saga-flow:signal', function () {
         ->and(CompensationLog::all())->toBe([]);
 });
 
-it('carries a signal payload from saga-flow:signal into the retried run', function () {
+it('refuses saga-flow:signal when the name is a retry policy', function () {
     $run = parkedQueuedRun();
 
-    Artisan::call('saga-flow:signal', [
-        'run' => $run->id,
-        'name' => 'balance-refilled',
-        '--payload' => '{"topped_up":500}',
-    ]);
+    $exit = Artisan::call('saga-flow:signal', ['run' => $run->id, 'name' => 'balance-refilled']);
 
-    drainQueue();
+    expect($exit)->toBe(1)
+        ->and(Artisan::output())->toContain('signalRetry()')
+        ->and(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+});
 
-    $final = SagaFlow::findRun($run->id);
+it('delivers the parked retry signal without naming it', function () {
+    FlakyPaymentAction::reset(failures: 1);
 
-    expect($final->status)->toBe(FlowStatus::Completed);
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-retry')->runSync();
 
-    // The delivery that ended the wait is the marker at the step's own ordinal, and
-    // it kept the payload the operator sent.
-    $marker = $final->signals()->orderByDesc('id')->first();
+    expect($run->status)->toBe(FlowStatus::Waiting);
 
-    expect($marker->wait_sequence)->toBe(1)
-        ->and($marker->payload)->toBe(['topped_up' => 500]);
+    SagaFlow::loadFlow($run->id)->signalRetry();
+
+    $final = app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->retry_signal_attempts)->toBe(1);
+});
+
+it('delivers an explicitly named retry signal', function () {
+    FlakyPaymentAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-named')->runSync();
+
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
+
+    $final = app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($final->actions()->where('sequence', 1)->first()->retry_signal_attempts)->toBe(1);
+});
+
+it('reports signalRetryIfRunning true for a parked run', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-safe')->runSync();
+
+    expect(SagaFlow::loadFlow($run->id)->signalRetryIfRunning())->toBeTrue();
+});
+
+it('rejects signalRetry when no step is awaiting a retry and no name is given', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $handle = SagaFlow::loadFlow($run->id);
+
+    expect(fn () => $handle->signalRetry())->toThrow(NoAwaitingRetrySignalException::class);
+    expect(fn () => $handle->signalRetryIfRunning())->toThrow(NoAwaitingRetrySignalException::class);
+});
+
+it('reports signalRetryIfRunning false for a terminal parked run', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-cancel')->runSync();
+
+    SagaFlow::loadFlow($run->id)->cancel();
+
+    $handle = SagaFlow::loadFlow($run->id);
+
+    expect(fn () => $handle->signalRetry())->toThrow(CannotSignalTerminalFlowException::class);
+    expect($handle->signalRetryIfRunning())->toBeFalse();
+});
+
+it('rejects signal() when the name is a declared retry policy', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-family')->runSync();
+    $handle = SagaFlow::loadFlow($run->id);
+
+    expect(fn () => $handle->signal('balance-refilled'))->toThrow(CannotSignalRetryException::class);
+    expect(fn () => $handle->signalIfRunning('balance-refilled'))->toThrow(CannotSignalRetryException::class);
+});
+
+it('rejects signalRetry() when the name is not a retry policy on the run', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+    $handle = SagaFlow::loadFlow($run->id);
+
+    expect(fn () => $handle->signalRetry('go'))->toThrow(InvalidRetrySignalException::class);
+    expect(fn () => $handle->signalRetryIfRunning('go'))->toThrow(InvalidRetrySignalException::class);
 });

--- a/tests/Feature/RetryOnSignalOperatorTest.php
+++ b/tests/Feature/RetryOnSignalOperatorTest.php
@@ -405,8 +405,8 @@ it('reports signalRetryIfRunning false for a terminal parked run', function () {
 
     $handle = SagaFlow::loadFlow($run->id);
 
-    expect(fn () => $handle->signalRetry())->toThrow(CannotSignalTerminalFlowException::class);
-    expect($handle->signalRetryIfRunning())->toBeFalse();
+    expect(fn () => $handle->signalRetry())->toThrow(CannotSignalTerminalFlowException::class)
+        ->and($handle->signalRetryIfRunning())->toBeFalse();
 });
 
 it('rejects signal() when the name is a declared retry policy', function () {

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -94,7 +94,7 @@ it('retries the parked step through the real queue', function () {
     expect($run->status)->toBe(FlowStatus::Waiting)
         ->and($run->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     $final = SagaFlow::findRun($run->id);
@@ -124,7 +124,7 @@ it('gives up and rolls the saga back once the retry budget is spent', function (
 
     expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     $final = SagaFlow::findRun($run->id);
@@ -213,7 +213,7 @@ it('reaches the optional fallback only after the retry budget is spent', functio
         ->and($parked->actions()->count())->toBe(1)
         ->and($parked->actions()->first()->status)->toBe(ActionStatus::AwaitingRetry);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     $final = SagaFlow::findRun($run->id);
@@ -234,10 +234,10 @@ it('leaves the same ordinals behind whether or not the step was retried', functi
     $retried = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q6')->run();
     drainQueue();
 
-    SagaFlow::loadFlow($retried->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($retried->id)->signalRetry('balance-refilled');
     drainQueue();
 
-    SagaFlow::loadFlow($retried->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($retried->id)->signalRetry('balance-refilled');
     drainQueue();
 
     FlakyPaymentAction::reset();
@@ -274,7 +274,7 @@ it('does not lose a signal delivered between the failure and the parking', funct
     // Stop right after the attempt failed, before the resume that would park it.
     workUntilStatus($run, 1, ActionStatus::Failed);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     expect($run->signals()->where('status', SignalStatus::Received)->count())->toBe(1);
 
@@ -301,7 +301,14 @@ it('ignores a floating signal that predates the failed attempt', function () {
 
     $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q8')->run();
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    // Before any step is scheduled there is no declared retry policy yet, so the
+    // handle API would refuse this name — deliver through the dispatcher to plant
+    // the floating row the seam must ignore.
+    app(SignalDispatcher::class)->deliver(
+        SagaFlow::findRun($run->id),
+        'balance-refilled',
+        [],
+    );
 
     // Age it: this signal belongs to something that happened before the attempt that
     // is about to fail, so it must not be claimed by this step's retry.
@@ -369,7 +376,7 @@ it('waits for the queue to run out of attempts before spending a retry cycle', f
     expect($step->attempts)->toBe(1)
         ->and(UnreliablePaymentAction::$calls)->toBe(1);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     // Age it so it unambiguously predates the attempt still to come: this test is
     // about the gate, not about which attempt may claim a borderline signal.
@@ -406,7 +413,7 @@ it('ignores a queued job left over from an earlier retry cycle', function () {
     $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q11')->run();
     drainQueue();
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
@@ -530,7 +537,7 @@ function stageDispatchedRetry(string $orderId): ActionRun
     // created_at it was first scheduled with.
     ActionRun::query()->whereKey($step->id)->update(['created_at' => now()->subMinutes(10)]);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     workUntilStatus($run, 1, ActionStatus::Pending);
 
@@ -598,7 +605,7 @@ it('gives each retry cycle its own repair budget', function () {
         'repair_attempts' => (int) config('saga-lara-flow.repair.max_attempts'),
     ]);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     workUntilStatus($run, 1, ActionStatus::Pending);
 
@@ -680,7 +687,7 @@ it('still owes native attempts to a step on its second retry cycle', function ()
         ->and($step->attempts)->toBe(2)
         ->and($step->retry_signal_attempts)->toBe(0);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     // Stop inside cycle 1, after its first native attempt failed and before the
     // second one has run. attempts is cumulative, so it now reads 3 — the gate has to
@@ -879,7 +886,7 @@ it('adopts an abandoned wait signal instead of recording a second one', function
         ->and($parked->actions()->where('sequence', 1)->first()->status)
         ->toBe(ActionStatus::AwaitingRetry);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Completed);
@@ -914,7 +921,7 @@ it('rolls the consumption back when the retry transition fails', function () {
     });
 
     try {
-        SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+        SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
         drainQueue();
     } catch (Throwable) {
         // The explosion is the setup; the rows it leaves behind are the assertion.
@@ -948,7 +955,7 @@ it('leaves a delivered signal alone when the monitor times it out', function () 
     // this is its snapshot from before the delivery landed.
     $stale = $run->signals()->firstOrFail();
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     expect($marker->fresh()->status)->toBe(SignalStatus::Received);
 
@@ -1010,7 +1017,7 @@ it('reports a broken history contract when an awaitSignal lands on a parked step
         ->toThrow(HistoryContractMismatchException::class);
 });
 
-it('hands a delivered signal back with its payload intact', function () {
+it('delivers a retry wake with an empty payload', function () {
     useDatabaseQueue();
     FlakyPaymentAction::reset(failures: 99);
 
@@ -1023,15 +1030,13 @@ it('hands a delivered signal back with its payload intact', function () {
         $seen = $event->signal->payload;
     });
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled', ['topped_up' => 500]);
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     $stored = SagaFlow::findRun($run->id)->signals()->where('name', 'balance-refilled')->first();
 
-    // Filling a claim's own database-ready values back into the model would encode the
-    // payload twice: the row right, every listener seeing a JSON string. And this is
-    // the ordinary awaitSignal delivery path, not just the retry one.
-    expect($stored->payload)->toBe(['topped_up' => 500])
-        ->and($seen)->toBe(['topped_up' => 500]);
+    // Retry wakes carry no operator payload — only an ordinary awaitSignal delivery does.
+    expect($stored->payload)->toBe([])
+        ->and($seen)->toBe([]);
 });
 
 it('holds the step to the budget persisted at scheduling time', function () {
@@ -1051,7 +1056,7 @@ it('holds the step to the budget persisted at scheduling time', function () {
     // the operator is being shown.
     config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 5);
 
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
     drainQueue();
 
     $final = SagaFlow::findRun($run->id);

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -33,7 +33,7 @@ beforeEach(function () {
  */
 function refillAndDrive(FlowRun $run): FlowRun
 {
-    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+    SagaFlow::loadFlow($run->id)->signalRetry('balance-refilled');
 
     return app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
 }

--- a/tests/Feature/SignalTest.php
+++ b/tests/Feature/SignalTest.php
@@ -97,6 +97,24 @@ it('rejects a signal on a terminal run and reports it via signalIfRunning', func
     expect($handle->signalIfRunning('whatever'))->toBeFalse();
 });
 
+it('rejects a signal when the run became terminal after the handle was loaded', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+    $handle = SagaFlow::loadFlow($run->id);
+
+    expect($handle->status())->toBe(FlowStatus::Waiting);
+
+    // Finish the run in the database without refreshing the handle — the bulk
+    // path keeps this stale Waiting snapshot across handles()->each(...).
+    $run->markCompleted();
+
+    $signalsBefore = $run->signals()->count();
+
+    expect($handle->status())->toBe(FlowStatus::Waiting)
+        ->and($handle->signalIfRunning('go'))->toBeFalse()
+        ->and(fn () => $handle->signal('go'))->toThrow(CannotSignalTerminalFlowException::class)
+        ->and($run->signals()->count())->toBe($signalsBefore);
+});
+
 it('reports signalIfRunning true for a waiting run', function () {
     useDatabaseQueue();
 

--- a/tests/Feature/SignalWaitQueryTest.php
+++ b/tests/Feature/SignalWaitQueryTest.php
@@ -59,7 +59,7 @@ it('carries the failure snapshot the parked step was queried for', function () {
 it('still finds a step whose signal arrived but whose resume never did', function () {
     $parked = parkedRun();
 
-    SagaFlow::loadFlow($parked)->signal('balance-refilled');
+    SagaFlow::loadFlow($parked)->signalRetry('balance-refilled');
 
     // Delivery marks the wait Received; the step stays parked until replay resumes
     // the run. A resume that never arrives leaves the run visible only here.

--- a/tests/Unit/NoAwaitingRetrySignalExceptionTest.php
+++ b/tests/Unit/NoAwaitingRetrySignalExceptionTest.php
@@ -1,0 +1,17 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\NoAwaitingRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+it('builds a clear message naming the run', function () {
+    $run = new FlowRun;
+    $run->id = '01J000000000000000000RUNID';
+    $run->status = FlowStatus::Waiting;
+
+    $exception = NoAwaitingRetrySignalException::for($run);
+
+    expect($exception->getMessage())
+        ->toContain('01J000000000000000000RUNID')
+        ->toContain('no step awaiting a retry signal');
+});

--- a/tests/Unit/SignalRetryFamilyExceptionTest.php
+++ b/tests/Unit/SignalRetryFamilyExceptionTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalRetryException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidRetrySignalException;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+it('names the run and the retry signal when signal() is misused', function () {
+    $run = new FlowRun;
+    $run->id = '01J000000000000000000RUNID';
+    $run->status = FlowStatus::Waiting;
+
+    $exception = CannotSignalRetryException::for($run, 'balance-refilled');
+
+    expect($exception->getMessage())
+        ->toContain('01J000000000000000000RUNID')
+        ->toContain('balance-refilled')
+        ->toContain('signalRetry()');
+});
+
+it('names the run and the unknown signal when signalRetry() is misused', function () {
+    $run = new FlowRun;
+    $run->id = '01J000000000000000000RUNID';
+    $run->status = FlowStatus::Waiting;
+
+    $exception = InvalidRetrySignalException::for($run, 'approval');
+
+    expect($exception->getMessage())
+        ->toContain('01J000000000000000000RUNID')
+        ->toContain('approval')
+        ->toContain('signal()');
+});


### PR DESCRIPTION
# General
Imagine a UI table listing abstract Orders. Each Order Saga has failed with an error that can be retried (retryOnSignal). We need to add the possibility to select **specific** failed Orders and retry **only** them. We don't know why they failed (no concrete retry signals), but we know their ids and we know they those failures can be retried (users can also decide to cancel specific failed Orders (whereId(...runIds)))

Disclaimer - I asked an LLM to write the text below, but I hope it sheds some light on my problem:

## Summary

- Split delivery into two families: `signal()` / `signalIfRunning()` for `awaitSignal()`, and `signalRetry()` / `signalRetryIfRunning()` for `retryOnSignal()` wakes (no payload). Cross-family use throws (`CannotSignalRetryException` / `InvalidRetrySignalException`).
- Add `saga-flow:signal-retry` and make `saga-flow:signal` refuse retry policy names.
- Add `FlowQuery::whereId(...$ids)` so bulk wakes stay on the fluent query (no `builder()->whereIn`).
- Document when to use each API, including bulk nameless retry.

### Why the split

`signal()` and `retryOnSignal()` shared a delivery pipe, but they mean different things in product code.

**Await** — an operator (or another service) sends a *decision* into the workflow:

```php
// Manager approved the spend
SagaFlow::loadFlow($runId)->signal('approval', ['approved' => true]);
```

The workflow suspended on `awaitSignal('approval')` and needs that payload.

**Retry** — something in the world changed; re-run the failed step with the *same* arguments:

```php
// Balance was topped up — try ChargeCard again
SagaFlow::loadFlow($runId)->signalRetry('balance-refilled');
```

Nothing useful belongs in a payload here: the action must observe the new world on its next attempt. Treating this as “just another `signal()`” invited the wrong mental model (and leftover “audit payload” docs that never fed the action).

### Motivation

Many runs are parked on different retry policies at once — insufficient balance on one, stock sync on another, gateway timeout on a third. An operator selects a set of failed checkouts and hits **Retry**. The app knows run ids, not signal names:

```php
SagaFlow::query()
    ->whereWorkflow(CheckoutWorkflow::class)
    ->whereTag('tenant', $tenantId)
    ->whereAwaitingRetrySignal()
    ->signalable()
    ->whereId(...$runIds)
    ->handles()
    ->each(fn ($handle) => $handle->signalRetry());
```

That only works cleanly if:

1. You can query “any parked retry” without naming the signal (`whereAwaitingRetrySignal()`).
2. You can wake without naming it (`signalRetry()`).
3. You cannot accidentally use `signal('balance-refilled')` when you meant an approval — or the reverse — because the families refuse each other’s names.

Before this change, retry delivery looked like an ordinary signal, so a bulk “retry selected” path had to dig `retry_signal` off actions by hand and still shared the same verb as approvals.