### PR TITLE
Document the engine rules and checks a contribution must satisfy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,43 @@
+<!--
+Please read CONTRIBUTING.md before filling this in.
+Open an issue first for anything breaking or larger than a focused fix.
+-->
+
+## What this changes
+
+<!-- The behaviour after this PR, in a few sentences. Link the issue it closes. -->
+
+## Checklist
+
+- [ ] One feature/fix; the diff is focused
+- [ ] `composer lint` passes (Pint + PHPStan level 5)
+- [ ] `composer test` passes
+- [ ] `CHANGELOG.md` is untouched
+- [ ] README **and** `/docs` updated if public behaviour changed, and `cd docs && npm run build` passes
+- [ ] Breaking changes are described in `UPGRADING.md`, under the section for the version in progress
+
+## Tests
+
+- [ ] Every regression test was verified to fail without its own fix
+- [ ] No existing assertion was deleted or weakened to fit the new behaviour
+- [ ] No mocks; faults are injected through model config or a fixture static
+
+<!-- Say which test covers what, and how you verified it fails without the fix. -->
+
+## Concurrency and drivers
+
+<!-- Delete this section only if the PR touches no code under
+     src/Runtime, src/States, src/Repositories, src/Jobs or src/Models. -->
+
+- [ ] No decision is taken from a model's in-memory status where the row could have moved
+- [ ] Conditional updates do not fence on a column that may already hold the value written
+      (MySQL counts *changed* rows, not matched ones)
+- [ ] Reads that decide something use `useWritePdo()`
+- [ ] No new write to `flow_runs.updated_at` as a side effect (it is the repair staleness clock)
+- [ ] Events raised inside a new transaction implement `ShouldDispatchAfterCommit`
+- [ ] Existing lock order (`flow_runs` → `action_runs` / `flow_signals`) is preserved
+
+CI runs on SQLite only. If this change is driver-dependent, explain how it behaves on MySQL and
+PostgreSQL:
+
+<!-- your reasoning here, or "not driver-dependent" -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,16 @@ before opening an issue or pull request.
 - Include the package version, PHP/Laravel versions, and a minimal reproduction.
 - For security vulnerabilities, follow [SECURITY.md](SECURITY.md) instead of opening a public issue.
 
+## Before you open a pull request
+
+- **Open an issue first** for anything breaking, anything that changes a public method's contract,
+  and anything larger than a focused fix. Agreeing on the shape first saves a rewrite.
+- **One feature/fix per PR.** Keep the diff focused.
+- **Do not edit `CHANGELOG.md`.** It is written by maintainers at release time and has no
+  `Unreleased` section. A PR that adds one will be asked to remove it.
+- **`UPGRADING.md`** is where a breaking change is described. Add to the section for the version in
+  progress; do not open a section of your own.
+
 ## Development setup
 
 This is a Laravel **package**, tested against a throwaway app via
@@ -32,22 +42,94 @@ composer format      # Laravel Pint
 composer lint        # Pint + PHPStan together
 ```
 
-## Pull requests
+## Engine rules
 
-- **One feature/fix per PR.** Keep the diff focused.
-- **Add tests.** New behaviour needs coverage; the suite runs with random order and fails on risky
-  or warning-producing tests.
-- **Run `composer lint`** before pushing — CI enforces Pint formatting and PHPStan level 5.
-- **Follow existing conventions.** Match the surrounding code's naming, structure, and idioms.
-- **Update documentation** (README and the docs under `/docs`) when you change public behaviour.
-- **Note queued tests** run against a real database queue driven with `queue:work --stop-when-empty`,
+This is a workflow engine: an operator, a queue worker, the monitor and the doctor all touch the
+same rows, and nothing serialises them. The queue's per-run lock covers jobs only — not the CLI,
+not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src/States`,
+`src/Repositories` and `src/Jobs` are held to the rules below.
+
+### Deciding on state
+
+- **Never decide from a model's in-memory status.** `FlowQuery::handles()` hands out snapshots taken
+  in one pass, so by the time a bulk loop reaches the hundredth handle the first ones are stale. A
+  check that must hold at write time belongs in the write.
+- **Fence writes with a conditional `UPDATE`** on the value you read (`where('status', $from)`).
+  It is the only form every supported driver enforces atomically — `lockForUpdate()` is a no-op on
+  SQLite.
+- **Zero affected rows is not proof the fence failed.** MySQL's `rowCount()` counts rows it
+  *changed*, not rows it *matched*, and Laravel never sets `PDO::MYSQL_ATTR_FOUND_ROWS`. An `UPDATE`
+  whose every value already equals what is stored reports zero there and one on SQLite and
+  PostgreSQL. Never fence on an update whose only written column may already hold its value, and
+  refuse only after reading back what actually holds the row. See `FlowStateMachine::write()`.
+- **A read that decides something must use `useWritePdo()`.** A lagging replica will answer with the
+  very state the fence was guarding against.
+- **Do not `refresh()` a model the caller still holds.** It discards their unsaved attributes;
+  `FlowHandle` hands that same instance back.
+
+### Status boundaries
+
+`FlowStatus::terminal()` and `FlowStatus::signalable()` are different sets and are not
+interchangeable. `Cancelling` is **not** terminal — it is a run mid-rollback. Swapping one boundary
+for the other changes public behaviour and needs its own exception and its own documentation.
+
+### Side effects
+
+- **`flow_runs.updated_at` is the repair staleness clock** (`EloquentFlowRepository::dueForRepair()`).
+  Do not write it as a side effect of something else; you will push stuck runs out of the doctor's
+  reach.
+- **Models are config-swappable** (`saga-lara-flow.models.*`). Never build an update payload from
+  `newInstance()->getAttributes()` — a host model's default attributes ride along and overwrite real
+  columns. Name the columns you mean to write.
+- **Events dispatched inside a transaction are seen before it commits.** If you wrap existing writes
+  in a transaction, check every event they raise: it must implement `ShouldDispatchAfterCommit`, or
+  listeners will act on a delivery that may still roll back — while holding your row locks.
+- **Keep the lock order.** Existing writers take `flow_runs` first, then `action_runs` and
+  `flow_signals`. Do not reverse it.
+
+## Tests
+
+- **Add tests.** The suite runs in random order and fails on risky or warning-producing tests.
+- **There are no mocks in this project.** Inject faults through model config
+  (`saga-lara-flow.models.*`) or a static on a fixture — see `tests/Fixtures/`.
+- **Verify every regression test fails without its own fix**, and say so in the PR description.
+  A test written after the code often only restates it.
+- **Do not weaken an existing test to fit new behaviour.** If a test carries a comment explaining
+  what it guards, that guard has to survive somewhere — move it, don't delete it.
+- **Queued tests** run against a real database queue driven with `queue:work --stop-when-empty`,
   not the `sync` driver.
 
