### PR TITLE
Settle terminal runs and fence every run transition

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -380,7 +380,8 @@ live raises, so the close is retried rather than dropped.
 
 **A same-state transition is checked too.** It used to return before touching the database, which is
 precisely how a stale instance slipped past. It is now a conditional write like any other, and one
-that has genuinely lost raises rather than reporting success.
+that has genuinely lost raises rather than reporting success. `cancelled_at` and `finished_at` are
+still written once and never again, so a landing that repeats does not move the moment the run ended.
 
 What this does **not** close: two workers that both legitimately see `running` both write
 successfully, because the status does not change between them. That is ownership, not transition

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -57,18 +57,21 @@ They are complementary: reclaim retries, the monitor gives up. Neither runs unle
 `action_runs` already had. It runs from the package like every other migration — do not
 `vendor:publish` it.
 
-### 3. Six transitions no longer raise Eloquent model events
+### 3. Status transitions no longer raise Eloquent model events
 
-`startAction()` / `startCompensation()` and the four outcome writes
-(`completeAction()`, `failAction()`, `completeCompensation()`, `failCompensation()`) are now
-conditional `UPDATE` statements, the same shape (and for the same reason — the only form every
-supported driver enforces atomically) as the signal transitions changed in 1.1.0.
+Every status write the engine makes is now a conditional `UPDATE` — the same shape (and for the same
+reason: the only form every supported driver enforces atomically) as the signal transitions changed
+in 1.1.0. That covers `startAction()` / `startCompensation()`, the four outcome writes
+(`completeAction()`, `failAction()`, `completeCompensation()`, `failCompensation()`), and — see item
+15 — every transition of a `flow_runs` row.
 
-The consequence, exactly as documented then: an **observer** registered on a swapped-in
-`models.action_run` or `models.compensation_run` no longer sees `updating`/`updated` for these
-transitions. Nothing is lost, though — each still records its own package event and `flow_events`
-entry whenever it actually writes: `ActionStarted` (`action.started`, unchanged), `ActionCompleted`,
-`ActionFailed`, `CompensationCompleted`, `CompensationFailed`, and the new `CompensationStepStarted`
+The consequence, exactly as documented in 1.1.0: an **observer** registered on a swapped-in
+`models.flow_run`, `models.action_run` or `models.compensation_run` no longer sees
+`updating`/`updated` for these transitions. Nothing is lost, though — each still records its own
+package event and `flow_events` entry whenever it actually writes: the flow lifecycle events
+(`FlowStarted`, `FlowWaiting`, `FlowResumed`, `FlowCompleted`, `FlowFailed`, `FlowCancelled`,
+`FlowExpired`), `ActionStarted` (`action.started`, unchanged), `ActionCompleted`, `ActionFailed`,
+`CompensationCompleted`, `CompensationFailed`, and the new `CompensationStepStarted`
 (`compensation.step_started` — distinct from `CompensationStarted`, which marks the whole rollback
 beginning once per run, not once per compensation). Listen to those, or read `flow_events`, instead
 of Eloquent hooks.
@@ -89,8 +92,11 @@ not touch `attempts`. `ActionRecorder::expireAction()` is conditional for the sa
 other side: a step that completes just before the sweep reaches it is not demoted to `Expired`. It
 now returns `bool`, and the monitor counts and wakes only for an expiry it actually won.
 
-Every quiet path — a lost claim, a rejected outcome, a batch closed early — is logged, since nothing
-else records them. See `logging.anomaly_level` in item 7.
+Every one of these paths — a lost claim, a rejected outcome, a batch closed early, and now a refused
+run transition (item 15) — is logged, since nothing else records them. The first three are also
+quiet: they never fail a job. The fourth is the exception, and only on one surface — the engine
+absorbs it, but `FlowHandle` lets it reach the caller, because an operator whose cancellation did not
+happen has to be told. See `logging.anomaly_level` in item 7.
 
 ### 5. `ActionRunRepository` gained one method
 
@@ -267,6 +273,136 @@ So while pre-upgrade rows are still being read, code that consumes a scalar resu
 shapes. Draining the affected parents before upgrading avoids the mixed period entirely. Note also
 that this release does not rescue a parent already parked over such a child and written against the
 unwrapped shape — that parent was failing before the upgrade and still fails after it.
+
+### 13. A finished run no longer leaves live-looking steps and waits
+
+`ActionStatus::Cancelled` was declared but never written. Cancelling, expiring or closing a run only
+touched its `flow_runs` row, so a run that ended days ago kept steps reporting `pending`, `running`
+or `awaiting_retry`, and wait-signals reporting `waiting`.
+
+Every terminal transition now settles what the run was still holding: steps in those three statuses
+become `cancelled`, and open wait-markers become `cancelled` too. Steps that had already reached an
+outcome — `completed`, `failed`, `optional_failed`, `expired` — are untouched, so a cancelled run
+still shows what actually ran. `SignalStatus::Cancelled` is new; a `match` over `SignalStatus` that
+was exhaustive before now needs that arm.
+
+Four things to check:
+
+**Queries filtered by step or signal status.** A dashboard counting `action_runs` where
+`status = 'running'` stops counting runs that ended. That was the point — those counts were wrong —
+but a query written to compensate for it (joining `flow_runs` to exclude terminal runs) is now
+redundant rather than harmful.
+
+**`FlowQuery::whereAwaitingSignal()` and `whereAwaitingRetrySignal()`** stop matching a run once it
+finishes, because it no longer holds the row they filter on. That is true of runs that finish on this
+release; rows left behind by runs that finished earlier still carry `waiting` and `awaiting_retry`,
+and their runs still match. Keep composing with `signalable()` while any of those remain — the SQL
+below clears them if you would rather be done with it.
+
+**A worker holding a `Running` step when its run is cancelled** races the settlement, and both
+orders leave the row consistent. If the settlement lands first the step is `cancelled` and the
+worker's outcome is refused, logged as `outcome_rejected` — the same fencing the monitor's expiry
+already used. If the worker lands first the step keeps the outcome it earned and the settlement
+passes over it. Expect `outcome_rejected` lines whenever runs are cancelled while steps are
+genuinely in flight.
+
+A refused outcome is not stored: before this release the late worker's result landed in
+`action_runs.result`, and now the `outcome_rejected` line — the run, the step, its sequence and
+class, and which outcome was refused — is what records it. If the step reaches an external system,
+that log line is the pointer to reconcile from.
+
+**Rows written before the upgrade keep their old status.** They are not migrated: the package's
+migrations run automatically on `php artisan migrate`, and rewriting a host's history without being
+asked is not something a migration should do. They are harmless — no sweep selects them any more (see
+below) — but `saga-flow:show` will keep rendering them as they are. To settle them yourself:
+
+```sql
+UPDATE saga_action_runs
+   SET status = 'cancelled'
+ WHERE status IN ('pending', 'running', 'awaiting_retry')
+   AND flow_run_id IN (
+       SELECT id FROM saga_flow_runs
+        WHERE status IN ('completed', 'failed', 'cancelled', 'expired')
+   );
+
+UPDATE saga_flow_signals
+   SET status = 'cancelled'
+ WHERE status = 'waiting'
+   AND wait_sequence IS NOT NULL
+   AND flow_run_id IN (
+       SELECT id FROM saga_flow_runs
+        WHERE status IN ('completed', 'failed', 'cancelled', 'expired')
+   );
+```
+
+Adjust the table names if you set `database.table_prefix`.
+
+### 14. No sweep selects work belonging to a finished run
+
+Four scans gained the same condition: the doctor's `dueForRepair()` and `dueForStaleRunningRepair()`,
+and the monitor's `dueForExpiration()` and `dueForTimeout()`.
+
+Each of them rejected such a row anyway, but only *after* spending a slot on it and *before* any
+counter could hold it off — the doctor returns ahead of its throttle, and the monitor has no counter
+at all. Ordered oldest-first and never changing, an unsettled row sat at the head of every batch for
+ever; enough of them and a pass filled up with dead rows and reached nothing live, while still
+reporting success.
+
+Item 13 stops new ones from appearing. This stops the ones already in your database from costing
+anything, which is why no data migration is needed.
+
+`FlowStatus::terminal()` is new, listing the four statuses a run never leaves. `isTerminal()` now
+reads from it.
+
+### 15. A run transition is refused if the row moved on
+
+Every transition of a `flow_runs` row now writes conditionally, on the status the caller read before
+deciding. If the row is no longer there, nothing is written and the transition raises
+`ConcurrentFlowTransitionException`.
+
+The hole it closes: nothing serialises an operator against a worker. The queue's per-run lock covers
+jobs; it does not cover `saga-flow:cancel`, a host calling `FlowHandle::cancel()`, or the monitor's
+sweep, which expires runs inline. Each side holds its own `FlowRun` instance, and whichever saved
+last used to win outright — up to a worker writing `running` over a run an operator had already
+cancelled, leaving a run that can never finish because its steps are settled and replay will not
+resolve them.
+
+Two things follow:
+
+**The engine absorbs it; `FlowHandle` does not.** `FlowExecutor::drive()`, `FlowExecutor::expireRun()`,
+`CancelChildWorkflowJob` and the queued rollback's batch continuation catch it and stop: a job ends cleanly rather than
+retrying, `runSync()` returns the run in the state the winner left it, and a parent awaiting the run
+as a child reads its status and resolves accordingly. `FlowHandle::cancel()` and `compensate()`
+deliberately let it through — see item 16. A rollback an operator asked for raises from its landing
+too, for the same reason: nobody else is waiting on that answer.
+
+**A same-state transition is checked too.** It used to return before touching the database, which is
+precisely how a stale instance slipped past. It is now a conditional write like any other, and one
+that has genuinely lost raises rather than reporting success.
+
+What this does **not** close: two workers that both legitimately see `running` both write
+successfully, because the status does not change between them. That is ownership, not transition
+ordering, and `WithoutOverlapping` on `run:{id}` remains what covers it.
+
+Refused transitions are logged as `transition_lost`, with the status observed, the one intended, and
+the one actually holding the row. A refusal leaves the `FlowRun` instance that asked for it exactly
+as it was, so a caller that catches one can read the run's real status off its own model and act on
+it — or simply try again.
+
+### 16. `FlowHandle::cancel()` can now throw a second exception
+
+`cancel()` and `compensate()` already raised `CannotCancelTerminalFlowException` when the run they
+hold is terminal. They can now also raise `ConcurrentFlowTransitionException`, when the run was still
+live as far as the handle knew but moved underneath it.
+
+If you catch around either call, catch both. They stay distinct on purpose:
+`CannotCancelTerminalFlowException` means the handle already knew the run was finished;
+`ConcurrentFlowTransitionException` means it lost a race and the run is now in some other state,
+which the message names.
+
+Note that neither is a subclass of `InvalidTransitionException`, and `ConcurrentFlowTransitionException`
+is deliberately not one either: that exception means the state graph forbids the move, and repeating
+it cannot help, whereas a lost race is transient and re-reading the run is the sensible response.
 
 ### Recommended while you are here
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -369,12 +369,14 @@ resolve them.
 
 Two things follow:
 