-## Running a single test
+Run a single test:
 
 ```bash
 vendor/bin/pest tests/Feature/CreateWorkflowTest.php
 vendor/bin/pest --filter="cancels a non-terminal run"
 ```
+
+### What CI does not check
+
+CI runs on **SQLite only**. Anything driver-dependent — row counts, locking, timestamp precision,
+transaction isolation — is invisible to it. Call out such a change in your PR and reason about
+MySQL and PostgreSQL explicitly; a green suite is not evidence there.
+
+## Documentation
+
+- **Update both** the README and the docs under `/docs` — they carry overlapping tables and
+  examples, and a change to one alone leaves the other lying.
+- **State facts.** No before/after narration, no justification of the change, no retelling of the
+  decision, no issue or PR numbers. Describe how the package behaves now.
+- **Check the prose you did not write.** A behaviour change usually falsifies a sentence somewhere
+  else in the same page.
+- `cd docs && npm run build` must pass — broken links fail the build.
+
+## Code style
+
+- **Run `composer lint`** before pushing — CI enforces Pint formatting and PHPStan level 5.
+- **Follow existing conventions.** Match the surrounding code's naming, structure, and idioms.
+- **Comments earn their place.** Keep what does not follow from the code and would otherwise be
+  refactored away; delete what the documentation already says.
+- **Do not add Eloquent query scopes to the models.** `FlowQuery` deliberately wraps a Builder
+  instead — larastan cannot type a scope on a generic Builder resolved from a config-swappable
+  model. Put the predicate where it is used.
 
 **Happy coding!**


### PR DESCRIPTION
Expands `CONTRIBUTING.md` with the rules a change to this engine has to satisfy, and adds a pull request template that asks for them.

## `CONTRIBUTING.md`

**Before you open a pull request** — open an issue first for breaking or larger changes; `CHANGELOG.md` is written by maintainers at release time and must not be edited; `UPGRADING.md` entries go under the section for the version in progress.

**Engine rules** (new) — an operator, a worker, the monitor and the doctor all touch the same rows, and the queue's per-run lock covers jobs only:

- Do not decide from a model's in-memory status; `FlowQuery::handles()` hands out snapshots taken in one pass.
- Fence writes with a conditional `UPDATE` — `lockForUpdate()` is a no-op on SQLite.
- Zero affected rows is not proof the fence failed: MySQL counts rows *changed*, not matched, and Laravel never sets `PDO::MYSQL_ATTR_FOUND_ROWS`. Refuse only after reading back what holds the row.
- A read that decides something uses `useWritePdo()`.
- Do not `refresh()` a model the caller still holds.
- `FlowStatus::terminal()` and `FlowStatus::signalable()` are different sets; `Cancelling` is not terminal.
- `flow_runs.updated_at` is the repair staleness clock — do not write it as a side effect.
- Models are config-swappable: never build an update payload from `newInstance()->getAttributes()`.
- Events raised inside a new transaction need `ShouldDispatchAfterCommit`.
- Keep the lock order `flow_runs` → `action_runs` / `flow_signals`.

**Tests** — no mocks; verify every regression test fails without its own fix and say so in the PR; do not weaken an existing test to fit new behaviour. A new **What CI does not check** section states that CI is SQLite-only, so driver-dependent behaviour needs explicit reasoning.

**Documentation** — update README and `/docs` together, state facts only, and re-read the surrounding prose a behaviour change may have falsified.

**Code style** — do not add Eloquent query scopes to the models; `FlowQuery` wraps a Builder deliberately.

## `.github/pull_request_template.md`

New. Carries the checklist, and a **Concurrency and drivers** section — removable only when the PR touches no code under `src/Runtime`, `src/States`, `src/Repositories`, `src/Jobs` or `src/Models` — which asks how the change behaves on MySQL and PostgreSQL.

Documentation only; no source or test files are touched.