-**The engine absorbs it; `FlowHandle` does not.** `FlowExecutor::drive()`, `FlowExecutor::expireRun()`,
-`CancelChildWorkflowJob` and the queued rollback's batch continuation catch it and stop: a job ends cleanly rather than
+**The engine absorbs it; `FlowHandle` does not.** `FlowExecutor::drive()`, `FlowExecutor::expireRun()`
+and the queued rollback's batch continuation catch it and stop: a job ends cleanly rather than
 retrying, `runSync()` returns the run in the state the winner left it, and a parent awaiting the run
 as a child reads its status and resolves accordingly. `FlowHandle::cancel()` and `compensate()`
 deliberately let it through — see item 16. A rollback an operator asked for raises from its landing
-too, for the same reason: nobody else is waiting on that answer.
+too, for the same reason: nobody else is waiting on that answer. `CancelChildWorkflowJob` stops only
+once the child it was sent to close is genuinely closed; losing it to something that leaves the child
+live raises, so the close is retried rather than dropped.
 
 **A same-state transition is checked too.** It used to return before touching the database, which is
 precisely how a stale instance slipped past. It is now a conditional write like any other, and one

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -71,6 +71,10 @@ This is deliberate. Keeping the sweep the single writer of a wait's status is wh
 seam safe to run concurrently. If your deadline is a hard business boundary rather than a safety net, enforce it in the
 workflow — the payload of a late signal can be checked against a deadline you captured with `sideEffect()`.
 
+A sweep only ever looks at work belonging to a run that is still going. A run that has finished settles its own steps
+and waits as it ends (see [statuses](./statuses.md)), and the scan skips whatever was left unsettled before that, so a
+batch is always filled with candidates a sweep can actually act on.
+
 ## Repair (the doctor)
 
 Separate from expiration: the **doctor** recovers a run whose progress was lost to a *dropped job* — an action that
@@ -97,7 +101,8 @@ Every parameter:
 - **`grace_seconds`** — minimum age, **in seconds**, before an entity is even *considered* stuck. This guards against
   racing a job that is simply still in flight: the doctor ignores anything younger than this, so a slow-but-alive action
   is left alone. Raise it if your jobs legitimately run long.
-- **`batch_size`** — how many candidate entities one repair pass inspects at most.
+- **`batch_size`** — how many candidate entities one repair pass inspects at most. Only entities of runs that have not
+  finished are counted against it.
 - **`max_attempts`** — per-entity cap. After this many repair attempts the doctor gives up on that entity and leaves it
   alone (re-drive it by hand with `saga-flow:kick`).
 - **`backoff`** — exponential backoff between repair attempts for a single entity, clamped between

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -66,6 +66,32 @@ action steps (sequential and parallel) and compensations, each keyed on its own 
   giving up and letting the queue retry it later.
 - **`prefix`** — string prefix for every lock key (namespacing when the store is shared).
 
+### What the lock does not cover
+
+The lock is job middleware, so it orders jobs against each other and nothing else. Three writers sit
+outside it: `saga-flow:cancel`, a host calling `FlowHandle::cancel()` or `compensate()`, and the
+monitor's sweep, which expires runs inline in `saga-flow:monitor`. A TTL is also a ceiling, not a
+promise — a job that outruns `workflow_ttl_seconds` keeps working while its lock is released.
+
+What covers those is the write itself. Every status write in the package — a run's transition, a step's
+claim, an outcome — is a conditional `UPDATE` on the value its caller read before deciding, which is
+the only form every supported driver enforces atomically. A writer whose row has moved on writes
+nothing and is told so, instead of overwriting whoever got there first:
+
+```php
+try {
+    SagaFlow::loadFlow($runId)->cancel('superseded');
+} catch (ConcurrentFlowTransitionException $e) {
+    // The run moved while you were deciding — the message names where it is now.
+}
+```
+
+The engine absorbs the same refusal on its own paths: a drive that loses simply stops, so the job
+ends cleanly rather than retrying.
+
+Two workers that both legitimately hold a run as `running` are a different problem — nothing changes
+between them for a condition to catch. That is what the lock is for.
+
 ## When a step is quietly skipped
 
 Three things can happen to a worker without failing its job: it loses the claim to whoever already
@@ -82,9 +108,12 @@ package keeps a second journal for them:
 ```
 
 Grep for `claim_lost`, `outcome_rejected` and `batch_finished_early`; each line carries the run id,
-row id, sequence and class. They are not written to `flow_events`, which records the run's business
-history — an abandoned attempt changed nothing in it. See
-[Reclaim & recovery](./reclaim-and-recovery.md) for what each one means and what to do about it.
+row id, sequence and class. A refused run transition is journalled here too, as `transition_lost`,
+carrying the status observed, the one intended and the one actually holding the row — it is the one
+entry that is not always quiet, since `FlowHandle` raises rather than absorbing it. None of them are
+written to `flow_events`, which records the run's business history — an abandoned attempt changed
+nothing in it. See [Reclaim & recovery](./reclaim-and-recovery.md) for what each one means and what
+to do about it.
 
 :::tip A lock TTL is not the same as reclaim
 `action_ttl_seconds` does not answer "when can a stuck `Running` step be retried". It governs a

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -97,7 +97,9 @@ A step stops waiting when any one of these happens:
 - **The signal arrives.** One cycle is spent, the step runs again.
 - **The budget runs out.** `retry_signal_attempts` reaches `maxRetries` → hard failure.
 - **The wait times out.** The monitor flips the wait to `timed_out` → hard failure.
-- **The run expires** on its own `expires_at`, or is cancelled.
+- **The run expires** on its own `expires_at`, or is cancelled. The park ends with it: the step is
+  settled as `cancelled` and its wait along with it, so nothing keeps advertising a signal that
+  would no longer be acted on. See [statuses](./statuses.md).
 
 :::info A timed-out wait ends the policy for good
 The wait deadline bounds *the waiting*, not one wait out of several. Once a wait has timed out, the

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -1,0 +1,82 @@
+---
+id: statuses
+title: Statuses
+sidebar_position: 21.5
+---
+
+# Statuses
+
+Every row the engine writes carries a status from a backed enum, so a host can filter on it,
+`match` on it, and read it straight out of the database.
+
+## `FlowStatus` — the run
+
+| Case | Meaning |
+|---|---|
+| `Pending` | Created, not yet driven. |
+| `Running` | A replay pass is in progress. |
+| `Waiting` | Suspended on something durable: a queued action, an open signal wait, or a child. |
+| `Cancelling` | Rolling back. Not terminal — its compensations are still running. |
+| `Completed` | `handle()` returned. |
+| `Failed` | A business exception ended it, after whatever rollback its policy asked for. |
+| `Cancelled` | Stopped because it was no longer wanted: `cancel()`, `compensate()`, or a child closed under `ChildClosePolicy::Cancel`. |
+| `Expired` | Its own `expires_at` passed and the deadline was enforced. |
+
+`Completed`, `Failed`, `Cancelled` and `Expired` are terminal: a run never leaves them, and it
+refuses signals and cancellation once there.
+
+## `ActionStatus` — one step
+
+| Case | Meaning |
+|---|---|
+| `Pending` | Scheduled. Its job has not settled it yet. |
+| `Running` | Claimed by a worker that is executing it. |
+| `Completed` | Returned a result, which replay hands back on every later pass. |
+| `Failed` | Threw. Replay surfaces it as a business error. |
+| `AwaitingRetry` | Failed and parked by [`retryOnSignal()`](./retry-on-signal.md), waiting for its signal. |
+| `OptionalFailed` | An [optional](./optional-actions.md) step gave up; the seam returns its fallback. |
+| `Expired` | The monitor enforced **this step's** own `expires_at`. |
+| `Cancelled` | The run it belongs to finished before the step reached an outcome of its own. |
+
+The difference between `Expired` and `Cancelled` is whose deadline ran out. `Expired` always
+carries the step's own `exception` and an `action.expired` event; `Cancelled` carries neither,
+because nothing happened to the step — the run under it ended.
+
+## `SignalStatus` — one signal row
+
+| Case | Meaning |
+|---|---|
+| `Waiting` | An open wait-marker: the run is parked at this sequence until the signal arrives. |
+| `Received` | Delivered, not yet taken by a replay pass. |
+| `Consumed` | Replay read its payload. |
+| `TimedOut` | The monitor enforced the wait's `timeout_at`; replay surfaces that as a business error. |
+| `Cancelled` | The run finished while the wait was still open. |
+
+A delivered signal that no `awaitSignal()` ever matched keeps its `Received` status for good — it
+records that a signal arrived and nobody used it.
+
+## What a finished run leaves behind
+
+Reaching a terminal state settles the work the run was still holding, so nothing under it keeps
+reading as live:
+
+- steps in `Pending`, `Running` or `AwaitingRetry` become `Cancelled`;
+- open wait-markers (`Waiting`) become `Cancelled`.
+
+Steps that already reached an outcome are untouched — a cancelled run still shows which of its
+steps ran, and what each of them did.
+
+One thing is deliberately left unsettled: a compensation still in `Pending` or `Running` when the
+rollback stopped. That is not leftover state but an open operational item — a run that did not
+fully unwind — and it is recorded on the run's own `exception` as
+`CompensationUnfinishedException`. See [sagas & compensations](./sagas-and-compensation.md).
+
+A step that is `Cancelled` is inert: a late job cannot claim it, and no monitor or repair sweep
+selects it.
+
+## `CompensationStatus` and `ChildStatus`
+
+`CompensationStatus` (`Pending`, `Running`, `Completed`, `Failed`) tracks one compensation of a
+rollback. `ChildStatus` (`Pending`, `Running`, `Completed`, `Failed`, `Cancelled`) tracks the link
+between a parent and a [child workflow](./child-workflows.md) — the child's own run row carries a
+`FlowStatus` of its own.

--- a/docs/docs/tags-and-querying.md
+++ b/docs/docs/tags-and-querying.md
@@ -111,8 +111,10 @@ it `TimedOut`, while the parked step keeps its `awaiting_retry` status until rep
 In that gap only `whereAwaitingRetrySignal()` matches — which is what makes it the filter that finds
 a run whose signal arrived but whose resume never did.
 
-Both match on the rows a run holds, not on its status: a run cancelled while parked still carries
-the wait and the parked step. Compose with `signalable()` to exclude those.
+Both read the rows a run holds rather than the run's own status. A run that finishes settles its open
+wait and its parked step alike (see [statuses](./statuses.md)), so it drops out of both filters on its
+own. Rows left behind by runs that finished before this behaviour existed still carry `waiting` and
+`awaiting_retry`, and their runs still match — compose with `signalable()` while any of those remain.
 
 ### Terminals
 

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -48,7 +48,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Reference',
-      items: ['testing'],
+      items: ['statuses', 'testing'],
     },
   ],
 };

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,14 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    <php>
+        <!--
+            Each test boots its own Testbench app against an in-memory database, so the
+            suite's peak grows with the number of tests. Pinning the limit here keeps it
+            independent of whatever php.ini a machine or a CI image happens to set.
+        -->
+        <ini name="memory_limit" value="512M"/>
+    </php>
     <logging>
         <junit outputFile="build/report.junit.xml"/>
     </logging>

--- a/src/Console/Commands/FlowListCommand.php
+++ b/src/Console/Commands/FlowListCommand.php
@@ -107,9 +107,9 @@ class FlowListCommand extends Command
     /**
      * The status cell, with the signal a parked run waits on appended to it.
      *
-     * Only a Waiting run is annotated: a step keeps its AwaitingRetry status after the
-     * run around it is cancelled, and naming a signal there would send the operator
-     * after a delivery a terminal run refuses.
+     * Only a Waiting run is annotated: a run mid-rollback is Cancelling, which is not
+     * terminal, so it still holds its AwaitingRetry step — and naming a signal there
+     * would send the operator after a delivery the run no longer accepts.
      *
      * @param  Collection<string, string>  $parked
      */

--- a/src/Console/Commands/FlowShowCommand.php
+++ b/src/Console/Commands/FlowShowCommand.php
@@ -123,9 +123,10 @@ class FlowShowCommand extends Command
      * is spent (an unset max is unbounded), plus the current wait deadline while the
      * step is actually parked. Steps without a retry policy stay blank.
      *
-     * The deadline shows only while the run itself is Waiting: a cancelled run keeps
-     * both the AwaitingRetry step and its timeout_at, and "until ..." there would be a
-     * countdown for a wait nothing will resolve.
+     * The deadline shows only while the run itself is Waiting. A run mid-rollback is
+     * Cancelling, which is not terminal, so it still holds both the AwaitingRetry step
+     * and its timeout_at — and "until ..." there would be a countdown for a wait
+     * nothing will resolve.
      *
      * @param  array<int, FlowSignal>  $signals
      */

--- a/src/Enums/FlowStatus.php
+++ b/src/Enums/FlowStatus.php
@@ -15,12 +15,18 @@ enum FlowStatus: string
 
     public function isTerminal(): bool
     {
-        return in_array($this, [
-            self::Completed,
-            self::Failed,
-            self::Cancelled,
-            self::Expired,
-        ], true);
+        return in_array($this, self::terminal(), true);
+    }
+
+    /**
+     * The statuses a run never leaves. Single source of truth for isTerminal() and
+     * for the sweeps that must not pick up work belonging to a finished run.
+     *
+     * @return array<int, self>
+     */
+    public static function terminal(): array
+    {
+        return [self::Completed, self::Failed, self::Cancelled, self::Expired];
     }
 
     /**

--- a/src/Enums/SignalStatus.php
+++ b/src/Enums/SignalStatus.php
@@ -8,4 +8,5 @@ enum SignalStatus: string
     case Received = 'received';
     case Consumed = 'consumed';
     case TimedOut = 'timed_out';
+    case Cancelled = 'cancelled';
 }

--- a/src/Exceptions/ConcurrentFlowTransitionException.php
+++ b/src/Exceptions/ConcurrentFlowTransitionException.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * Raised when a transition is refused because the run had already moved on: the row
+ * no longer holds the status the caller read before deciding.
+ *
+ * Deliberately not an InvalidTransitionException. That one means the state graph
+ * forbids the move, and repeating it cannot help. This one means the move was legal and
+ * somebody else got there first, so re-reading the run and deciding again is the
+ * sensible response — the opposite reaction of the two.
+ */
+class ConcurrentFlowTransitionException extends FlowException
+{
+    public static function for(FlowRun $run, FlowStatus $from, FlowStatus $to, ?FlowStatus $actual): self
+    {
+        return new self(sprintf(
+            'Cannot transition flow run [%s] from [%s] to [%s]: the row is %s.',
+            $run->id,
+            $from->value,
+            $to->value,
+            $actual === null ? 'no longer there' : "now [{$actual->value}]",
+        ));
+    }
+}

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -7,6 +7,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotCancelTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ChildWorkflowManager;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -131,6 +132,7 @@ readonly class FlowHandle
      * and carried on the FlowCancelled event. Throws on a terminal run.
      *
      * @throws CannotCancelTerminalFlowException
+     * @throws ConcurrentFlowTransitionException
      */
     public function cancel(?string $reason = null): FlowRun
     {
@@ -154,6 +156,7 @@ readonly class FlowHandle
      * the run lands in Cancelled. Only valid for a non-terminal run.
      *
      * @throws CannotCancelTerminalFlowException
+     * @throws ConcurrentFlowTransitionException
      * @throws Throwable
      */
     public function compensate(): FlowRun

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -7,6 +7,7 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ParentClosedException;
 use DiscoveryUkraine\SagaLaraFlow\Middleware\LockMiddlewareFactory;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
@@ -54,6 +55,27 @@ class CancelChildWorkflowJob implements ShouldQueue
             return;
         }
 
+        try {
+            $this->close($executor, $sagaRunner, $repository, $stateMachine, $lifecycle, $tenancy, $child);
+        } catch (ConcurrentFlowTransitionException) {
+            // The per-run lock covers jobs and nothing else, so an operator reaching the
+            // child directly is an ordinary race. Failing here would retry a job with
+            // nothing left to do.
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function close(
+        FlowExecutor $executor,
+        SagaRunner $sagaRunner,
+        FlowRepository $repository,
+        StateMachine $stateMachine,
+        FlowLifecycleRecorder $lifecycle,
+        TenancyManager $tenancy,
+        FlowRun $child,
+    ): void {
         $tenancy->for($child, $child->workflow_class, function () use (
             $executor,
             $sagaRunner,

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -57,10 +57,18 @@ class CancelChildWorkflowJob implements ShouldQueue
 
         try {
             $this->close($executor, $sagaRunner, $repository, $stateMachine, $lifecycle, $tenancy, $child);
-        } catch (ConcurrentFlowTransitionException) {
-            // The per-run lock covers jobs and nothing else, so an operator reaching the
-            // child directly is an ordinary race. Failing here would retry a job with
-            // nothing left to do.
+        } catch (ConcurrentFlowTransitionException $lost) {
+            // The per-run lock covers jobs and nothing else, so losing the child to an
+            // operator or to a sync drive under the parent's own replay is an ordinary
+            // race. Ending quietly is only right once the child is genuinely closed, or
+            // once another rollback owns its landing — a child still live is one this
+            // job was sent to close, and dropping it here would strand it with a
+            // terminal parent and no close policy left to apply.
+            $current = $repository->find($this->childFlowRunId);
+
+            if ($current !== null && ! $current->isTerminal() && $current->status !== FlowStatus::Cancelling) {
+                throw $lost;
+            }
         }
     }
 

--- a/src/Queries/FlowQuery.php
+++ b/src/Queries/FlowQuery.php
@@ -66,8 +66,9 @@ readonly class FlowQuery
      * matches any name.
      *
      * Only whereAwaitingRetrySignal() tells the two seams apart. Matching is on the
-     * signal row rather than the run's status, so compose with signalable() to skip
-     * runs that have already finished.
+     * signal row rather than the run's status. A run settles its open waits as it
+     * finishes, so it leaves this filter on its own; compose with signalable() to skip
+     * the rows left behind by runs that finished before that behaviour existed.
      */
     public function whereAwaitingSignal(?string $name = null): static
     {

--- a/src/Repositories/EloquentActionRunRepository.php
+++ b/src/Repositories/EloquentActionRunRepository.php
@@ -4,7 +4,10 @@ namespace DiscoveryUkraine\SagaLaraFlow\Repositories;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class EloquentActionRunRepository implements ActionRunRepository
@@ -23,6 +26,7 @@ class EloquentActionRunRepository implements ActionRunRepository
             ->whereIn('status', [ActionStatus::Pending, ActionStatus::Running])
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', Carbon::now())
+            ->whereHas('flowRun', $this->liveRun(...))
             ->orderBy('expires_at')
             ->limit($limit)
             ->get();
@@ -42,6 +46,7 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
+            ->whereHas('flowRun', $this->liveRun(...))
             ->orderBy('created_at')
             ->limit($limit)
             ->get();
@@ -69,9 +74,23 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
+            ->whereHas('flowRun', $this->liveRun(...))
             ->orderBy('reclaim_stale_at')
             ->limit($limit)
             ->get();
+    }
+
+    /**
+     * Never hand a sweep a step whose run has already finished. Terminal settlement
+     * leaves only rows written before it existed, but they are enough to starve a sweep:
+     * every guard that rejects them returns before any throttle is bumped, so the same
+     * rows come back at the head of every batch, oldest-first, for ever.
+     *
+     * @param  Builder<FlowRun>  $query
+     */
+    private function liveRun(Builder $query): void
+    {
+        $query->whereNotIn('status', FlowStatus::terminal());
     }
 
     /**

--- a/src/Repositories/EloquentSignalRepository.php
+++ b/src/Repositories/EloquentSignalRepository.php
@@ -4,8 +4,11 @@ namespace DiscoveryUkraine\SagaLaraFlow\Repositories;
 
 use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class EloquentSignalRepository implements SignalRepository
@@ -67,9 +70,22 @@ class EloquentSignalRepository implements SignalRepository
             ->where('status', SignalStatus::Waiting)
             ->whereNotNull('timeout_at')
             ->where('timeout_at', '<=', Carbon::now())
+            ->whereHas('flowRun', $this->liveRun(...))
             ->orderBy('timeout_at')
             ->limit($limit)
             ->get();
+    }
+
+    /**
+     * Never hand the sweep a wait whose run has already finished. Terminal settlement
+     * leaves only rows written before it existed, but timeoutSignal() rejects them with
+     * no counter to hold them off, so one would sit at the head of every batch for ever.
+     *
+     * @param  Builder<FlowRun>  $query
+     */
+    private function liveRun(Builder $query): void
+    {
+        $query->whereNotIn('status', FlowStatus::terminal());
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -24,6 +24,7 @@ use Throwable;
 /**
  * Persists an action step through its lifecycle (scheduled → started → completed
  * /failed), serializing arguments and results and appending the matching events.
+ * It also settles the steps a finished run leaves behind (settleOpenSteps).
  */
 final readonly class ActionRecorder
 {
@@ -380,6 +381,32 @@ final readonly class ActionRecorder
 
         $actionRun->status = ActionStatus::Failed;
         $actionRun->save();
+    }
+
+    /**
+     * Close every step of a run that reached a terminal state without an outcome of its
+     * own. Cancelled says exactly that: the step stopped because the run under it ended,
+     * not because of anything the step itself did. Steps that already settled keep their
+     * status, so a finished run still shows which of its steps actually ran.
+     *
+     * Only `status` is written: an AwaitingRetry row carries the finished_at of the
+     * attempt that failed, and the moment of the closure is flow_runs.finished_at. No
+     * event is appended, for the same reason settleAwaitingRetry() appends none — the
+     * run's own terminal event records both the moment and the cause.
+     */
+    public function settleOpenSteps(FlowRun $flowRun): int
+    {
+        /** @var class-string<ActionRun> $model */
+        $model = config('saga-lara-flow.models.action_run');
+
+        return $model::query()
+            ->where('flow_run_id', $flowRun->id)
+            ->whereIn('status', [
+                ActionStatus::Pending,
+                ActionStatus::Running,
+                ActionStatus::AwaitingRetry,
+            ])
+            ->update(['status' => ActionStatus::Cancelled]);
     }
 
     /**

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -11,8 +11,13 @@ use Throwable;
  * EventLog records what happened to a run in business terms. This records the moments
  * where the world turned out not to be what the engine assumed — a claim lost to
  * whoever already owned the row, an outcome write refused because the row had changed
- * hands, a batch already closed by a duplicate before its own job reported. All are
- * ordinary consequences of at-least-once delivery, so none of them fails a job.
+ * hands, a batch already closed by a duplicate before its own job reported, a run
+ * transition refused because the row had moved on. All are ordinary consequences of
+ * at-least-once delivery and of nothing serialising an operator against a worker.
+ *
+ * None of them fails a job. A refused transition also reaches its caller: the engine
+ * absorbs it and stops, but FlowHandle lets it surface, because an operator whose
+ * cancellation did not happen has to be told.
  *
  * Which is why they need a journal of their own: the job succeeds, flow_events stays
  * silent, and an operator investigating a step that ran twice would have nothing to go
@@ -26,6 +31,8 @@ final readonly class AnomalyLog
     public const string REASON_OUTCOME_REJECTED = 'outcome_rejected';
 
     public const string REASON_BATCH_FINISHED_EARLY = 'batch_finished_early';
+
+    public const string REASON_TRANSITION_LOST = 'transition_lost';
 
     /**
      * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -8,6 +8,7 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
@@ -46,11 +47,19 @@ class FlowExecutor
      */
     public function drive(FlowRun $flowRun, RunMode $mode): FlowRun
     {
-        return $this->tenancy->for(
-            $flowRun,
-            $flowRun->workflow_class,
-            fn (): FlowRun => $this->driveInner($flowRun, $mode),
-        );
+        try {
+            return $this->tenancy->for(
+                $flowRun,
+                $flowRun->workflow_class,
+                fn (): FlowRun => $this->driveInner($flowRun, $mode),
+            );
+        } catch (ConcurrentFlowTransitionException) {
+            // Somebody else owns this run now. Returning it rather than throwing lets
+            // every caller do the right thing without knowing about the race: a job ends
+            // cleanly, runSync() returns the run as the winner left it, and a parent
+            // awaiting it as a child reads its status and resolves accordingly.
+            return $flowRun->fresh() ?? $flowRun;
+        }
     }
 
     /**
@@ -91,6 +100,10 @@ class FlowExecutor
                 return $this->suspend($flowRun);
             } catch (InternalFlowControl) {
                 return $this->suspend($flowRun);
+            } catch (ConcurrentFlowTransitionException $lost) {
+                // Must precede the catch below: compensating over a refused transition
+                // would roll back a run this pass no longer owns.
+                throw $lost;
             } catch (Throwable $exception) {
                 return $this->failAndCompensate($flowRun, $exception, $mode);
             }
@@ -231,9 +244,24 @@ class FlowExecutor
      * (queued) and finalize as Expired — or, with nothing to undo, expire directly.
      * Shared by the monitor's sweep (FlowMonitor::expireRun) and the lazy drive check.
      *
+     * Guarded separately from drive(), because the sweep reaches it directly: one run
+     * claimed by someone else in the meantime must not end the whole pass.
+     *
      * @throws Throwable
      */
     public function expireRun(FlowRun $flowRun): FlowRun
+    {
+        try {
+            return $this->expireRunInner($flowRun);
+        } catch (ConcurrentFlowTransitionException) {
+            return $flowRun->fresh() ?? $flowRun;
+        }
+    }
+
+    /**
+     * @throws Throwable
+     */
+    private function expireRunInner(FlowRun $flowRun): FlowRun
     {
         $primary = $this->exceptionToArray(FlowExpiredException::forFlowRun($flowRun));
 

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -58,7 +58,7 @@ class FlowExecutor
             // every caller do the right thing without knowing about the race: a job ends
             // cleanly, runSync() returns the run as the winner left it, and a parent
             // awaiting it as a child reads its status and resolves accordingly.
-            return $flowRun->fresh() ?? $flowRun;
+            return $this->reread($flowRun);
         }
     }
 
@@ -254,8 +254,18 @@ class FlowExecutor
         try {
             return $this->expireRunInner($flowRun);
         } catch (ConcurrentFlowTransitionException) {
-            return $flowRun->fresh() ?? $flowRun;
+            return $this->reread($flowRun);
         }
+    }
+
+    /**
+     * Read the run as the winner of a refused transition left it. From the writer: the
+     * whole point of this read is the state that was just committed, and it is what a
+     * caller — a parent resolving this run as a child among them — decides on.
+     */
+    private function reread(FlowRun $flowRun): FlowRun
+    {
+        return $flowRun->newQuery()->useWritePdo()->find($flowRun->getKey()) ?? $flowRun;
     }
 
     /**

--- a/src/Runtime/SagaRunner.php
+++ b/src/Runtime/SagaRunner.php
@@ -11,6 +11,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CompensationFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CompensationUnfinishedException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\RunCompensationJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
@@ -86,13 +87,19 @@ class SagaRunner
             return;
         }
 
-        if ($this->levelStopped($ranCompensationIds)) {
-            $this->finalize($flowRun, $finalState, $primary);
+        try {
+            if ($this->levelStopped($ranCompensationIds)) {
+                $this->finalize($flowRun, $finalState, $primary);
 
-            return;
+                return;
+            }
+
+            $this->dispatchLevel($flowRun, $remainingLevels, $primary, $finalState);
+        } catch (ConcurrentFlowTransitionException) {
+            // Another actor finished the run while the compensations were in flight; what
+            // they ran is recorded either way. A batch callback is the one landing with no
+            // caller to tell, so it absorbs here rather than in finalize().
         }
-
-        $this->dispatchLevel($flowRun, $remainingLevels, $primary, $finalState);
     }
 
     /**
@@ -179,6 +186,11 @@ class SagaRunner
     }
 
     /**
+     * Land the run once the rollback is done.
+     *
+     * A refused landing is raised, not swallowed: only the caller knows whether losing
+     * the run matters. FlowHandle::compensate() is an operator who has to be told.
+     *
      * @param  array<string, mixed>|null  $primary
      */
     private function finalize(FlowRun $flowRun, FlowStatus $finalState, ?array $primary): void

--- a/src/Runtime/SignalRecorder.php
+++ b/src/Runtime/SignalRecorder.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Carbon;
 /**
  * Persists the signal lifecycle (waiting → received → consumed) and dispatches
  * the matching events. Signal payloads are stored via the model's JSON cast.
+ * It also settles the waits a finished run leaves open (settleOpenWaits).
  */
 final readonly class SignalRecorder
 {
@@ -226,6 +227,28 @@ final readonly class SignalRecorder
         $signal->refresh();
 
         return true;
+    }
+
+    /**
+     * Close the wait-signals a run that reached a terminal state left open. Cancelled
+     * says the wait ended with the run, not on its own terms — unlike TimedOut, which
+     * means a deadline passed and which replay surfaces as a business error.
+     *
+     * Only open wait-markers are settled. A delivered signal (no wait_sequence) and a
+     * wait already flipped to Received are history — "arrived, nobody consumed it" — and
+     * rewriting them would erase that. No event is appended: the run's own terminal
+     * event records both the moment and the cause.
+     */
+    public function settleOpenWaits(FlowRun $flowRun): int
+    {
+        /** @var class-string<FlowSignal> $model */
+        $model = config('saga-lara-flow.models.flow_signal');
+
+        return $model::query()
+            ->where('flow_run_id', $flowRun->id)
+            ->whereNotNull('wait_sequence')
+            ->where('status', SignalStatus::Waiting)
+            ->update(['status' => SignalStatus::Cancelled]);
     }
 
     private function emitSignalReceived(FlowRun $flowRun, FlowSignal $signal): void

--- a/src/States/FlowStateMachine.php
+++ b/src/States/FlowStateMachine.php
@@ -37,11 +37,15 @@ class FlowStateMachine implements StateMachine
             $run->started_at = $now;
         }
 
-        if ($to === FlowStatus::Cancelled) {
+        // Both are written once and never again. A same-state terminal transition is a
+        // legal no-op that at-least-once delivery does reach — a duplicated batch
+        // callback lands a run that is already Cancelled — and rewriting the marks there
+        // would move the moment the run actually ended to whenever the duplicate arrived.
+        if ($to === FlowStatus::Cancelled && $run->cancelled_at === null) {
             $run->cancelled_at = $now;
         }
 
-        if ($to->isTerminal()) {
+        if ($to->isTerminal() && $run->finished_at === null) {
             $run->finished_at = $now;
         }
 

--- a/src/States/FlowStateMachine.php
+++ b/src/States/FlowStateMachine.php
@@ -2,10 +2,16 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\States;
 
+use Closure;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
+use Throwable;
 
 class FlowStateMachine implements StateMachine
 {
@@ -13,14 +19,14 @@ class FlowStateMachine implements StateMachine
     {
         $from = $run->status;
 
-        // Same-state transitions are idempotent no-ops (safe to call on replay).
-        if ($from === $to) {
-            return $run;
-        }
-
-        if (! $this->canTransition($from, $to)) {
+        // A same-state transition is legal by definition, but must not return early:
+        // an instance whose stale status happens to equal the target is exactly the one
+        // that would slip past the write's guard unchecked.
+        if ($from !== $to && ! $this->canTransition($from, $to)) {
             throw InvalidTransitionException::between($from, $to);
         }
+
+        $restore = $this->snapshot($run);
 
         $now = now();
 
@@ -38,9 +44,127 @@ class FlowStateMachine implements StateMachine
             $run->finished_at = $now;
         }
 
-        $run->save();
+        try {
+            $to->isTerminal()
+                ? $this->finish($run, $from, $to)
+                : $this->write($run, $from, $to);
+        } catch (Throwable $failure) {
+            $restore();
+
+            throw $failure;
+        }
+
+        $run->syncOriginal();
 
         return $run;
+    }
+
+    /**
+     * Capture the instance as the caller left it — attributes and the original snapshot
+     * they are measured against — and return the closure that puts it back.
+     *
+     * The instance is mutated before the row confirms anything, so an exit that leaves
+     * the row untouched has to leave the instance untouched too: a caller reading a
+     * terminal status the database rejected would find cancel() refusing their retry.
+     *
+     * @return Closure(): void
+     */
+    private function snapshot(FlowRun $run): Closure
+    {
+        $attributes = $run->getAttributes();
+        $original = $run->getRawOriginal();
+
+        return static function () use ($run, $attributes, $original): void {
+            $run->setRawAttributes($original, sync: true);
+            $run->setRawAttributes($attributes, sync: false);
+        };
+    }
+
+    /**
+     * Persist the transition, but only if the row still holds the status this instance
+     * read before deciding on it. Nothing serialises an operator's cancel against a
+     * worker driving the run: each holds its own FlowRun instance, and the queue's
+     * per-run lock covers jobs, not the CLI or the monitor's inline sweep. The
+     * conditional UPDATE is the same shape the action writes use, and for the same
+     * reason — it is the only form every supported driver enforces atomically.
+     *
+     * `status` is always part of the SET, even when unchanged: getDirty() can come back
+     * empty, and update([]) writes nothing and reports zero rows.
+     */
+    private function write(FlowRun $run, FlowStatus $from, FlowStatus $to): void
+    {
+        $dirty = $run->getDirty();
+
+        $affected = $run->newQuery()
+            ->whereKey($run->getKey())
+            ->where('status', $from)
+            ->update($dirty + ['status' => $run->getAttributes()['status']]);
+
+        if ($affected === 1) {
+            return;
+        }
+
+        // Zero rows is not proof the guard failed: MySQL counts rows it changed, not
+        // rows it matched, so an update whose every value already equals what is stored
+        // reports zero there and one on SQLite and PostgreSQL. Only a same-state
+        // transition with nothing else to write can land in that shape — status is what
+        // it already is, and updated_at, stored to the second, is rewritten inside that
+        // same second. There the row is read back, and from the writer: this read
+        // decides whether the write counts, and a lagging replica would answer with the
+        // very status the guard was fencing against.
+        $ambiguous = $from === $to && $dirty === [];
+
+        /** @var ?FlowStatus $actual */
+        $actual = $run->newQuery()
+            ->whereKey($run->getKey())
+            ->when($ambiguous, fn ($query) => $query->useWritePdo())
+            ->value('status');
+
+        if ($ambiguous && $actual === $from) {
+            return;
+        }
+
+        $this->refuse($run, $from, $to, $actual);
+    }
+
+    /**
+     * Report a transition the row refused. The status actually there goes into both the
+     * log line and the exception: without it an operator knows only that they lost.
+     */
+    private function refuse(FlowRun $run, FlowStatus $from, FlowStatus $to, ?FlowStatus $actual): never
+    {
+        app(AnomalyLog::class)->log(AnomalyLog::REASON_TRANSITION_LOST, [
+            'entity' => 'flow',
+            'flow_run_id' => $run->id,
+            'observed' => $from->value,
+            'intended' => $to->value,
+            'actual' => $actual?->value,
+        ]);
+
+        throw ConcurrentFlowTransitionException::for($run, $from, $to, $actual);
+    }
+
+    /**
+     * Land a run in a terminal state and close the work it leaves behind in one
+     * transaction: steps that never reached an outcome of their own, and wait-signals
+     * nothing will resolve. Every terminal transition passes through here, so no
+     * cancellation, expiry or child-close can mark a run finished while leaving its
+     * steps looking live.
+     *
+     * The run row is written inside the transaction rather than before it, so a failed
+     * settle rolls the run back for the caller to try again instead of leaving it
+     * finished but unsettled, with nothing left to notice. The transaction is opened on
+     * the run's own connection, so it still covers all three writes when the package
+     * lives on a dedicated one.
+     */
+    private function finish(FlowRun $run, FlowStatus $from, FlowStatus $to): void
+    {
+        $run->getConnection()->transaction(function () use ($run, $from, $to): void {
+            $this->write($run, $from, $to);
+
+            app(ActionRecorder::class)->settleOpenSteps($run);
+            app(SignalRecorder::class)->settleOpenWaits($run);
+        });
     }
 
     public function canTransition(FlowStatus $from, FlowStatus $to): bool

--- a/src/States/FlowStateMachine.php
+++ b/src/States/FlowStateMachine.php
@@ -11,6 +11,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
+use Illuminate\Support\Arr;
 use Throwable;
 
 class FlowStateMachine implements StateMachine
@@ -43,6 +44,11 @@ class FlowStateMachine implements StateMachine
         if ($to->isTerminal()) {
             $run->finished_at = $now;
         }
+
+        // Set here rather than left to the builder, which fills the column in the SQL
+        // without telling the model. Otherwise the instance — and every lifecycle event
+        // raised off it a moment later — keeps the timestamp of the previous write.
+        $run->updated_at = $now;
 
         try {
             $to->isTerminal()
@@ -104,21 +110,22 @@ class FlowStateMachine implements StateMachine
             return;
         }
 
+        // Read from the writer. This read decides whether the write counts and names the
+        // winner in the log and the exception; a lagging replica would answer with the
+        // very status the guard was fencing against.
+        /** @var ?FlowStatus $actual */
+        $actual = $run->newQuery()
+            ->useWritePdo()
+            ->whereKey($run->getKey())
+            ->value('status');
+
         // Zero rows is not proof the guard failed: MySQL counts rows it changed, not
         // rows it matched, so an update whose every value already equals what is stored
         // reports zero there and one on SQLite and PostgreSQL. Only a same-state
-        // transition with nothing else to write can land in that shape — status is what
-        // it already is, and updated_at, stored to the second, is rewritten inside that
-        // same second. There the row is read back, and from the writer: this read
-        // decides whether the write counts, and a lagging replica would answer with the
-        // very status the guard was fencing against.
-        $ambiguous = $from === $to && $dirty === [];
-
-        /** @var ?FlowStatus $actual */
-        $actual = $run->newQuery()
-            ->whereKey($run->getKey())
-            ->when($ambiguous, fn ($query) => $query->useWritePdo())
-            ->value('status');
+        // transition with nothing of its own to write can land in that shape — status is
+        // what it already is, and updated_at, stored to the second, is rewritten inside
+        // that same second.
+        $ambiguous = $from === $to && Arr::except($dirty, $run->getUpdatedAtColumn()) === [];
 
         if ($ambiguous && $actual === $from) {
             return;

--- a/tests/Feature/ConcurrentTransitionTest.php
+++ b/tests/Feature/ConcurrentTransitionTest.php
@@ -239,6 +239,25 @@ it('retries a child close it lost while the child is still live', function () {
     expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Waiting);
 });
 
+it('keeps the moment a run ended when the same landing arrives twice', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    $landed = SagaFlow::findRun($run->id);
+
+    $this->travel(5)->minutes();
+
+    // A landing that repeats is legal and writes, since the row is where the caller
+    // believes it is. What it must not do is move the marks of when the run ended.
+    app(StateMachine::class)->transition(SagaFlow::findRun($run->id), FlowStatus::Cancelled);
+
+    $after = SagaFlow::findRun($run->id);
+
+    expect($after->finished_at->equalTo($landed->finished_at))->toBeTrue()
+        ->and($after->cancelled_at->equalTo($landed->cancelled_at))->toBeTrue();
+});
+
 it('leaves an ordinary transition alone', function () {
     [, $current] = staleAndFresh();
 

--- a/tests/Feature/ConcurrentTransitionTest.php
+++ b/tests/Feature/ConcurrentTransitionTest.php
@@ -1,0 +1,231 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\FlowHandle;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\CancelChildWorkflowJob;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\StolenRollbackWorkflow;
+
+/**
+ * Nothing serialises an operator against a worker: the queue's per-run lock covers
+ * jobs, not the CLI and not the monitor's inline sweep, and each side holds its own
+ * FlowRun instance. A transition therefore writes only if the row still holds the
+ * status its caller read, and the loser is told rather than silently overwritten.
+ *
+ * Both sides are staged from one process here — two independently loaded instances,
+ * one of which moves the row — so the interleaving is exact instead of hoped for.
+ */
+function staleAndFresh(): array
+{
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    // What a worker and an operator each hold: the same row, read twice.
+    return [SagaFlow::findRun($run->id), SagaFlow::findRun($run->id)];
+}
+
+it('refuses to write a run that has moved on since it was read', function () {
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    expect(fn () => app(StateMachine::class)->transition($stale, FlowStatus::Running))
+        ->toThrow(ConcurrentFlowTransitionException::class);
+
+    // The cancellation stands whole: its own status, and the step and wait it settled.
+    $after = SagaFlow::findRun($stale->id);
+
+    expect($after->status)->toBe(FlowStatus::Cancelled)
+        ->and($after->signals->pluck('status')->all())->toBe([SignalStatus::Cancelled]);
+});
+
+it('names the status that actually holds the row', function () {
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    expect(fn () => app(StateMachine::class)->transition($stale, FlowStatus::Running))
+        ->toThrow(
+            ConcurrentFlowTransitionException::class,
+            "Cannot transition flow run [{$stale->id}] from [waiting] to [running]: the row is now [cancelled].",
+        );
+});
+
+it('checks the row even when the transition would not change the status', function () {
+    [$stale, $current] = staleAndFresh();
+
+    // A stale instance whose status already equals the target used to return early,
+    // before anything looked at the database — the one case a stale reader slipped
+    // through unchecked.
+    app(StateMachine::class)->transition($stale, FlowStatus::Running);
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    expect(fn () => app(StateMachine::class)->transition($stale, FlowStatus::Running))
+        ->toThrow(ConcurrentFlowTransitionException::class);
+});
+
+it('logs a refused transition with all three statuses', function () {
+    $path = sys_get_temp_dir().'/saga-transition-'.uniqid().'.log';
+
+    logToFile($path);
+
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    try {
+        app(StateMachine::class)->transition($stale, FlowStatus::Running);
+    } catch (ConcurrentFlowTransitionException) {
+        // The log line is what an operator has afterwards; the exception is not.
+    }
+
+    expect(file_get_contents($path))
+        ->toContain('transition_lost')
+        ->toContain($stale->id)
+        ->toContain('"observed":"waiting"')
+        ->toContain('"intended":"running"')
+        ->toContain('"actual":"cancelled"');
+});
+
+it('lets the operator know their cancellation did not happen', function () {
+    [$stale, $current] = staleAndFresh();
+
+    app(StateMachine::class)->transition($current, FlowStatus::Running);
+
+    // FlowHandle deliberately does not absorb this: a cancel that did not take effect
+    // is the one outcome an operator must not be left to infer.
+    expect(fn () => new FlowHandle($stale)->cancel('operator'))
+        ->toThrow(ConcurrentFlowTransitionException::class);
+
+    expect(SagaFlow::findRun($stale->id)->status)->toBe(FlowStatus::Running);
+});
+
+it('stops a drive over a run someone else took, without failing it', function () {
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    $driven = app(FlowExecutor::class)->drive($stale, RunMode::Sync);
+
+    // The engine absorbs it: no exception for the job to retry, no compensation, and
+    // the run handed back in the state the winner left it.
+    expect($driven->status)->toBe(FlowStatus::Cancelled)
+        ->and(SagaFlow::findRun($stale->id)->status)->toBe(FlowStatus::Cancelled);
+});
+
+it('stops an expiry over a run someone else took, without ending the sweep', function () {
+    [$stale, $current] = staleAndFresh();
+
+    FlowRun::query()->whereKey($stale->id)->update(['expires_at' => now()->subMinute()]);
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    // The sweep reaches expireRun() directly rather than through drive(), one run at a
+    // time, holding whatever it read before this cancel landed. A throw here would end
+    // the whole pass over a single run that is no longer the sweep's to expire.
+    $expired = app(FlowExecutor::class)->expireRun($stale);
+
+    expect($expired->status)->toBe(FlowStatus::Cancelled)
+        ->and(SagaFlow::findRun($stale->id)->status)->toBe(FlowStatus::Cancelled);
+});
+
+it('still refuses a transition the state graph forbids', function () {
+    [$stale] = staleAndFresh();
+
+    // The two refusals stay distinct: this one is illegal by the graph and repeating
+    // it cannot help, unlike a transition that merely lost a race.
+    SagaFlow::loadFlow($stale->id)->cancel('operator');
+
+    $cancelled = SagaFlow::findRun($stale->id);
+
+    expect(fn () => app(StateMachine::class)->transition($cancelled, FlowStatus::Running))
+        ->toThrow(InvalidTransitionException::class);
+});
+
+it('leaves the instance it refused exactly as it found it', function () {
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    try {
+        app(StateMachine::class)->transition($stale, FlowStatus::Cancelled);
+    } catch (ConcurrentFlowTransitionException) {
+        // The instance is mutated before the row is asked to confirm anything. A caller
+        // still holds it afterwards, and one reading a terminal status off a transition
+        // the database refused would be reading a run that does not exist.
+    }
+
+    expect($stale->status)->toBe(FlowStatus::Waiting)
+        ->and($stale->finished_at)->toBeNull()
+        ->and($stale->cancelled_at)->toBeNull()
+        ->and($stale->isDirty())->toBeFalse();
+});
+
+it('keeps changes the caller made before asking for a refused transition', function () {
+    [$stale, $current] = staleAndFresh();
+
+    SagaFlow::loadFlow($current->id)->cancel('operator');
+
+    // completeFlow() writes the result onto the instance and lets the transition carry
+    // it, so restoring the instance must put back what the caller had, not what the row
+    // last held.
+    $stale->result = 'carried';
+
+    try {
+        app(StateMachine::class)->transition($stale, FlowStatus::Completed);
+    } catch (ConcurrentFlowTransitionException) {
+        // Asserted below.
+    }
+
+    expect($stale->result)->toBe('carried')
+        ->and($stale->status)->toBe(FlowStatus::Waiting)
+        ->and($stale->isDirty())->toBeTrue();
+});
+
+it('tells an operator their manual rollback did not land', function () {
+    $run = SagaFlow::create(StolenRollbackWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    // The compensation moves the run while the rollback that started it is still
+    // running. Only the caller knows whether losing the landing matters, so the
+    // rollback raises and the two engine seams that own a landing answer for
+    // themselves — drive() for a failure it started, advance() for a queued
+    // continuation with nobody to tell.
+    expect(fn () => SagaFlow::loadFlow($run->id)->compensate())
+        ->toThrow(ConcurrentFlowTransitionException::class);
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Failed);
+});
+
+it('ends a child close cleanly when the child is taken mid-rollback', function () {
+    $child = SagaFlow::create(StolenRollbackWorkflow::class)->runSync();
+
+    // Closing a child under a Cancel policy is engine-owned work on a queue, and its
+    // rollback lands the child itself. The per-run lock covers jobs, so an operator
+    // reaching the child directly is a race this job has to end quietly rather than
+    // fail and retry over.
+    dispatch_sync(new CancelChildWorkflowJob($child->id, FlowStatus::Cancelled, true));
+
+    expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Failed);
+});
+
+it('leaves an ordinary transition alone', function () {
+    [, $current] = staleAndFresh();
+
+    app(StateMachine::class)->transition($current, FlowStatus::Running);
+
+    expect(SagaFlow::findRun($current->id)->status)->toBe(FlowStatus::Running)
+        ->and($current->status)->toBe(FlowStatus::Running)
+        ->and($current->isDirty())->toBeFalse();
+});

--- a/tests/Feature/ConcurrentTransitionTest.php
+++ b/tests/Feature/ConcurrentTransitionTest.php
@@ -12,6 +12,7 @@ use DiscoveryUkraine\SagaLaraFlow\Jobs\CancelChildWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\StealsRunCompensation;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\StolenRollbackWorkflow;
 
 /**
@@ -23,6 +24,10 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\StolenRollbackWorkflow;
  * Both sides are staged from one process here — two independently loaded instances,
  * one of which moves the row — so the interleaving is exact instead of hoped for.
  */
+beforeEach(function () {
+    StealsRunCompensation::reset();
+});
+
 function staleAndFresh(): array
 {
     $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
@@ -218,6 +223,20 @@ it('ends a child close cleanly when the child is taken mid-rollback', function (
     dispatch_sync(new CancelChildWorkflowJob($child->id, FlowStatus::Cancelled, true));
 
     expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Failed);
+});
+
+it('retries a child close it lost while the child is still live', function () {
+    $child = SagaFlow::create(StolenRollbackWorkflow::class)->runSync();
+
+    StealsRunCompensation::$leaveAs = FlowStatus::Waiting;
+
+    // Losing the child to a move that leaves it live is not a closed child. This job is
+    // the only thing applying the parent's close policy, so ending quietly here would
+    // strand a running child under a terminal parent with nothing left to close it.
+    expect(fn () => dispatch_sync(new CancelChildWorkflowJob($child->id, FlowStatus::Cancelled, true)))
+        ->toThrow(ConcurrentFlowTransitionException::class);
+
+    expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Waiting);
 });
 
 it('leaves an ordinary transition alone', function () {

--- a/tests/Feature/FlowCliTest.php
+++ b/tests/Feature/FlowCliTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
@@ -9,6 +10,7 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ManualCompensateWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TwoStepWorkflow;
+use Illuminate\Support\Facades\Artisan;
 
 function cliPendingRun(): FlowRun
 {
@@ -58,6 +60,28 @@ it('cancels a non-terminal run', function () {
     $this->artisan('saga-flow:cancel', ['run' => $run->id])->assertSuccessful();
 
     expect($run->fresh()->status)->toBe(FlowStatus::Cancelled);
+});
+
+it('shows the steps of a cancelled run as settled', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 1,
+        'action_class' => 'App\\Actions\\Ship',
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    $this->artisan('saga-flow:cancel', ['run' => $run->id])->assertSuccessful();
+
+    Artisan::call('saga-flow:show', ['run' => $run->id]);
+
+    // Matched on the table rows, not the whole output: the event log below them still
+    // says flow.waiting, which is history and stays true.
+    expect(Artisan::output())
+        ->toMatch('/\|\s+1\s+\|\s+cancelled\s+\|/')
+        ->toMatch('/\|\s+go\s+\|\s+cancelled\s+\|/');
 });
 
 it('warns when cancelling a terminal run', function () {

--- a/tests/Feature/RetryOnSignalOperatorTest.php
+++ b/tests/Feature/RetryOnSignalOperatorTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
@@ -249,21 +250,47 @@ it('drops the retry annotation once the run is no longer waiting', function () {
 
     $cancelled = SagaFlow::findRun($run->id);
 
-    // The step keeps its status — nothing rewrites action rows on cancellation —
-    // so the annotation has to be gated on the run, not on the step. A terminal run
-    // refuses signals, and naming one here would send the operator after a delivery
-    // that does nothing.
+    // Cancelling the run settles the step it was parked on, so both commands see a
+    // step that is plainly over. The retry policy it carried is still on the row for
+    // an operator to read.
     expect($cancelled->status)->toBe(FlowStatus::Cancelled)
         ->and($cancelled->actions()->where('sequence', 1)->first()->status)
-        ->toBe(ActionStatus::AwaitingRetry);
+        ->toBe(ActionStatus::Cancelled);
 
     expect(commandOutput('saga-flow:list'))
         ->toContain('cancelled')
         ->not->toContain('(retry:');
 
-    // Same reasoning in saga-flow:show. The wait-signal keeps its timeout_at, so the
-    // deadline is still there to print — but counting down to it would promise the
-    // operator a wait that nothing is going to resolve.
+    // Same in saga-flow:show. The wait-signal keeps its timeout_at, so the deadline is
+    // still there to print — but counting down to it would promise the operator a wait
+    // that nothing is going to resolve.
+    expect(commandOutput('saga-flow:show', ['run' => $run->id]))
+        ->toContain('balance-refilled 0/')
+        ->not->toContain('until');
+});
+
+it('drops the retry annotation while the run is rolling back', function () {
+    FlakyPaymentAction::reset(failures: 99);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)
+        ->withArguments('order-rolling-back')
+        ->runSync();
+
+    // Cancelling is not terminal, so the step stays parked with its deadline intact —
+    // the case the run-status gate exists for. Naming its signal would send the operator
+    // after a delivery a run already taken over by its rollback will not act on.
+    app(StateMachine::class)->transition(SagaFlow::findRun($run->id), FlowStatus::Cancelling);
+
+    $rollingBack = SagaFlow::findRun($run->id);
+
+    expect($rollingBack->status)->toBe(FlowStatus::Cancelling)
+        ->and($rollingBack->actions()->where('sequence', 1)->first()->status)
+        ->toBe(ActionStatus::AwaitingRetry);
+
+    expect(commandOutput('saga-flow:list'))
+        ->toContain('cancelling')
+        ->not->toContain('(retry:');
+
     expect(commandOutput('saga-flow:show', ['run' => $run->id]))
         ->toContain('balance-refilled 0/')
         ->not->toContain('until');

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -628,10 +628,13 @@ it('does not restart or re-park a parked step while collecting compensations', f
     $step = $final->actions()->where('sequence', 1)->first();
 
     // Compensation-only planning stops at the parked frontier: the step is not
-    // re-executed, not re-parked, and no second marker is written.
+    // re-executed, not re-parked, and no second marker is written. It ends up
+    // Cancelled because the run it belongs to finished, not because the seam touched
+    // it — an unspent retry budget is what shows the park was left alone.
     expect($final->status)->toBe(FlowStatus::Cancelled)
         ->and(FlakyPaymentAction::$calls)->toBe(1)
-        ->and($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->status)->toBe(ActionStatus::Cancelled)
+        ->and($step->retry_signal)->toBe('balance-refilled')
         ->and($step->retry_signal_attempts)->toBe(0)
         ->and($final->signals()->count())->toBe($before)
         ->and(CompensationLog::all())->toBe(['undo:created']);

--- a/tests/Feature/SignalWaitQueryTest.php
+++ b/tests/Feature/SignalWaitQueryTest.php
@@ -68,13 +68,15 @@ it('still finds a step whose signal arrived but whose resume never did', functio
         ->toBe([$parked]);
 });
 
-it('matches on the rows a run holds, not on the run status', function () {
+it('stops matching a run that has finished', function () {
     $parked = parkedRun();
 
     SagaFlow::loadFlow($parked)->cancel();
 
+    // Both filters read the rows a run holds, and a terminal run holds neither an open
+    // wait nor a parked step — so neither can hand an operator a run that would refuse
+    // the signal they were about to send.
     expect(SagaFlow::findRun($parked)->status)->toBe(FlowStatus::Cancelled)
-        ->and(SagaFlow::query()->whereAwaitingRetrySignal('balance-refilled')->count())->toBe(1)
-        ->and(SagaFlow::query()->whereAwaitingSignal('balance-refilled')->count())->toBe(1)
-        ->and(SagaFlow::query()->whereAwaitingRetrySignal('balance-refilled')->signalable()->count())->toBe(0);
+        ->and(SagaFlow::query()->whereAwaitingRetrySignal('balance-refilled')->count())->toBe(0)
+        ->and(SagaFlow::query()->whereAwaitingSignal('balance-refilled')->count())->toBe(0);
 });

--- a/tests/Feature/TerminalBatchExclusionTest.php
+++ b/tests/Feature/TerminalBatchExclusionTest.php
@@ -1,0 +1,140 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * No sweep may take work that belongs to a run which has already finished. Terminal
+ * settlement leaves only rows written before it existed, so these tests stage them
+ * straight into the database — the engine can no longer produce one.
+ *
+ * They matter because every sweep rejects such a row *after* spending a slot on it and
+ * *before* any counter holds it off: the doctor returns ahead of its throttle, and the
+ * monitor has no counter at all. Ordered oldest-first and never changing, one sits at
+ * the head of every batch for ever, starving the sweep of live candidates.
+ */
+function runWith(FlowStatus $status): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => $status,
+        'arguments' => [],
+    ]);
+}
+
+/**
+ * A step that outlived the run it belongs to. Written directly, the way a row that
+ * predates the settlement looks.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function strandedStep(FlowStatus $runStatus, ActionStatus $stepStatus, array $attributes = []): ActionRun
+{
+    $step = ActionRun::create([
+        'flow_run_id' => runWith($runStatus)->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => $stepStatus,
+        'attempts' => 0,
+        ...$attributes,
+    ]);
+
+    ActionRun::query()->whereKey($step->id)->update(['created_at' => now()->subMinutes(10)]);
+
+    return $step->fresh();
+}
+
+/**
+ * A wait-signal that outlived the run it belongs to, with its deadline already past.
+ */
+function strandedWait(FlowStatus $runStatus): FlowSignal
+{
+    return FlowSignal::create([
+        'flow_run_id' => runWith($runStatus)->id,
+        'name' => 'approval',
+        'status' => SignalStatus::Waiting,
+        'wait_sequence' => 0,
+        'timeout_at' => now()->subMinute(),
+    ]);
+}
+
+it('does not offer the doctor a lost action whose run has finished', function () {
+    $stranded = strandedStep(FlowStatus::Cancelled, ActionStatus::Pending);
+    $live = strandedStep(FlowStatus::Waiting, ActionStatus::Pending);
+
+    $due = collect(app(ActionRunRepository::class)->dueForRepair(100, 60, 10))->pluck('id')->all();
+
+    expect($due)->toBe([$live->id])
+        ->and($due)->not->toContain($stranded->id);
+});
+
+it('does not offer the doctor a stale running action whose run has finished', function () {
+    $attributes = ['reclaim_stale_at' => now()->subMinute()];
+
+    $stranded = strandedStep(FlowStatus::Expired, ActionStatus::Running, $attributes);
+    $live = strandedStep(FlowStatus::Running, ActionStatus::Running, $attributes);
+
+    $due = collect(app(ActionRunRepository::class)->dueForStaleRunningRepair(100, 10))->pluck('id')->all();
+
+    expect($due)->toBe([$live->id])
+        ->and($due)->not->toContain($stranded->id);
+});
+
+it('does not offer the monitor an overdue action whose run has finished', function () {
+    $attributes = ['expires_at' => now()->subMinute()];
+
+    $stranded = strandedStep(FlowStatus::Failed, ActionStatus::Pending, $attributes);
+    $live = strandedStep(FlowStatus::Waiting, ActionStatus::Pending, $attributes);
+
+    $due = collect(app(ActionRunRepository::class)->dueForExpiration(100))->pluck('id')->all();
+
+    expect($due)->toBe([$live->id])
+        ->and($due)->not->toContain($stranded->id);
+});
+
+it('does not offer the monitor an overdue wait whose run has finished', function () {
+    $stranded = strandedWait(FlowStatus::Cancelled);
+    $live = strandedWait(FlowStatus::Waiting);
+
+    $due = collect(app(SignalRepository::class)->dueForTimeout(100))->pluck('id')->all();
+
+    expect($due)->toBe([$live->id])
+        ->and($due)->not->toContain($stranded->id);
+});
+
+it('repairs a genuinely stuck action a batch of stranded ones would have crowded out', function () {
+    useDatabaseQueue();
+
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.batch_size', 2);
+
+    // Older than the stuck step below, so an unfiltered batch — ordered oldest-first
+    // and capped at two — would be filled entirely by these and never reach it.
+    foreach (range(1, 3) as $ignored) {
+        strandedStep(FlowStatus::Cancelled, ActionStatus::Pending);
+    }
+
+    $run = app(FlowExecutor::class)->drive(runWith(FlowStatus::Pending), RunMode::Queued);
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    $stuck = $run->actions()->first();
+
+    ActionRun::query()->whereKey($stuck->id)->update(['created_at' => now()->subMinutes(2)]);
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(1)
+        ->and($stuck->fresh()->repair_attempts)->toBe(1);
+});

--- a/tests/Feature/TerminalSettlementTest.php
+++ b/tests/Feature/TerminalSettlementTest.php
@@ -1,0 +1,321 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParentCancelPolicyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParentFailPolicyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TwoStepWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnwritableActionRun;
+use Illuminate\Database\QueryException;
+
+/**
+ * A run that reaches a terminal state settles the work it leaves behind: steps that
+ * never reached an outcome of their own become Cancelled, and wait-signals nothing
+ * will resolve become Cancelled too. Without it a finished run keeps rows that read
+ * as live — which lies to every operator surface and to every query a host builds
+ * over action_runs.
+ *
+ * The batches those leftover rows used to starve are covered by
+ * TerminalBatchExclusionTest.
+ */
+beforeEach(function () {
+    CompensationLog::reset();
+    FlakyPaymentAction::reset();
+
+    config()->set('saga-lara-flow.queue.after_commit', false);
+});
+
+/**
+ * A run parked on a step whose job has not run: the action row is Pending, which is
+ * exactly what a cancel has to settle.
+ */
+function runHoldingPendingStep(): FlowRun
+{
+    useDatabaseQueue();
+
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Pending,
+        'arguments' => [],
+    ]);
+
+    $driven = app(FlowExecutor::class)->drive($run, RunMode::Queued);
+
+    expect($driven->status)->toBe(FlowStatus::Waiting)
+        ->and($driven->actions()->first()->status)->toBe(ActionStatus::Pending);
+
+    return $driven;
+}
+
+/**
+ * A run parked by retryOnSignal(): a completed compensatable step at sequence 0 and
+ * a step at sequence 1 sitting in awaiting_retry behind an open wait.
+ */
+function runHoldingParkedStep(): FlowRun
+{
+    FlakyPaymentAction::reset(failures: 99);
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-settle')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    return $run;
+}
+
+/**
+ * @return array<int, ActionStatus>
+ */
+function stepStatuses(string $flowRunId): array
+{
+    return SagaFlow::findRun($flowRunId)
+        ->actions()
+        ->orderBy('sequence')
+        ->get()
+        ->pluck('status')
+        ->all();
+}
+
+it('settles a pending step when the run is cancelled', function () {
+    $run = runHoldingPendingStep();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Cancelled]);
+});
+
+it('settles a parked step and its open wait, keeping the step that completed', function () {
+    $run = runHoldingParkedStep();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    $cancelled = SagaFlow::findRun($run->id);
+
+    // Sequence 0 ran and succeeded; a cancelled run must still show that, or its
+    // compensation history stops making sense.
+    expect($cancelled->status)->toBe(FlowStatus::Cancelled)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Completed, ActionStatus::Cancelled])
+        ->and($cancelled->signals->pluck('status')->all())->toBe([SignalStatus::Cancelled]);
+});
+
+it('keeps the retry policy readable on a settled step', function () {
+    $run = runHoldingParkedStep();
+
+    $parked = $run->actions()->where('sequence', 1)->first();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    $settled = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
+
+    // Only the status is rewritten. finished_at carries the moment the last attempt
+    // failed, and overwriting it would erase when the step last really ran; the moment
+    // of the closure is on the run itself.
+    expect($settled->status)->toBe(ActionStatus::Cancelled)
+        ->and($settled->retry_signal)->toBe('balance-refilled')
+        ->and($settled->exception['message'] ?? null)->toBe('insufficient balance')
+        ->and($settled->finished_at?->toDateTimeString())->toBe($parked->finished_at?->toDateTimeString())
+        ->and($settled->finished_at)->not->toBeNull();
+});
+
+it('leaves a step that already reached an outcome of its own alone', function (ActionStatus $settled) {
+    $run = runHoldingPendingStep();
+
+    ActionRun::query()
+        ->where('flow_run_id', $run->id)
+        ->update(['status' => $settled]);
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    expect(stepStatuses($run->id))->toBe([$settled]);
+})->with([
+    ActionStatus::Completed,
+    ActionStatus::Failed,
+    ActionStatus::OptionalFailed,
+    ActionStatus::Expired,
+]);
+
+it('settles the steps of a run cancelled through compensate()', function () {
+    $run = runHoldingParkedStep();
+
+    SagaFlow::loadFlow($run->id)->compensate();
+
+    // Rolling back first changes nothing about the settlement: compensation undoes
+    // steps that succeeded, and the parked one never did.
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Completed, ActionStatus::Cancelled])
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('settles the steps of an expired run', function () {
+    $run = runHoldingPendingStep();
+
+    $run->expires_at = now()->subMinute();
+    $run->save();
+
+    app(FlowExecutor::class)->expireRun($run);
+
+    // The step is Cancelled, not Expired: Expired on a step means the monitor enforced
+    // that step's own deadline, and this one never had one.
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Expired)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Cancelled]);
+});
+
+it('settles the steps and waits of a child closed under the Cancel policy', function () {
+    $run = SagaFlow::create(ParentCancelPolicyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    SagaFlow::loadFlow($run->id)->cancel();
+
+    $child = $run->children()->first()->child->fresh();
+
+    expect($child->status)->toBe(FlowStatus::Cancelled)
+        ->and(stepStatuses($child->id))->toBe([ActionStatus::Completed])
+        ->and($child->signals->pluck('status')->all())->toBe([SignalStatus::Cancelled]);
+});
+
+it('settles the steps and waits of a child closed under the Fail policy', function () {
+    $run = SagaFlow::create(ParentFailPolicyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    SagaFlow::loadFlow($run->id)->compensate();
+
+    $child = $run->children()->first()->child->fresh();
+
+    // The child lands in Failed rather than Cancelled, and its open wait is settled
+    // all the same: the wait ended with the run, whatever the run's own outcome.
+    expect($child->status)->toBe(FlowStatus::Failed)
+        ->and($child->signals->pluck('status')->all())->toBe([SignalStatus::Cancelled]);
+});
+
+it('leaves a run that completed with nothing to settle', function () {
+    $run = SagaFlow::create(TwoStepWorkflow::class)->withArguments('order-complete')->runSync();
+
+    // Replay suspends on the first step that has not finished, so a run cannot reach
+    // Completed while holding one. Nothing is settled here, and that is the point.
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Completed, ActionStatus::Completed]);
+});
+
+it('rejects the outcome of a worker that finishes after the run was cancelled', function () {
+    $path = sys_get_temp_dir().'/saga-settle-'.uniqid().'.log';
+
+    logToFile($path);
+
+    $run = runHoldingPendingStep();
+    $step = $run->actions()->first();
+
+    expect(app(ActionRecorder::class)->startAction($step))->toBeTrue();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    // Settling a Running step fences the worker still holding it, exactly the way the
+    // monitor's expiry does: the outcome is refused rather than written over a run
+    // that has already finished, and the refusal is logged.
+    expect(app(ActionRecorder::class)->completeAction($step, 'too late'))->toBeFalse()
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Cancelled])
+        ->and(file_get_contents($path))->toContain('outcome_rejected');
+});
+
+it('keeps the outcome of a worker that finished before the run was cancelled', function () {
+    $run = runHoldingPendingStep();
+    $step = $run->actions()->first();
+
+    expect(app(ActionRecorder::class)->startAction($step))->toBeTrue()
+        ->and(app(ActionRecorder::class)->completeAction($step, 'in time'))->toBeTrue();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    // The other side of the same race: the step earned its outcome before the run
+    // ended, and the settlement passes over it rather than erasing what it returned.
+    expect(stepStatuses($run->id))->toBe([ActionStatus::Completed])
+        ->and(SagaFlow::findRun($run->id)->actions()->first()->result)->toBe('in time');
+});
+
+it('leaves the run where it was when settling it fails', function () {
+    $run = runHoldingParkedStep();
+
+    // A model pointed at a table that does not exist: the settlement fails for real,
+    // the way a lost connection or a rejected update would.
+    config()->set('saga-lara-flow.models.action_run', UnwritableActionRun::class);
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->cancel('operator'))->toThrow(QueryException::class);
+
+    config()->set('saga-lara-flow.models.action_run', ActionRun::class);
+
+    // The run row goes down with the settlement. A run left terminal but unsettled
+    // would read as finished to every surface while its steps stayed live.
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Completed, ActionStatus::AwaitingRetry])
+        ->and(SagaFlow::findRun($run->id)->signals->pluck('status')->all())->toBe([SignalStatus::Waiting]);
+});
+
+it('leaves the handle that failed to settle able to try again', function () {
+    $run = runHoldingParkedStep();
+    $handle = SagaFlow::loadFlow($run->id);
+
+    config()->set('saga-lara-flow.models.action_run', UnwritableActionRun::class);
+
+    expect(fn () => $handle->cancel('operator'))->toThrow(QueryException::class);
+
+    // The rollback reaches the caller's instance too. A model still carrying the
+    // cancellation the database refused would report a terminal run to the operator
+    // holding it, and cancel() would turn their retry into CannotCancelTerminalFlow.
+    expect($handle->status())->toBe(FlowStatus::Waiting);
+
+    config()->set('saga-lara-flow.models.action_run', ActionRun::class);
+
+    $handle->cancel('operator');
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled)
+        ->and(stepStatuses($run->id))->toBe([ActionStatus::Completed, ActionStatus::Cancelled]);
+});
+
+it('pins that a delivered signal nobody consumed is left as history', function () {
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+
+    SagaFlow::loadFlow($run->id)->signal('unrelated');
+
+    SagaFlow::loadFlow($run->id)->cancel();
+
+    $signals = SagaFlow::findRun($run->id)->signals->keyBy('name');
+
+    // The wait is live state and is settled; the delivered row records that a signal
+    // arrived and nobody used it, which stays true after the run ends.
+    expect($signals['go']->status)->toBe(SignalStatus::Cancelled)
+        ->and($signals['unrelated']->status)->toBe(SignalStatus::Received);
+});
+
+it('pins that a wait already marked received is left as history', function () {
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    SagaFlow::loadFlow($run->id)->signal('go');
+
+    expect(SagaFlow::findRun($run->id)->signals->first()->status)->toBe(SignalStatus::Received);
+
+    SagaFlow::loadFlow($run->id)->cancel();
+
+    // Delivery marks the wait Received before any replay consumes it. Rewriting that
+    // would erase the fact that the signal did arrive.
+    expect(SagaFlow::findRun($run->id)->signals->first()->status)->toBe(SignalStatus::Received);
+});

--- a/tests/Fixtures/StealsRunCompensation.php
+++ b/tests/Fixtures/StealsRunCompensation.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * Compensation that takes the run away from the rollback executing it: the row
+ * leaves Cancelling while its own compensations are still running, which is the
+ * one window in which a rollback can lose its landing.
+ */
+final class StealsRunCompensation extends Action
+{
+    /**
+     * @return array{stolen: string}
+     */
+    public function handle(string $label): array
+    {
+        FlowRun::query()
+            ->where('status', FlowStatus::Cancelling)
+            ->update(['status' => FlowStatus::Failed, 'finished_at' => now()]);
+
+        return ['stolen' => $label];
+    }
+}

--- a/tests/Fixtures/StealsRunCompensation.php
+++ b/tests/Fixtures/StealsRunCompensation.php
@@ -7,12 +7,20 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
 /**
- * Compensation that takes the run away from the rollback executing it: the row
- * leaves Cancelling while its own compensations are still running, which is the
- * one window in which a rollback can lose its landing.
+ * Compensation that takes the run away from the rollback executing it: the row leaves
+ * Cancelling while its own compensations are still running, which is the one window in
+ * which a rollback can lose its landing. $leaveAs chooses what the thief leaves behind,
+ * so a test can stage both a closed run and one that is still live.
  */
 final class StealsRunCompensation extends Action
 {
+    public static FlowStatus $leaveAs = FlowStatus::Failed;
+
+    public static function reset(): void
+    {
+        self::$leaveAs = FlowStatus::Failed;
+    }
+
     /**
      * @return array{stolen: string}
      */
@@ -20,7 +28,10 @@ final class StealsRunCompensation extends Action
     {
         FlowRun::query()
             ->where('status', FlowStatus::Cancelling)
-            ->update(['status' => FlowStatus::Failed, 'finished_at' => now()]);
+            ->update([
+                'status' => self::$leaveAs,
+                'finished_at' => self::$leaveAs->isTerminal() ? now() : null,
+            ]);
 
         return ['stolen' => $label];
     }

--- a/tests/Fixtures/StolenRollbackWorkflow.php
+++ b/tests/Fixtures/StolenRollbackWorkflow.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Completes one compensatable action and parks on a signal, like
+ * ManualCompensateWorkflow — but its compensation moves the run out from under the
+ * rollback, so a manual compensate() reaches its landing with the run already gone.
+ */
+final class StolenRollbackWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(StealsRunCompensation::class, 'a')
+            ->run();
+
+        $this->awaitSignal('go');
+    }
+}

--- a/tests/Fixtures/UnwritableActionRun.php
+++ b/tests/Fixtures/UnwritableActionRun.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+
+/**
+ * An ActionRun pointed at a table that does not exist, so any query against it
+ * fails. Swapped in through config('saga-lara-flow.models.action_run') to make the
+ * settlement of a finished run fail for real, without a mock.
+ */
+final class UnwritableActionRun extends ActionRun
+{
+    protected $table = 'saga_action_runs_that_do_not_exist';
+}

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -69,9 +69,14 @@ if (! function_exists('useDatabaseQueue')) {
         // --sleep=0 matters more than it looks: Worker::daemon() sleeps BEFORE it
         // checks stopWhenEmpty, so every drain would otherwise pay the default three
         // seconds after the queue is already empty.
+        //
+        // --memory is measured against the whole PHP process, not the jobs. The worker
+        // runs inside the test run, so at the default 128 it stops silently the moment
+        // the suite's own footprint passes it, leaving the queue full and the run parked.
         Artisan::call('queue:work', [
             '--stop-when-empty' => true,
             '--sleep' => 0,
+            '--memory' => 4096,
             '--no-interaction' => true,
         ]);
     }


### PR DESCRIPTION
Closes #14

`ActionStatus::Cancelled` was declared and never written. A run that ended kept its `action_runs` in
`pending`, `running` or `awaiting_retry` and its `flow_signals` wait-markers in `waiting`, so every
operator surface and every host query over those tables read them as live work.

## Terminal settlement

Every terminal transition now closes what the run was still holding, in one transaction with the run
row itself:

- steps in `Pending`, `Running` or `AwaitingRetry` become `Cancelled`;
- open wait-markers become `Cancelled` — `SignalStatus::Cancelled` is new.

Only `status` is written, and no event is appended: the run's own terminal event already records the
moment and the cause, and an `AwaitingRetry` row keeps the `finished_at` of the attempt that failed.
Steps that reached an outcome of their own are untouched, so a cancelled run still shows what ran.

`Expired` is not mirrored onto steps. `ActionRecorder::expireAction()` stays the sole writer of
`ActionStatus::Expired` and always pairs it with an exception payload and an `action.expired` event.

Four batch selectors — `dueForRepair`, `dueForStaleRunningRepair`, `dueForExpiration`,
`dueForTimeout` — now skip work whose run has finished. Each rejects such a row after spending a
batch slot and before bumping any throttle, so ordered oldest-first they would sit at the head of
every pass for ever.

Rows written before this release are not migrated; `UPGRADING.md` carries the SQL for anyone who
wants them settled.

## Fenced run transitions

Nothing serialises an operator against a worker: the queue's per-run lock covers jobs, not
`saga-flow:cancel`, not `FlowHandle`, not the monitor's inline sweep. Each side holds its own
`FlowRun`, and whichever saved last used to win — up to a stale worker writing `running` over a run
that was already cancelled and settled.

Every `flow_runs` transition is now a conditional `UPDATE` on the status its caller read, mirroring
the action writes. A same-state transition goes through the same write rather than returning early,
since a stale instance whose status happens to equal the target is exactly the one that would slip
past unchecked. A refusal is journalled as `transition_lost` (observed, intended, and the status
actually holding the row) and raises `ConcurrentFlowTransitionException` — deliberately not an
`InvalidTransitionException`, because that one means the graph forbids the move while this one means
somebody else got there first.

The engine absorbs it and stops: `FlowExecutor::drive()`, `FlowExecutor::expireRun()`,
`CancelChildWorkflowJob`, and the queued rollback's batch continuation. `driveInner()` re-throws it
ahead of its `catch (Throwable)`, so a lost race can never be mistaken for a business failure and
send the saga rolling back. `FlowHandle::cancel()` and `compensate()` let it reach the operator, and
so does a rollback an operator asked for — a cancellation that did not happen is the one outcome
nobody should have to infer.

A refused transition leaves the caller's `FlowRun` instance exactly as it found it, so catching one
and trying again works.

Two workers that both legitimately hold a run as `running` are out of scope here: nothing changes
between them for a condition to catch, and `WithoutOverlapping` on `run:{id}` remains what covers it.

## Also

- New `docs/docs/statuses.md`: every enum the engine writes, and what a finished run leaves behind.
- `UPGRADING.md` items 3, 4 and 13 corrected, and items 13–16 added.
- `drainQueue()` passes `--memory=4096` and `phpunit.xml.dist` pins `memory_limit=512M`. `queue:work`
  measures `--memory` against the whole PHP process, so at the default 128 the worker stopped
  mid-drain once the suite's own footprint passed it, leaving runs parked and failing unrelated tests
  depending on order.

349 tests / 1237 assertions, Pint and PHPStan level 5 clean, docs build clean.
