### PR TITLE
Let a retryOnSignal() policy object decide whether a failure is worth parking

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,8 @@ $this->action(ChargeCard::class, $orderId)
         maxRetries: 3,                                  // null = unbounded, never negative
         waitSeconds: 86400,                             // how long one wait may last
         only: [InsufficientBalanceException::class],    // null = park on any exception
+        // the final say, for what the class alone cannot express
+        when: fn (RetryContext $context): bool => $context->failure->code !== 422,
     )
     ->run();
 ```
@@ -391,8 +393,42 @@ $this->action(ChargeCard::class, $orderId)
 Deliver `balance-refilled` the way you deliver any other signal and `ChargeCard` runs again, alone;
 earlier steps stay completed and un-compensated. The layers stack: Laravel's `$tries` first, then
 `retryOnSignal()`, then `continueOnFailure()`, then hard failure and compensation. When the budget is
-spent or the wait times out, the step fails exactly as it would have without the policy — same
-`ActionFailedException`, same rollback.
+spent, the wait times out, or the policy refuses the failure, the step fails exactly as it would have
+without the policy — same `ActionFailedException`, same rollback.
+
+A policy worth naming goes in a class instead, and the call site takes the object:
+
+```php
+final class BalanceRefillRecovery extends RetryPolicy
+{
+    public function signal(): string
+    {
+        return 'balance-refilled';
+    }
+
+    public function maxRetries(): ?int
+    {
+        return 3;
+    }
+
+    public function only(): ?array
+    {
+        return [InsufficientBalanceException::class];
+    }
+
+    public function shouldRetry(RetryContext $context): bool
+    {
+        return $context->failure->code !== 422;
+    }
+}
+
+$this->action(ChargeCard::class, $orderId)->retryOnSignal(new BalanceRefillRecovery)->run();
+```
+
+Nothing about the policy is persisted — it is rebuilt by `handle()` on every replay — and it decides
+whether to **park**, not whether to wake: an already-parked step spends its cycle when the signal
+arrives. The predicate must stay a pure function of its `RetryContext`; writing to the run it is
+deciding for raises `RetryPolicyReentryException`.
 
 A retry consumes **no new sequence**: the step reuses its own ordinal and `action_runs` row, so
 downstream steps land identically whether it retried or not. `saga()->step()` mirrors the method.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -407,6 +407,30 @@ Note that neither is a subclass of `InvalidTransitionException`, and `Concurrent
 is deliberately not one either: that exception means the state graph forbids the move, and repeating
 it cannot help, whereas a lost race is transient and re-reading the run is the sensible response.
 
+### 17. `retryOnSignal()` takes a policy object and a `when:` predicate
+
+The first parameter widens from `string` to `RetryPolicy|string`, and a fifth optional parameter,
+`when:`, is appended. Every existing call site compiles and behaves identically — nothing is
+required of you.
+
+What is new is the fourth gate. A failure that passed `only:` is now also put to `when:` (or to the
+policy's `shouldRetry()`), and a `false` there ends the policy for that failure: the step fails
+exactly as it would have without one. With neither given, nothing is asked and nothing changes.
+
+The one thing to know before writing a policy class: **every method is called on every replay**, and
+only the ceiling's stored value is frozen. `maxRetries()` is read when the step is scheduled and held
+on `action_runs.retry_signal_max_attempts`, which is what replay enforces from then on — the same
+rule `maxRetries:` has always followed. What is *not* frozen is the calling: the builder reconstructs
+the policy on every pass, so all five run again even for a step already scheduled or completed, and
+their values, `maxRetries()`'s excepted, take effect immediately. A deploy therefore changes
+`signal()`, `waitSeconds()`, `only()` and `shouldRetry()` for runs already in flight — including
+which signal a parked step will next wait for.
+
+`ActionBuilder` and `SagaStepBuilder` are constructed by the engine, and this release widens
+`retryOnSignal()` on both. That is reachable if you override the public `Workflow::action()` to
+return your own builder subclass: PHP refuses to load an override whose signature no longer matches,
+so widen it to `RetryPolicy|string $signal` and accept the fifth `?Closure $when` parameter.
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -421,10 +421,11 @@ The one thing to know before writing a policy class: **nothing about it is persi
 ceiling's stored value is frozen. `maxRetries()` is read when the step is scheduled and held on
 `action_runs.retry_signal_max_attempts`, which is what replay enforces from then on — the same rule
 `maxRetries:` has always followed. What is *not* frozen is the calling: your `handle()` builds the
-policy again on every pass, and the builder reads `signal()`, `waitSeconds()` and `only()` off it
-again — for a step already scheduled or completed included — with their values taking effect
-immediately. `shouldRetry()` is asked only of a failed step, at the gate. A deploy therefore changes
-all four for runs already in flight — including which signal a parked step will next wait for.
+policy again on every pass, and the builder re-reads `signal()`, `waitSeconds()` and `only()` off it
+every time — including on a pass that only replays a step already scheduled or completed. Their
+values take effect immediately. `shouldRetry()` is stored rather than called, and runs at the gate
+only for a step that has failed. A deploy therefore changes all four for runs already in flight —
+including which signal a parked step will next wait for.
 
 `ActionBuilder` and `SagaStepBuilder` are constructed by the engine, and this release widens
 `retryOnSignal()` on both. That is reachable if you override the public `Workflow::action()` to

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -417,14 +417,14 @@ What is new is the fourth gate. A failure that passed `only:` is now also put to
 policy's `shouldRetry()`), and a `false` there ends the policy for that failure: the step fails
 exactly as it would have without one. With neither given, nothing is asked and nothing changes.
 
-The one thing to know before writing a policy class: **every method is called on every replay**, and
-only the ceiling's stored value is frozen. `maxRetries()` is read when the step is scheduled and held
-on `action_runs.retry_signal_max_attempts`, which is what replay enforces from then on — the same
-rule `maxRetries:` has always followed. What is *not* frozen is the calling: the builder reconstructs
-the policy on every pass, so all five run again even for a step already scheduled or completed, and
-their values, `maxRetries()`'s excepted, take effect immediately. A deploy therefore changes
-`signal()`, `waitSeconds()`, `only()` and `shouldRetry()` for runs already in flight — including
-which signal a parked step will next wait for.
+The one thing to know before writing a policy class: **nothing about it is persisted**, and only the
+ceiling's stored value is frozen. `maxRetries()` is read when the step is scheduled and held on
+`action_runs.retry_signal_max_attempts`, which is what replay enforces from then on — the same rule
+`maxRetries:` has always followed. What is *not* frozen is the calling: your `handle()` builds the
+policy again on every pass, and the builder reads `signal()`, `waitSeconds()` and `only()` off it
+again — for a step already scheduled or completed included — with their values taking effect
+immediately. `shouldRetry()` is asked only of a failed step, at the gate. A deploy therefore changes
+all four for runs already in flight — including which signal a parked step will next wait for.
 
 `ActionBuilder` and `SagaStepBuilder` are constructed by the engine, and this release widens
 `retryOnSignal()` on both. That is reachable if you override the public `Workflow::action()` to

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -192,11 +192,17 @@ delivery already made under the old name. That is true of the plain string form 
 
 A predicate may not write to the run it is deciding for — no `action()`, `awaitSignal()`, `child()`,
 `sideEffect()` or `tag()`, and no `signal()`, `cancel()`, `compensate()` or `withTags()` on that
-run's own handle.
-It is not asked again once the step it guards succeeds, so an ordinal it consumed would be left
-unclaimed and the next step would land in the wrong slot, and a run it cancelled would be handed a
-live wait a moment later. The engine refuses the attempt with `RetryPolicyReentryException` before
-anything is written. Other runs are fair game.
+run's own handle. It is not asked again once the step it guards succeeds, so an ordinal it consumed
+would be left unclaimed and the next step would land in the wrong slot, and a run it cancelled would
+be handed a live wait a moment later.
+
+Nor may it drive *any* run, its own or somebody else's — `runSync()` and `compensate()` are refused
+too. One runtime serves the whole process, so a nested pass would rewind the ordinal counter and
+empty the saga stack of the pass waiting on the answer. Reading other runs — their status, their
+history, their tags — stays fair game.
+
+The engine refuses every one of these with `RetryPolicyReentryException` before anything is
+written.
 
 A predicate that throws anything else is read as `false`: the step fails as it would have without a
 policy, and the run carries the step's own business failure rather than the policy's. The throw is

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -176,8 +176,10 @@ cancel the run, or let the wait time out.
 :::
 
 :::info One value is frozen; no method is
-All five methods run on every replay — the builder rebuilds the policy each pass, so even a step
-already scheduled or completed calls them again.
+Your `handle()` builds the policy afresh on every replay, so nothing about it is persisted. The
+builder reads `signal()`, `maxRetries()`, `waitSeconds()` and `only()` there and then, for a step
+already scheduled or completed included. `shouldRetry()` it keeps for the gate, where only a failed
+step is put to it.
 
 `maxRetries()` is the one whose value is kept: it is written to
 `action_runs.retry_signal_max_attempts` when the step is scheduled, and every later replay enforces

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -38,10 +38,11 @@ alone; if it succeeds, the workflow continues to `ShipOrder` as if nothing had h
 
 ```php
 ->retryOnSignal(
-    string $signal,
+    RetryPolicy|string $signal,
     ?int $maxRetries = null,   // null = unbounded
     ?int $waitSeconds = null,  // null = monitor.expiration.defaults.signal
     ?array $only = null,       // null = park on any exception
+    ?Closure $when = null,     // null = park on every failure that passed $only
 )
 ```
 
@@ -54,6 +55,9 @@ alone; if it succeeds, the workflow continues to `ShipOrder` as if nothing had h
   replay.
 - **`$only`** — a list of exception classes that may trigger a park. Subclasses count. Anything else
   fails the step normally, so a `TypeError` never parks a saga for a day.
+- **`$when`** — the final say on a failure that got past `$only`. It receives a
+  [`RetryContext`](#deciding-on-more-than-the-exception-class) and returning `false` ends the policy
+  for that failure.
 
 `maxRetries` and `waitSeconds` must be zero or greater — `null`, not a negative number, is how you
 say "no limit". A negative value raises an `InvalidArgumentException` rather than reaching the
@@ -72,6 +76,136 @@ $this->action(ChargeCard::class, $orderId)
     ->run();
 ```
 
+## Deciding on more than the exception class
+
+`$only` answers one question — *is it one of these classes?* When the decision needs the HTTP status,
+the provider's error code, or how much of the budget is already gone, pass a predicate:
+
+```php
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+
+->retryOnSignal(
+    'balance-refilled',
+    maxRetries: 3,
+    only: [PaymentFailedException::class],
+    // A rejected card is not going to be fixed by topping the balance up.
+    when: fn (RetryContext $context): bool => $context->failure->code !== 422,
+)
+```
+
+The predicate runs during replay, so it must answer the same question the same way on every pass.
+Capture workflow arguments, not request state or `now()`.
+
+### A policy you can name and reuse
+
+A closure repeated at five call sites is the same copy-paste the argument list was. Extend
+`RetryPolicy` and the whole policy becomes one object with a name, a unit test, and one place to
+change:
+
+```php
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryPolicy;
+
+final class BalanceRefillRecovery extends RetryPolicy
+{
+    public function signal(): string
+    {
+        return 'balance-refilled';
+    }
+
+    public function maxRetries(): ?int
+    {
+        return 3;
+    }
+
+    public function only(): ?array
+    {
+        return [PaymentFailedException::class];
+    }
+
+    public function shouldRetry(RetryContext $context): bool
+    {
+        return $context->failure->code !== 422;
+    }
+}
+```
+
+```php
+$this->action(ChargeCard::class, $orderId)
+    ->compensateWith(RefundCard::class, $orderId)
+    ->retryOnSignal(new BalanceRefillRecovery)
+    ->run();
+```
+
+Only `signal()` is required; the other four have defaults that reproduce the plain
+`retryOnSignal('name')` behaviour. Construct the policy inside `handle()` — it is rebuilt on every
+replay and never stored, so it must not depend on anything a replay cannot reproduce.
+
+Only `shouldRetry()` is guarded. A getter that throws fails the run and leaves that step's
+compensation unregistered, the way any throwing expression in `handle()` does.
+
+A policy and the arguments it replaces are two sources of truth for one decision, so combining them
+raises an `InvalidArgumentException` at build time.
+
+### What the predicate is given
+
+```php
+final readonly class RetryContext
+{
+    public string $runId;
+    public string $workflowClass;
+    public string $actionClass;
+    public int $sequence;
+    public string $signal;
+    public int $cyclesSpent;    // signal-gated cycles already spent; 0 the first time
+    public ?int $cap;           // the ceiling on the row; null is unbounded
+    public int $executions;     // every run of the step, the queue's own retries included
+    public RecordedFailure $failure;
+}
+```
+
+`$failure` is a snapshot of `action_runs.exception` — `class`, `message`, `code`, and
+`is(...$classes)` for a subclass-aware check. It is not the thrown object: a queued step fails in
+another process, and every later replay reads the row, so there is no stack trace. `class` is `null`
+when the row records none, and `is()` answers `false` for such a failure.
+
+:::warning It decides whether to park, not whether to wake
+Once a step is parked, the signal that arrives spends a cycle and re-runs it. The predicate is not
+asked again. A policy that changes its mind mid-wait does not cancel a wait already advertised —
+cancel the run, or let the wait time out.
+:::
+
+:::info One value is frozen; no method is
+All five methods run on every replay — the builder rebuilds the policy each pass, so even a step
+already scheduled or completed calls them again.
+
+`maxRetries()` is the one whose value is kept: it is written to
+`action_runs.retry_signal_max_attempts` when the step is scheduled, and every later replay enforces
+the row, so raising it in a deploy does not lift the ceiling of a step already parked. See
+[the budget is read from the row](#the-budget-is-read-from-the-row-not-from-your-code).
+
+The other four take effect immediately, for runs already in flight included.
+`action_runs.retry_signal` records the name a step last parked on but is rewritten at every parking
+and never read back, so renaming a signal moves what a parked step will next wait for and abandons a
+delivery already made under the old name. That is true of the plain string form too.
+:::
+
+A predicate may not write to the run it is deciding for — no `action()`, `awaitSignal()`, `child()`,
+`sideEffect()` or `tag()`, and no `signal()`, `cancel()`, `compensate()` or `withTags()` on that
+run's own handle.
+It is not asked again once the step it guards succeeds, so an ordinal it consumed would be left
+unclaimed and the next step would land in the wrong slot, and a run it cancelled would be handed a
+live wait a moment later. The engine refuses the attempt with `RetryPolicyReentryException` before
+anything is written. Other runs are fair game.
+
+A predicate that throws anything else is read as `false`: the step fails as it would have without a
+policy, and the run carries the step's own business failure rather than the policy's. The throw is
+recorded in the anomaly log under `retry_policy_threw`, because a policy that quietly throws on
+every call looks exactly like one that never parks anything.
+
+The predicate is not called exactly once — a process that dies between the decision and the parking
+makes the next replay ask again. Keep it pure and put side effects in a listener.
+
 ## Where it sits among the other failure layers
 
 Failure handling stacks, and `retryOnSignal()` sits in the middle:
@@ -81,8 +215,8 @@ Failure handling stacks, and `retryOnSignal()` sits in the middle:
 2. **`retryOnSignal()`** parks and waits. Every arriving signal spends one cycle and re-runs the
    step, which starts its `$tries` over.
 3. **`continueOnFailure()`** — see [Optional actions](./optional-actions.md) — takes over only after
-   the retry budget is spent or the wait times out. An optional step with a retry policy waits
-   first and falls back to its fallback value second.
+   the retry budget is spent, the wait times out, or the policy refuses the failure. An optional step
+   with a retry policy waits first and falls back to its fallback value second.
 4. **Hard failure and compensation** — the ordinary path from
    [Sagas & compensations](./sagas-and-compensation.md).
 
@@ -97,6 +231,8 @@ A step stops waiting when any one of these happens:
 - **The signal arrives.** One cycle is spent, the step runs again.
 - **The budget runs out.** `retry_signal_attempts` reaches `maxRetries` → hard failure.
 - **The wait times out.** The monitor flips the wait to `timed_out` → hard failure.
+- **The policy refuses the failure.** `only` does not list it, or `shouldRetry()` / `when` returns
+  `false` → hard failure.
 - **The run expires** on its own `expires_at`, or is cancelled. The park ends with it: the step is
   settled as `cancelled` and its wait along with it, so nothing keeps advertising a signal that
   would no longer be acted on. See [statuses](./statuses.md).
@@ -126,7 +262,7 @@ $this->saga()
     ->step(CreateOrder::class, $orderId)->compensateWith(CancelOrder::class, $orderId)
     ->step(ChargeCard::class, $orderId)
         ->compensateWith(RefundCard::class, $orderId)
-        ->retryOnSignal('balance-refilled', maxRetries: 3)
+        ->retryOnSignal(new BalanceRefillRecovery)
     ->step(ShipOrder::class, $orderId)
     ->run();
 ```

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -177,9 +177,10 @@ cancel the run, or let the wait time out.
 
 :::info One value is frozen; no method is
 Your `handle()` builds the policy afresh on every replay, so nothing about it is persisted. The
-builder reads `signal()`, `maxRetries()`, `waitSeconds()` and `only()` there and then, for a step
-already scheduled or completed included. `shouldRetry()` it keeps for the gate, where only a failed
-step is put to it.
+builder reads `signal()`, `maxRetries()`, `waitSeconds()` and `only()` the moment it is handed the
+object, and it does so on every pass — including a pass that only replays a step already scheduled
+or completed. `shouldRetry()` is stored rather than called: it runs at the gate, and only for a step
+that has failed.
 
 `maxRetries()` is the one whose value is kept: it is written to
 `action_runs.retry_signal_max_attempts` when the step is scheduled, and every later replay enforces

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -19,11 +19,17 @@ use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\InternalFlowControl;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RecordedFailure;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryPolicy;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationEntry;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowSuspender;
@@ -50,9 +56,14 @@ use Throwable;
  * nothing. onCompensationFailure() overrides the default Stop policy. All three
  * resolve with precedence action > group (saga()) > config.
  *
+ * Constructed by the engine, and reachable for subclassing only by overriding
+ * Workflow::action(): its method signatures are treated as internal.
+ *
  * retryOnSignal() turns a failure into a wait: the step parks on a named signal, and
  * each delivery re-runs THIS step alone at the very same ordinal. The seam is the only
- * decision-maker, so nothing else resolves the row it reads back.
+ * decision-maker, so nothing else resolves the row it reads back. Its policy may be
+ * four arguments or a RetryPolicy object; either way nothing about it is persisted
+ * beyond the signal name and the ceiling, and the decision is retaken on every replay.
  */
 class ActionBuilder
 {
@@ -84,6 +95,14 @@ class ActionBuilder
      * @var list<class-string<Throwable>>|null
      */
     private ?array $retryOnly = null;
+
+    /**
+     * Both forms of the fourth gate reduce to this, so nothing below knows which the
+     * caller used: a RetryPolicy contributes shouldRetry(...), when: contributes itself.
+     *
+     * @var ?Closure(RetryContext): bool
+     */
+    private ?Closure $retryDecision = null;
 
     private ?int $reclaimStaleAfterSeconds = null;
 
@@ -234,18 +253,38 @@ class ActionBuilder
      * $waitSeconds bounds ONE wait (null falls back to the configured default signal
      * timeout);
      * $only restricts the policy to the listed exception classes and their
-     * subclasses (null reacts to every failure). Once the budget is spent, the wait
-     * times out, or the failure falls outside $only, the step fails exactly as it
-     * would have without this policy.
+     * subclasses (null reacts to every failure);
+     * $when has the final say on a failure that passed $only, and returning false
+     * from it ends the policy for that failure. Once the budget is spent, the wait
+     * times out, the failure falls outside $only, or $when refuses it, the step
+     * fails exactly as it would have without this policy.
+     *
+     * A RetryPolicy passed as $signal carries all four itself, and combining it with
+     * any of them is refused. See RetryPolicy for which of its values survive a
+     * deploy and which do not.
      *
      * @param  list<class-string<Throwable>>|null  $only
+     * @param  ?Closure(RetryContext): bool  $when
      */
     public function retryOnSignal(
-        string $signal,
+        RetryPolicy|string $signal,
         ?int $maxRetries = null,
         ?int $waitSeconds = null,
         ?array $only = null,
+        ?Closure $when = null,
     ): static {
+        if ($signal instanceof RetryPolicy) {
+            $this->rejectPolicyWithArguments($maxRetries, $waitSeconds, $only, $when);
+
+            // Unwrapped once, so the policy is asked as often as an argument list is
+            // evaluated and every seam below goes on reading a plain string.
+            $when = $signal->shouldRetry(...);
+            $maxRetries = $signal->maxRetries();
+            $waitSeconds = $signal->waitSeconds();
+            $only = $signal->only();
+            $signal = $signal->signal();
+        }
+
         $this->rejectNegative('maxRetries', $maxRetries);
         $this->rejectNegative('waitSeconds', $waitSeconds);
 
@@ -253,6 +292,7 @@ class ActionBuilder
         $this->retryMaxRetries = $maxRetries;
         $this->retryWaitSeconds = $waitSeconds;
         $this->retryOnly = $only;
+        $this->retryDecision = $when;
 
         return $this;
     }
@@ -448,8 +488,20 @@ class ActionBuilder
                     app(FlowSuspender::class)->suspend('action', $sequence);
                 }
 
-                if ($this->shouldRetryOnSignal($step)) {
-                    $this->parkForRetry($step, $sequence);
+                try {
+                    if ($this->shouldRetryOnSignal($step)) {
+                        $this->parkForRetry($step, $sequence);
+                    }
+                } catch (RetryPolicyReentryException $reentry) {
+                    // The predicate is broken, but the step under it really did fail,
+                    // and the rollback is built from this pass alone — so without this
+                    // the one thing the run forgets is the compensation the caller
+                    // asked for on this very step.
+                    if ($this->shouldCompensateFailedStep()) {
+                        $this->pushCompensation($step->id, $sequence);
+                    }
+
+                    throw $reentry;
                 }
 
                 // An optional step still has retries left: it is not yet
@@ -798,6 +850,8 @@ class ActionBuilder
      * Whether this replay pass should park the failed step for a signal-gated retry.
      * The seam decides alone: the only-filter is never persisted, and the budget and
      * the wait are read from the row.
+     *
+     * @throws InternalFlowControl
      */
     private function shouldRetryOnSignal(ActionRun $step): bool
     {
@@ -818,7 +872,77 @@ class ActionBuilder
             return false;
         }
 
-        return $this->matchesOnly($step);
+        if (! $this->matchesOnly($step)) {
+            return false;
+        }
+
+        return $this->policyAllows($step, $maxRetries);
+    }
+
+    /**
+     * The last gate, and the only one that runs the caller's own code — hence last,
+     * after three structural checks that cost a column read.
+     *
+     * A throw is absorbed as "do not park", the outcome the caller was already
+     * prepared for; letting it out would fail the whole run on one path and truncate
+     * the compensation stack in silence on the other. It is logged rather than
+     * swallowed: a policy that never parks looks identical to one that always throws.
+     *
+     * @throws InternalFlowControl
+     */
+    private function policyAllows(ActionRun $step, ?int $maxRetries): bool
+    {
+        $decide = $this->retryDecision;
+
+        if ($decide === null) {
+            return true;
+        }
+
+        // Compensation-only planning stops at this step either way, so the answer
+        // would change nothing — and it runs caller code, which that pass must not.
+        if ($this->runtime->isCollecting()) {
+            return true;
+        }
+
+        $flowRun = $this->runtime->run();
+
+        // Outside the guard: that absorbs a defect in the caller's predicate, and
+        // reading our own row is not one. A throw here is ours and should surface.
+        $context = new RetryContext(
+            runId: $flowRun->id,
+            workflowClass: $flowRun->workflow_class,
+            actionClass: $step->action_class,
+            sequence: $step->sequence,
+            signal: (string) $this->retrySignal,
+            cyclesSpent: $step->retry_signal_attempts,
+            cap: $maxRetries,
+            executions: $step->attempts,
+            failure: RecordedFailure::fromRecord($step->exception),
+        );
+
+        $this->runtime->beginDeciding();
+
+        try {
+            return $decide($context);
+        } catch (InternalFlowControl|HistoryContractMismatchException|RetryPolicyReentryException $control) {
+            // Not answers, and none has a safe reading: the engine suspends with the
+            // first, reports the second on its own terms, and the third is a workflow
+            // the caller has to fix, not a step that quietly never parks.
+            throw $control;
+        } catch (Throwable $exception) {
+            app(AnomalyLog::class)->log(AnomalyLog::REASON_RETRY_POLICY_THREW, [
+                'flow_run_id' => $flowRun->id,
+                'action_run_id' => $step->id,
+                'sequence' => $step->sequence,
+                'signal' => $this->retrySignal,
+                'exception' => $exception::class,
+                'message' => $exception->getMessage(),
+            ]);
+
+            return false;
+        } finally {
+            $this->runtime->endDeciding();
+        }
     }
 
     /**
@@ -909,6 +1033,36 @@ class ActionBuilder
                 "retryOnSignal() {$name} must be zero or greater, got {$value}.",
             );
         }
+    }
+
+    /**
+     * A policy object and the arguments it replaces are two sources of truth for one
+     * decision, and there is no reading of "both" that is not a guess about which one
+     * the caller meant. Refuse it, naming what to drop.
+     *
+     * @param  list<class-string<Throwable>>|null  $only
+     */
+    private function rejectPolicyWithArguments(
+        ?int $maxRetries,
+        ?int $waitSeconds,
+        ?array $only,
+        ?Closure $when,
+    ): void {
+        $given = array_keys(array_filter([
+            'maxRetries' => $maxRetries !== null,
+            'waitSeconds' => $waitSeconds !== null,
+            'only' => $only !== null,
+            'when' => $when !== null,
+        ]));
+
+        if ($given === []) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            'retryOnSignal() takes a RetryPolicy or the arguments it replaces, not both; '
+            .'drop '.implode(', ', $given).' or move it into the policy.',
+        );
     }
 
     /**

--- a/src/Builders/SagaStepBuilder.php
+++ b/src/Builders/SagaStepBuilder.php
@@ -4,6 +4,8 @@ namespace DiscoveryUkraine\SagaLaraFlow\Builders;
 
 use Closure;
 use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationFailurePolicy;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryPolicy;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use Throwable;
 
@@ -14,6 +16,8 @@ use Throwable;
  * config). retryOnSignal() mirrors the action-level policy so a step inside a group
  * can park on a signal too. step()/run() delegate back to the group so the fluent
  * chain reads as a single transactional block.
+ *
+ * Constructed by SagaBuilder::step(); its method signatures are treated as internal.
  */
 final class SagaStepBuilder
 {
@@ -28,7 +32,7 @@ final class SagaStepBuilder
 
     private ?bool $compensateOnSelfFailure = null;
 
-    private ?string $retrySignal = null;
+    private RetryPolicy|string|null $retrySignal = null;
 
     private ?int $retryMaxRetries = null;
 
@@ -38,6 +42,11 @@ final class SagaStepBuilder
      * @var list<class-string<Throwable>>|null
      */
     private ?array $retryOnly = null;
+
+    /**
+     * @var ?Closure(RetryContext): bool
+     */
+    private ?Closure $retryWhen = null;
 
     private ?int $reclaimStaleAfterSeconds = null;
 
@@ -84,18 +93,26 @@ final class SagaStepBuilder
      * suspends the group where it stands: the steps already completed keep their
      * compensations on the stack and roll back only if this one eventually gives up.
      *
+     * Stored untouched, policy object included, and handed to the action builder when
+     * the group runs. Reading or validating here would happen before run() replayed a
+     * single step, so a misconfigured later step would fail the group with its earlier
+     * steps' compensations unregistered.
+     *
      * @param  list<class-string<Throwable>>|null  $only
+     * @param  ?Closure(RetryContext): bool  $when
      */
     public function retryOnSignal(
-        string $signal,
+        RetryPolicy|string $signal,
         ?int $maxRetries = null,
         ?int $waitSeconds = null,
         ?array $only = null,
+        ?Closure $when = null,
     ): self {
         $this->retrySignal = $signal;
         $this->retryMaxRetries = $maxRetries;
         $this->retryWaitSeconds = $waitSeconds;
         $this->retryOnly = $only;
+        $this->retryWhen = $when;
 
         return $this;
     }
@@ -187,6 +204,7 @@ final class SagaStepBuilder
                 $this->retryMaxRetries,
                 $this->retryWaitSeconds,
                 $this->retryOnly,
+                $this->retryWhen,
             );
         }
 

--- a/src/Concerns/Workflow/ProvidesFlowMetadata.php
+++ b/src/Concerns/Workflow/ProvidesFlowMetadata.php
@@ -2,6 +2,8 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Concerns\Workflow;
 
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
+
 /**
  * Read-only access to the current run's identity/metadata, plus queryable tags,
  * attachable one at a time or in bulk.
@@ -10,9 +12,17 @@ trait ProvidesFlowMetadata
 {
     /**
      * Attach a queryable tag to the current run. Idempotent across replays.
+     *
+     * @throws RetryPolicyReentryException
      */
     public function tag(string $key, string|int|null $value = null): void
     {
+        // The only workflow-facing write that never takes an ordinal, so
+        // nextSequence() cannot cover it: guard it where it happens.
+        if ($this->runtime->isDecidingRun($this->runtime->run()->id)) {
+            throw RetryPolicyReentryException::for('tag()');
+        }
+
         $this->runtime->run()->tags()->updateOrCreate(
             ['key' => $key],
             ['value' => $value === null ? null : (string) $value],

--- a/src/Exceptions/RetryPolicyReentryException.php
+++ b/src/Exceptions/RetryPolicyReentryException.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+/**
+ * A retryOnSignal() predicate reached back into the workflow DSL. It cannot be
+ * allowed to: the predicate is asked only while a failed step is deciding whether
+ * to park, and it is not asked at all once that step succeeds — so any ordinal it
+ * consumed would be left unclaimed on the next replay and the step after it would
+ * land in the wrong slot.
+ *
+ * Unlike an ordinary throw from a predicate, this one is not absorbed as "do not
+ * park". There is no answer that makes it safe, and the alternative is history the
+ * engine would later blame on the workflow having changed.
+ */
+class RetryPolicyReentryException extends FlowException
+{
+    public static function for(string $operation): self
+    {
+        return new self(
+            "A retryOnSignal() decision tried to run {$operation}. A retry predicate must be a pure "
+            .'function of the RetryContext it is given: it cannot start actions, await signals, run '
+            .'child workflows, or record side effects, because it is not replayed once the step it '
+            .'guards succeeds. Move the work into the action, or into a listener.'
+        );
+    }
+}

--- a/src/Exceptions/RetryPolicyReentryException.php
+++ b/src/Exceptions/RetryPolicyReentryException.php
@@ -20,8 +20,8 @@ class RetryPolicyReentryException extends FlowException
         return new self(
             "A retryOnSignal() decision tried to run {$operation}. A retry predicate must be a pure "
             .'function of the RetryContext it is given: it cannot start actions, await signals, run '
-            .'child workflows, or record side effects, because it is not replayed once the step it '
-            .'guards succeeds. Move the work into the action, or into a listener.'
+            .'child workflows, record side effects, or drive another run, because it is not replayed '
+            .'once the step it guards succeeds. Move the work into the action, or into a listener.'
         );
     }
 }

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -8,6 +8,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotCancelTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ChildWorkflowManager;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -31,6 +32,21 @@ readonly class FlowHandle
     public function id(): string
     {
         return $this->flowRun->id;
+    }
+
+    /**
+     * Refuse a write to the run whose own retryOnSignal() predicate is running.
+     *
+     * @throws RetryPolicyReentryException
+     */
+    private function rejectWhileDeciding(string $operation): void
+    {
+        // Asked of the executor, not of the container: FlowExecutor is a singleton
+        // holding a scoped runtime, and a queue worker forgets scoped instances
+        // between jobs — so a fresh resolve would answer for the wrong instance.
+        if (app(FlowExecutor::class)->isDecidingRun($this->flowRun->id)) {
+            throw RetryPolicyReentryException::for($operation);
+        }
     }
 
     public function run(): FlowRun
@@ -80,6 +96,8 @@ readonly class FlowHandle
      */
     public function withTags(array $tags): static
     {
+        $this->rejectWhileDeciding('withTags()');
+
         foreach ($tags as $key => $value) {
             $this->flowRun->tags()->updateOrCreate(['key' => $key], ['value' => $value]);
         }
@@ -100,6 +118,8 @@ readonly class FlowHandle
      */
     public function signal(string $name, array $payload = []): FlowRun
     {
+        $this->rejectWhileDeciding('signal()');
+
         app(SignalDispatcher::class)->deliver($this->flowRun, $name, $payload);
 
         return $this->flowRun;
@@ -136,6 +156,8 @@ readonly class FlowHandle
      */
     public function cancel(?string $reason = null): FlowRun
     {
+        $this->rejectWhileDeciding('cancel()');
+
         if ($this->flowRun->isTerminal()) {
             throw CannotCancelTerminalFlowException::for($this->flowRun);
         }
@@ -161,6 +183,8 @@ readonly class FlowHandle
      */
     public function compensate(): FlowRun
     {
+        $this->rejectWhileDeciding('compensate()');
+
         if ($this->flowRun->isTerminal()) {
             throw CannotCancelTerminalFlowException::for($this->flowRun);
         }

--- a/src/Retry/RecordedFailure.php
+++ b/src/Retry/RecordedFailure.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Retry;
+
+use Throwable;
+
+/**
+ * What action_runs.exception records about the attempt that failed: the class, the
+ * message and the code, and nothing else. It is a snapshot of a column, not a live
+ * Throwable — by the time a policy is asked, the object that was thrown is gone (a
+ * queued step fails in another process, and every later replay reads the row). There
+ * is no stack trace and no previous exception for the same reason.
+ *
+ * $class is null when the row records none. is() answers false for such a failure,
+ * the same way an explicit only: filter has always refused one.
+ */
+final readonly class RecordedFailure
+{
+    public function __construct(
+        public ?string $class = null,
+        public string $message = '',
+        public int|string $code = 0,
+    ) {}
+
+    /**
+     * Rebuild a failure from the row's exception column, tolerating a partial or
+     * absent record rather than assuming the three keys are there.
+     *
+     * @param  ?array<int|string, mixed>  $exception
+     */
+    public static function fromRecord(?array $exception): self
+    {
+        $class = $exception['class'] ?? null;
+        $message = $exception['message'] ?? null;
+        $code = $exception['code'] ?? null;
+
+        return new self(
+            is_string($class) ? $class : null,
+            is_string($message) ? $message : '',
+            is_int($code) || is_string($code) ? $code : 0,
+        );
+    }
+
+    /**
+     * Whether the failure is one of these classes, subclasses included.
+     *
+     * @param  class-string<Throwable>  ...$classes
+     */
+    public function is(string ...$classes): bool
+    {
+        $failure = $this->class;
+
+        if ($failure === null) {
+            return false;
+        }
+
+        return array_any(
+            $classes,
+            fn (string $candidate): bool => is_a($failure, $candidate, allow_string: true),
+        );
+    }
+}

--- a/src/Retry/RetryContext.php
+++ b/src/Retry/RetryContext.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Retry;
+
+/**
+ * Everything a retry policy is told about the failure it is being asked to judge.
+ * Built by the replay seam from the step's row; the policy never constructs one.
+ *
+ * The counters are three different things and none of them is a "try number":
+ * $cyclesSpent counts the signal-gated cycles already spent on this step (0 the
+ * first time the step parks), $cap is the ceiling the row was scheduled with, and
+ * $executions counts every run of the step, the queue's own retries included.
+ *
+ * The row is deliberately absent. A policy is a predicate over this snapshot; the
+ * step it is deciding about is mid-replay, and handing it out would invite a write.
+ */
+final readonly class RetryContext
+{
+    public function __construct(
+        public string $runId,
+        public string $workflowClass,
+        public string $actionClass,
+        public int $sequence,
+        public string $signal,
+        public int $cyclesSpent,
+        public ?int $cap,
+        public int $executions,
+        public RecordedFailure $failure,
+    ) {}
+}

--- a/src/Retry/RetryPolicy.php
+++ b/src/Retry/RetryPolicy.php
@@ -13,10 +13,11 @@ use Throwable;
  * step behaves exactly as it would have with the equivalent arguments.
  *
  * Your handle() builds the policy afresh on every replay, so nothing about it is
- * persisted. The builder reads signal(), maxRetries(), waitSeconds() and only() there
- * and then — for a step already scheduled or completed included; shouldRetry() it
- * keeps for the gate, where only a failed step is put to it. What is frozen is one
- * value, not one method:
+ * persisted. The builder reads signal(), maxRetries(), waitSeconds() and only() the
+ * moment it is handed the object, and it does so on every pass — including a pass
+ * that only replays a step already scheduled or completed. shouldRetry() is stored
+ * rather than called: it runs at the gate, and only for a step that has failed. What
+ * is frozen is one value, not one method:
  *
  * - maxRetries() is read when the step is SCHEDULED into
  *   action_runs.retry_signal_max_attempts, and every later replay enforces the row.

--- a/src/Retry/RetryPolicy.php
+++ b/src/Retry/RetryPolicy.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Retry;
+
+use Throwable;
+
+/**
+ * A named, reusable retryOnSignal() policy: one object that owns which signal a
+ * failed step parks on, how long it may keep parking, and — the part four scalar
+ * arguments could never express — whether THIS failure is worth parking at all.
+ *
+ * Pass an instance to ActionBuilder::retryOnSignal(); the builder reads it and the
+ * step behaves exactly as it would have with the equivalent arguments.
+ *
+ * All five run on every replay — the builder rebuilds the policy each pass, so even a
+ * step already scheduled or completed calls them again. What is frozen is one value,
+ * not one method:
+ *
+ * - maxRetries() is read when the step is SCHEDULED into
+ *   action_runs.retry_signal_max_attempts, and every later replay enforces the row.
+ *   Raising it in a deploy does not lift the ceiling of a step already parked.
+ * - signal(), waitSeconds(), only() and shouldRetry() take effect immediately, so a
+ *   deploy changes them for runs already in flight. action_runs.retry_signal records
+ *   the name a step last parked on but is rewritten at every parking and never read
+ *   back: renaming a signal moves what a parked step will next wait for, and abandons
+ *   a delivery already made under the old name.
+ *
+ * Every method runs during replay, so all five must be deterministic — the same
+ * question must get the same answer on every pass. Two further obligations:
+ *
+ * - The first four are called while the workflow is still building the step, before
+ *   the seam has resolved anything, so one that throws takes the whole run down with
+ *   it and the step it was attached to never registers its compensation — exactly as
+ *   an argument expression that throws would. Only shouldRetry() is guarded.
+ * - shouldRetry() is not called exactly once (a process that dies between the
+ *   decision and the parking makes the next replay ask again), so it must be a pure
+ *   predicate and leave side effects to a listener. It also may not write to the run
+ *   it is deciding for — no seam, and no FlowHandle mutation on that run: it is not
+ *   asked again once the step it guards succeeds, so an ordinal it consumed would be
+ *   left for nobody to replay, and a run it cancelled would be handed a live wait the
+ *   moment it returned. RetryPolicyReentryException refuses the attempt before
+ *   anything is written. Other runs are fair game.
+ */
+abstract class RetryPolicy
+{
+    /**
+     * The signal name a failed step parks on. Takes effect on every replay: the
+     * column records it but is never read back.
+     */
+    abstract public function signal(): string;
+
+    /**
+     * Cap on signal-gated cycles; null falls back to
+     * actions.retry_on_signal.max_retries, and null there means unbounded. Called on
+     * every replay, but only the value read at scheduling is kept, on the row.
+     */
+    public function maxRetries(): ?int
+    {
+        return null;
+    }
+
+    /**
+     * How long ONE wait may last before the monitor gives up on it; null falls back
+     * to the configured default signal timeout.
+     */
+    public function waitSeconds(): ?int
+    {
+        return null;
+    }
+
+    /**
+     * Exception classes this policy reacts to, subclasses included; null reacts to
+     * every failure. Checked before shouldRetry().
+     *
+     * @return list<class-string<Throwable>>|null
+     */
+    public function only(): ?array
+    {
+        return null;
+    }
+
+    /**
+     * The final say. Returning false ends the policy for this failure and the step
+     * fails exactly as it would have without a retry policy at all.
+     *
+     * It decides whether to PARK, not whether to wake: once a step is parked, the
+     * signal that arrives spends a cycle and re-runs it without asking again.
+     *
+     * A throw is absorbed and read as false — the step fails rather than the run —
+     * and recorded in the engine's anomaly log. Reaching back into the workflow is
+     * the exception: that is refused outright, because no answer makes it safe.
+     */
+    public function shouldRetry(RetryContext $context): bool
+    {
+        return true;
+    }
+}

--- a/src/Retry/RetryPolicy.php
+++ b/src/Retry/RetryPolicy.php
@@ -12,9 +12,11 @@ use Throwable;
  * Pass an instance to ActionBuilder::retryOnSignal(); the builder reads it and the
  * step behaves exactly as it would have with the equivalent arguments.
  *
- * All five run on every replay — the builder rebuilds the policy each pass, so even a
- * step already scheduled or completed calls them again. What is frozen is one value,
- * not one method:
+ * Your handle() builds the policy afresh on every replay, so nothing about it is
+ * persisted. The builder reads signal(), maxRetries(), waitSeconds() and only() there
+ * and then — for a step already scheduled or completed included; shouldRetry() it
+ * keeps for the gate, where only a failed step is put to it. What is frozen is one
+ * value, not one method:
  *
  * - maxRetries() is read when the step is SCHEDULED into
  *   action_runs.retry_signal_max_attempts, and every later replay enforces the row.
@@ -25,8 +27,8 @@ use Throwable;
  *   back: renaming a signal moves what a parked step will next wait for, and abandons
  *   a delivery already made under the old name.
  *
- * Every method runs during replay, so all five must be deterministic — the same
- * question must get the same answer on every pass. Two further obligations:
+ * None of the five is asked once and remembered, so all five must be deterministic —
+ * the same question must get the same answer on every pass. Two further obligations:
  *
  * - The first four are called while the workflow is still building the step, before
  *   the seam has resolved anything, so one that throws takes the whole run down with

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -12,8 +12,10 @@ use Throwable;
  * where the world turned out not to be what the engine assumed — a claim lost to
  * whoever already owned the row, an outcome write refused because the row had changed
  * hands, a batch already closed by a duplicate before its own job reported, a run
- * transition refused because the row had moved on. All are ordinary consequences of
- * at-least-once delivery and of nothing serialising an operator against a worker.
+ * transition refused because the row had moved on, a retry policy that threw. Most are
+ * ordinary consequences of at-least-once delivery and of nothing serialising an operator
+ * against a worker; the last is a defect in the caller's own code, journalled here for
+ * the same reason as the rest — the engine carried on, so nothing else records it.
  *
  * None of them fails a job. A refused transition also reaches its caller: the engine
  * absorbs it and stops, but FlowHandle lets it surface, because an operator whose
@@ -33,6 +35,8 @@ final readonly class AnomalyLog
     public const string REASON_BATCH_FINISHED_EARLY = 'batch_finished_early';
 
     public const string REASON_TRANSITION_LOST = 'transition_lost';
+
+    public const string REASON_RETRY_POLICY_THREW = 'retry_policy_threw';
 
     /**
      * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -43,6 +43,15 @@ class FlowExecutor
     ) {}
 
     /**
+     * Whether the run currently deciding a retryOnSignal() predicate is this one.
+     * The executor answers because it owns the runtime a pass is driven with.
+     */
+    public function isDecidingRun(string $flowRunId): bool
+    {
+        return $this->runtime->isDecidingRun($flowRunId);
+    }
+
+    /**
      * @throws Throwable
      */
     public function drive(FlowRun $flowRun, RunMode $mode): FlowRun

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -13,6 +13,7 @@ use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\InternalFlowControl;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Support\TenancyManager;
 use Throwable;
@@ -52,10 +53,28 @@ class FlowExecutor
     }
 
     /**
+     * A retryOnSignal() predicate may read any run it likes, but it may not drive
+     * one — not even somebody else's. There is a single runtime behind this
+     * singleton, and a nested pass rebinds and resets the one the deciding pass is
+     * suspended inside: the outer run loses its saga stack, its ordinal counter and,
+     * once the nested pass clears up after itself, the run it was bound to.
+     *
+     * @throws RetryPolicyReentryException
+     */
+    private function rejectWhileDeciding(): void
+    {
+        if ($this->runtime->isDeciding()) {
+            throw RetryPolicyReentryException::for('a nested flow execution');
+        }
+    }
+
+    /**
      * @throws Throwable
      */
     public function drive(FlowRun $flowRun, RunMode $mode): FlowRun
     {
+        $this->rejectWhileDeciding();
+
         try {
             return $this->tenancy->for(
                 $flowRun,
@@ -133,6 +152,8 @@ class FlowExecutor
      */
     public function collectCompensations(FlowRun $flowRun): array
     {
+        $this->rejectWhileDeciding();
+
         return $this->tenancy->for(
             $flowRun,
             $flowRun->workflow_class,

--- a/src/Runtime/FlowRuntime.php
+++ b/src/Runtime/FlowRuntime.php
@@ -118,6 +118,15 @@ final class FlowRuntime
     }
 
     /**
+     * Whether any retryOnSignal() decision is in flight. Reads on other runs are
+     * fine during one; driving the engine is not, because there is one runtime.
+     */
+    public function isDeciding(): bool
+    {
+        return $this->deciding;
+    }
+
+    /**
      * Whether the run being decided is this one. A predicate may touch other runs;
      * not the one whose parking the seam writes the moment it returns.
      */

--- a/src/Runtime/FlowRuntime.php
+++ b/src/Runtime/FlowRuntime.php
@@ -4,6 +4,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\MissingFlowContextException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
 /**
@@ -24,6 +25,8 @@ final class FlowRuntime
     private int $sagaGroup = 0;
 
     private bool $collecting = false;
+
+    private bool $deciding = false;
 
     public function __construct(
         private readonly StepSequence $sequence = new StepSequence,
@@ -48,8 +51,16 @@ final class FlowRuntime
         return $this->mode;
     }
 
+    /**
+     * @throws RetryPolicyReentryException
+     */
     public function nextSequence(): int
     {
+        // Every seam takes its ordinal here first, so one check covers them all.
+        if ($this->deciding) {
+            throw RetryPolicyReentryException::for('a workflow operation');
+        }
+
         return $this->sequence->next();
     }
 
@@ -93,6 +104,29 @@ final class FlowRuntime
     }
 
     /**
+     * Enter a retryOnSignal() decision: while the caller's predicate runs, no seam
+     * may consume an ordinal. See RetryPolicyReentryException for why.
+     */
+    public function beginDeciding(): void
+    {
+        $this->deciding = true;
+    }
+
+    public function endDeciding(): void
+    {
+        $this->deciding = false;
+    }
+
+    /**
+     * Whether the run being decided is this one. A predicate may touch other runs;
+     * not the one whose parking the seam writes the moment it returns.
+     */
+    public function isDecidingRun(string $flowRunId): bool
+    {
+        return $this->deciding && $this->flowRun?->id === $flowRunId;
+    }
+
+    /**
      * Start a replay pass: rewind the sequence counter and the saga stack/group
      * counter so the pass rebuilds them deterministically from stored history.
      */
@@ -102,6 +136,7 @@ final class FlowRuntime
         $this->sagaStack->reset();
         $this->sagaGroup = 0;
         $this->collecting = false;
+        $this->deciding = false;
     }
 
     /**

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -23,13 +23,16 @@ use DiscoveryUkraine\SagaLaraFlow\Runtime\HistoryContractGuard;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\SignalRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\DeclinableChargeAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FailingWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalFallbackWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RecordingRetryPolicy;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryBudgetSagaWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryPolicyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliablePaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliableRetryOnSignalWorkflow;
 use Illuminate\Support\Facades\Artisan;
@@ -44,6 +47,8 @@ use Illuminate\Support\Facades\Event;
 beforeEach(function () {
     FlakyPaymentAction::reset();
     UnreliablePaymentAction::reset();
+    DeclinableChargeAction::reset();
+    RecordingRetryPolicy::reset();
     CompensationLog::reset();
 });
 
@@ -1176,4 +1181,42 @@ it('does not reopen an optional step that already published its give-up', functi
     expect($final->status)->toBe(FlowStatus::Completed)
         ->and($final->actions()->where('sequence', 0)->first()->status)
         ->toBe(ActionStatus::OptionalFailed);
+});
+
+it('reaches the same retry policy decision through the queue as inline', function () {
+    useDatabaseQueue();
+    DeclinableChargeAction::reset(failures: 99, code: 422);
+    RecordingRetryPolicy::$refuseCode = 422;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-q-policy')->run();
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    // The gate lives on the replay seam, which both transports share — but only the
+    // queued path lets the step burn its native attempts first, so the policy must
+    // still be asked exactly once, and only after the queue has given up.
+    expect($final->status)->toBe(FlowStatus::Failed)
+        ->and($final->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::Failed)
+        ->and($final->signals()->count())->toBe(0)
+        ->and(RecordingRetryPolicy::calls())->toBe(1)
+        ->and(RecordingRetryPolicy::last()->cyclesSpent)->toBe(0)
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('parks through the queue when the policy allows the failure', function () {
+    useDatabaseQueue();
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$refuseCode = 422;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-q-park')->run();
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+
+    expect($final->status)->toBe(FlowStatus::Waiting)
+        ->and($final->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and(RecordingRetryPolicy::calls())->toBe(1)
+        ->and(RecordingRetryPolicy::last()->failure->code)->toBe(503)
+        ->and(CompensationLog::all())->toBe([]);
 });

--- a/tests/Feature/RetryPolicyTest.php
+++ b/tests/Feature/RetryPolicyTest.php
@@ -413,6 +413,20 @@ it('holds the re-entry guard when the container forgets its scoped instances', f
         ->and($run->signals()->count())->toBe(0);
 });
 
+it('reads the policy config on every replay but asks the predicate only of a failure [pinning]', function () {
+    DeclinableChargeAction::reset(failures: 1);
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-22')->runSync();
+    $run = refillAndDriveRun($run);
+
+    // Pins what the docs promise: handle() rebuilds the policy on every pass and the
+    // builder reads its configuration off it again, a completed step included, while
+    // the predicate is only ever put to a step that has actually failed.
+    expect($run->status)->toBe(FlowStatus::Completed)
+        ->and(RecordingRetryPolicy::calls())->toBe(1)
+        ->and(RecordingRetryPolicy::$configReads)->toBeGreaterThan(RecordingRetryPolicy::calls());
+});
+
 it('refuses a predicate that drives another run', function () {
     DeclinableChargeAction::reset(failures: 99);
 

--- a/tests/Feature/RetryPolicyTest.php
+++ b/tests/Feature/RetryPolicyTest.php
@@ -14,6 +14,9 @@ use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\DeclinableChargeAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ManualCompensateWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\NestedCompensateRetryWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\NestedDriveRetryWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RecordingRetryPolicy;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ReentrantRetryCompensationWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalSagaGroupWorkflow;
@@ -408,4 +411,38 @@ it('holds the re-entry guard when the container forgets its scoped instances', f
         ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
         ->and($run->actions()->where('status', ActionStatus::AwaitingRetry)->count())->toBe(0)
         ->and($run->signals()->count())->toBe(0);
+});
+
+it('refuses a predicate that drives another run', function () {
+    DeclinableChargeAction::reset(failures: 99);
+
+    $run = SagaFlow::create(NestedDriveRetryWorkflow::class)->withArguments('order-20')->runSync();
+
+    // There is one runtime behind the singleton executor: a nested pass rebinds and
+    // resets it, then clears it on the way out, leaving the deciding pass with no
+    // bound run at all. The target being a different run is no protection.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and($run->signals()->count())->toBe(0)
+        ->and($run->actions()->where('status', ActionStatus::AwaitingRetry)->count())->toBe(0);
+});
+
+it('refuses a predicate that compensates another run', function () {
+    DeclinableChargeAction::reset(failures: 99);
+
+    // Non-terminal, so compensate() gets past its own terminal check and reaches
+    // the executor — which is the path under test.
+    $other = SagaFlow::create(ManualCompensateWorkflow::class)->runSync();
+    expect($other->status)->toBe(FlowStatus::Waiting);
+
+    $run = SagaFlow::create(NestedCompensateRetryWorkflow::class)
+        ->withArguments('order-21', $other->id)
+        ->runSync();
+
+    // compensate() reaches the same executor by a compensation-only replay, so it
+    // is refused on the same grounds — and the other run is left as it was.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and(SagaFlow::findRun($other->id)->status)->toBe(FlowStatus::Waiting)
+        ->and(CompensationLog::all())->toBe([]);
 });

--- a/tests/Feature/RetryPolicyTest.php
+++ b/tests/Feature/RetryPolicyTest.php
@@ -1,0 +1,411 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Builders\ActionBuilder;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RecordedFailure;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\DeclinableChargeAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RecordingRetryPolicy;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ReentrantRetryCompensationWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalSagaGroupWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryPolicySagaWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryPolicyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryWhenWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SelfCancellingRetryWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SuspendingRetryWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TaggingRetryWorkflow;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sync-mode coverage for the retry policy object and the when: shorthand — the
+ * fourth gate, which decides whether a failure is worth parking at all. Waking the
+ * run on delivery is switched off so the signal does not queue a resume: these tests
+ * drive the run again explicitly, keeping the inline path under test.
+ */
+beforeEach(function () {
+    DeclinableChargeAction::reset();
+    RecordingRetryPolicy::reset();
+    CompensationLog::reset();
+
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+});
+
+function refillAndDriveRun(FlowRun $run): FlowRun
+{
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    return app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+}
+
+it('parks the step when the policy allows the failure', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-1')->runSync();
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal)->toBe('balance-refilled')
+        ->and(RecordingRetryPolicy::calls())->toBe(1)
+        ->and(CompensationLog::all())->toBe([]);
+});
+
+it('fails the step exactly as a policy-less step when shouldRetry refuses', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 422);
+    RecordingRetryPolicy::$refuseCode = 422;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-2')->runSync();
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    // The same outcome as a step that never carried a policy: hard failure, no wait
+    // marker advertising a signal nobody will act on, and the completed step before
+    // it rolled back.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($step->status)->toBe(ActionStatus::Failed)
+        ->and($run->signals()->count())->toBe(0)
+        ->and(CompensationLog::all())->toBe(['undo:created'])
+        ->and(DeclinableChargeAction::$calls)->toBe(1);
+});
+
+it('hands the policy the failure recorded on the row', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 402);
+
+    SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-3')->runSync();
+
+    $context = RecordingRetryPolicy::last();
+
+    expect($context->actionClass)->toBe(DeclinableChargeAction::class)
+        ->and($context->workflowClass)->toBe(RetryPolicyWorkflow::class)
+        ->and($context->sequence)->toBe(1)
+        ->and($context->signal)->toBe('balance-refilled')
+        ->and($context->failure->class)->toBe(RuntimeException::class)
+        ->and($context->failure->message)->toBe('charge declined')
+        ->and($context->failure->code)->toBe(402)
+        ->and($context->failure->is(RuntimeException::class))->toBeTrue()
+        ->and($context->failure->is(LogicException::class))->toBeFalse();
+});
+
+it('counts spent cycles rather than numbering attempts', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$maxRetries = 3;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-4')->runSync();
+
+    // Nothing has been spent yet the first time the step parks.
+    expect(RecordingRetryPolicy::last()->cyclesSpent)->toBe(0)
+        ->and(RecordingRetryPolicy::last()->cap)->toBe(3)
+        ->and(RecordingRetryPolicy::last()->executions)->toBe(1);
+
+    refillAndDriveRun($run);
+
+    expect(RecordingRetryPolicy::last()->cyclesSpent)->toBe(1)
+        ->and(RecordingRetryPolicy::last()->cap)->toBe(3)
+        ->and(RecordingRetryPolicy::last()->executions)->toBe(2);
+});
+
+it('never asks the policy once the budget is spent', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$maxRetries = 0;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-5')->runSync();
+
+    // The three structural gates short-circuit before the one that runs user code.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(RecordingRetryPolicy::calls())->toBe(0);
+});
+
+it('never asks the policy about a failure outside only', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$only = [LogicException::class];
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-6')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(RecordingRetryPolicy::calls())->toBe(0);
+});
+
+it('reads a policy that throws as a refusal and records it', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$throws = true;
+
+    $logged = [];
+
+    Log::listen(function ($message) use (&$logged) {
+        $logged[] = $message->message;
+    });
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-7')->runSync();
+
+    // A broken predicate fails the STEP, not the run on its own terms: the run
+    // ends carrying the step's business failure, exactly as it would have without
+    // a policy — the policy's own exception never becomes the run's.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->actions()->where('sequence', 1)->first()->status)->toBe(ActionStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(ActionFailedException::class)
+        ->and($run->exception['message'] ?? '')->toContain('charge declined')
+        ->and($run->exception['message'] ?? '')->not->toContain('the policy itself is broken')
+        ->and($logged)->toContain('saga-lara-flow: retry_policy_threw')
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('wakes a parked step without asking the policy again', function () {
+    DeclinableChargeAction::reset(failures: 1, code: 503);
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-8')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and(RecordingRetryPolicy::calls())->toBe(1);
+
+    // The gate decides whether to PARK, not whether to wake. A policy that would
+    // now refuse must not swallow a delivery the run is already advertising.
+    RecordingRetryPolicy::$throws = true;
+
+    $final = refillAndDriveRun($run);
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and(RecordingRetryPolicy::calls())->toBe(1);
+});
+
+it('applies the policy to a step inside a saga group', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 422);
+    RecordingRetryPolicy::$refuseCode = 422;
+
+    $run = SagaFlow::create(RetryPolicySagaWorkflow::class)->withArguments('order-9')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(RecordingRetryPolicy::calls())->toBe(1)
+        ->and(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('decides the same way through the when shorthand', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 422);
+
+    $refused = SagaFlow::create(RetryWhenWorkflow::class)->withArguments('order-10', 422)->runSync();
+
+    expect($refused->status)->toBe(FlowStatus::Failed)
+        ->and($refused->signals()->count())->toBe(0);
+
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    $parked = SagaFlow::create(RetryWhenWorkflow::class)->withArguments('order-11', 422)->runSync();
+
+    expect($parked->status)->toBe(FlowStatus::Waiting)
+        ->and($parked->actions()->where('sequence', 0)->first()->status)
+        ->toBe(ActionStatus::AwaitingRetry);
+});
+
+it('refuses a policy combined with the arguments it replaces', function () {
+    $action = new ActionBuilder(app(FlowRuntime::class), DeclinableChargeAction::class, []);
+
+    expect(fn () => $action->retryOnSignal(new RecordingRetryPolicy, maxRetries: 3))
+        ->toThrow(InvalidArgumentException::class, 'drop maxRetries')
+        ->and(fn () => $action->retryOnSignal(new RecordingRetryPolicy, only: [LogicException::class], when: fn () => true))
+        ->toThrow(InvalidArgumentException::class, 'drop only, when');
+});
+
+it('holds a saga step misconfiguration back until the group replays', function () {
+    CompensationLog::reset();
+
+    $run = SagaFlow::create(RetryOnSignalSagaGroupWorkflow::class)
+        ->withArguments('order-saga-neg', -1)
+        ->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(InvalidArgumentException::class)
+        ->and($run->exception['message'] ?? '')->toContain('maxRetries must be zero or greater');
+
+    // The refusal has to arrive from the step's own execute(), not from the fluent
+    // chain that builds the group: SagaBuilder::run() replays the steps in order, so
+    // refusing while the chain is still being assembled would leave the completed
+    // first step with no compensation registered and roll back nothing.
+    expect(CompensationLog::all())->toBe(['undo:created']);
+});
+
+it('stores nothing about the policy on the row [pinning]', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$maxRetries = 2;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-12')->runSync();
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    // Only the signal name and the ceiling are persisted, exactly as for the scalar
+    // form. The policy is reconstructed by handle() on every replay, so a class name
+    // in the row would be a second source of truth nothing keeps in step.
+    $columns = $step->getAttributes();
+
+    expect($step->retry_signal)->toBe('balance-refilled')
+        ->and($step->retry_signal_max_attempts)->toBe(2)
+        ->and(json_encode($columns))->not->toContain('RecordingRetryPolicy');
+});
+
+it('builds a recorded failure from a partial or absent record', function () {
+    $absent = RecordedFailure::fromRecord(null);
+
+    expect($absent->class)->toBeNull()
+        ->and($absent->message)->toBe('')
+        ->and($absent->code)->toBe(0)
+        ->and($absent->is(RuntimeException::class))->toBeFalse();
+
+    $partial = RecordedFailure::fromRecord(['message' => 'no class here']);
+
+    expect($partial->class)->toBeNull()
+        ->and($partial->message)->toBe('no class here');
+
+    $stringCode = RecordedFailure::fromRecord([
+        'class' => RuntimeException::class,
+        'message' => 'pdo style',
+        'code' => 'HY000',
+    ]);
+
+    expect($stringCode->code)->toBe('HY000')
+        ->and($stringCode->is(LogicException::class, RuntimeException::class))->toBeTrue();
+});
+
+it('holds the cap on the row but re-reads the signal name [pinning]', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+    RecordingRetryPolicy::$maxRetries = 3;
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-13')->runSync();
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    expect($step->retry_signal)->toBe('balance-refilled')
+        ->and($step->retry_signal_max_attempts)->toBe(3);
+
+    // A deploy that rewrites the policy. Only one of the two survives it.
+    RecordingRetryPolicy::$signalName = 'card-replaced';
+    RecordingRetryPolicy::$maxRetries = 99;
+
+    refillAndDriveRun($run);
+
+    $step = $run->actions()->where('sequence', 1)->first();
+
+    // The ceiling is read back off the row, so the deploy cannot move it. The signal
+    // name is not: the seam uses whatever the workflow asks for now and rewrites the
+    // column with it, so the step is left waiting on a name nobody has been told to
+    // deliver, and the marker for the old one is spent.
+    expect($step->retry_signal_max_attempts)->toBe(3)
+        ->and(RecordingRetryPolicy::last()->cap)->toBe(3)
+        ->and($step->retry_signal)->toBe('card-replaced')
+        ->and($run->signals()->where('status', SignalStatus::Waiting)->pluck('name')->all())
+        ->toBe(['card-replaced']);
+});
+
+it('refuses a predicate that reaches back into the workflow', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    $logged = [];
+
+    Log::listen(function ($message) use (&$logged) {
+        $logged[] = $message->message;
+    });
+
+    $run = SagaFlow::create(SuspendingRetryWorkflow::class)->withArguments('order-14')->runSync();
+
+    // Refused before the seam took an ordinal, so no wait was recorded for a
+    // predicate nobody would replay. Left to run, it would take the ordinal the step
+    // after it needs — and once the guarded step succeeded the predicate would never
+    // be asked again, so the run would fail claiming the workflow code had changed.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and($run->exception['message'] ?? '')->toContain('must be a pure function')
+        ->and($run->signals()->count())->toBe(0)
+        ->and($run->actions()->count())->toBe(1);
+
+    // Not a policy defect with a safe answer: it is not absorbed and not logged as one.
+    expect($logged)->not->toContain('saga-lara-flow: retry_policy_threw');
+});
+
+it('never asks the policy while planning a compensation', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    $run = SagaFlow::create(RetryPolicyWorkflow::class)->withArguments('order-15')->runSync();
+
+    // The state a queued step reaches when its job gave up and the resume was lost:
+    // Failed, budget untouched so every cheap gate passes, nothing left to drive it.
+    $step = $run->actions()->where('sequence', 1)->first();
+    $step->status = ActionStatus::Failed;
+    $step->queue_attempts_exhausted = true;
+    $step->save();
+
+    $asked = RecordingRetryPolicy::calls();
+
+    app(FlowExecutor::class)->collectCompensations(SagaFlow::findRun($run->id));
+
+    // collectCompensations() promises to replay without running business logic. A
+    // predicate is business logic, and its answer cannot change where the planning
+    // stops anyway.
+    expect(RecordingRetryPolicy::calls())->toBe($asked);
+});
+
+it('refuses a predicate that writes to the run it is deciding for', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    $run = SagaFlow::create(SelfCancellingRetryWorkflow::class)->withArguments('order-16')->runSync();
+
+    // Left to run, the cancellation would settle the run's open rows and the seam
+    // would park the step immediately afterwards — a live wait advertising a signal
+    // on a run nobody will drive again.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and($run->signals()->count())->toBe(0)
+        ->and($run->actions()->where('status', ActionStatus::AwaitingRetry)->count())->toBe(0);
+});
+
+it('still compensates the failed step when its predicate re-enters', function () {
+    DeclinableChargeAction::reset(failures: 99);
+
+    $run = SagaFlow::create(ReentrantRetryCompensationWorkflow::class)
+        ->withArguments('order-17')
+        ->runSync();
+
+    // The rollback is built from the failing pass alone, and the re-entry throw
+    // leaves that pass before the step is resolved. Its own compensation has to be
+    // registered on the way out, or the caller's compensateStepOnSelfFailure() is
+    // the one instruction the run drops.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and(CompensationLog::all())->toBe(['undo:charge', 'undo:a']);
+});
+
+it('refuses a predicate that tags the run it is deciding for', function () {
+    DeclinableChargeAction::reset(failures: 99);
+
+    $run = SagaFlow::create(TaggingRetryWorkflow::class)->withArguments('order-18')->runSync();
+
+    // tag() is the only workflow-facing write that never asks for an ordinal, so
+    // the guard in nextSequence() never sees it and it needs its own.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and($run->tags()->count())->toBe(0);
+});
+
+it('holds the re-entry guard when the container forgets its scoped instances', function () {
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    // What a queue worker does between jobs: FlowExecutor is a singleton and keeps
+    // the runtime it was built with, while a fresh resolve now answers for another
+    // instance. The guard has to read the one the pass is actually driven with.
+    $held = (fn () => $this->runtime)->call(app(FlowExecutor::class));
+    app()->forgetScopedInstances();
+    expect(app(FlowRuntime::class))->not->toBe($held);
+
+    $run = SagaFlow::create(SelfCancellingRetryWorkflow::class)->withArguments('order-19')->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and($run->actions()->where('status', ActionStatus::AwaitingRetry)->count())->toBe(0)
+        ->and($run->signals()->count())->toBe(0);
+});

--- a/tests/Fixtures/DeclinableChargeAction.php
+++ b/tests/Fixtures/DeclinableChargeAction.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use RuntimeException;
+
+/**
+ * A payment step whose failure carries a controllable exception code, so a test can
+ * drive a retry policy that branches on something other than the exception class.
+ * The counters are static (like FlakyPaymentAction) because the cycles happen across
+ * separate replays — and, in queued mode, separate jobs — of the same run.
+ */
+final class DeclinableChargeAction extends Action
+{
+    public static int $failures = 0;
+
+    public static int $calls = 0;
+
+    public static int $code = 0;
+
+    public static function reset(int $failures = 0, int $code = 0): void
+    {
+        self::$failures = $failures;
+        self::$calls = 0;
+        self::$code = $code;
+    }
+
+    /**
+     * @return array{charged: string, calls: int}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        if (self::$calls <= self::$failures) {
+            throw new RuntimeException('charge declined', self::$code);
+        }
+
+        return ['charged' => $orderId, 'calls' => self::$calls];
+    }
+}

--- a/tests/Fixtures/NestedCompensateRetryWorkflow.php
+++ b/tests/Fixtures/NestedCompensateRetryWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that rolls back a different run. compensate() reconstructs the
+ * stack by a compensation-only replay, which drives the shared runtime just as a
+ * nested run does — the target being somebody else's run does not make it safe.
+ */
+final class NestedCompensateRetryWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId, string $otherRunId): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal(
+                'balance-refilled',
+                when: function (RetryContext $context) use ($otherRunId): bool {
+                    SagaFlow::loadFlow($otherRunId)->compensate();
+
+                    return true;
+                },
+            )
+            ->run();
+    }
+}

--- a/tests/Fixtures/NestedDriveRetryWorkflow.php
+++ b/tests/Fixtures/NestedDriveRetryWorkflow.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that drives a second run to completion. The second run is not
+ * the one being decided, so the id-specific guards let it through — but the
+ * executor is a singleton and the nested pass rebinds and resets the very runtime
+ * the outer pass is suspended inside.
+ */
+final class NestedDriveRetryWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal(
+                'balance-refilled',
+                when: function (RetryContext $context): bool {
+                    SagaFlow::create(OneActionWorkflow::class)->runSync();
+
+                    return true;
+                },
+            )
+            ->run();
+    }
+}

--- a/tests/Fixtures/RecordingRetryPolicy.php
+++ b/tests/Fixtures/RecordingRetryPolicy.php
@@ -23,6 +23,12 @@ final class RecordingRetryPolicy extends RetryPolicy
 
     public static string $signalName = 'balance-refilled';
 
+    /**
+     * How often the builder read the policy's configuration, as against how often it
+     * put a failure to the predicate. The two are deliberately different numbers.
+     */
+    public static int $configReads = 0;
+
     public static ?int $refuseCode = null;
 
     public static bool $throws = false;
@@ -39,6 +45,7 @@ final class RecordingRetryPolicy extends RetryPolicy
     public static function reset(): void
     {
         self::$seen = [];
+        self::$configReads = 0;
         self::$signalName = 'balance-refilled';
         self::$refuseCode = null;
         self::$throws = false;
@@ -59,6 +66,8 @@ final class RecordingRetryPolicy extends RetryPolicy
 
     public function signal(): string
     {
+        self::$configReads++;
+
         return self::$signalName;
     }
 

--- a/tests/Fixtures/RecordingRetryPolicy.php
+++ b/tests/Fixtures/RecordingRetryPolicy.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryPolicy;
+use RuntimeException;
+use Throwable;
+
+/**
+ * A retry policy that records every context it was handed and answers according to
+ * statics a test sets up front. The statics are how a test observes it at all: the
+ * workflow constructs a fresh instance on every replay, so an instance property
+ * would not survive to be asserted on — and in queued mode the cycles run in
+ * separate jobs.
+ */
+final class RecordingRetryPolicy extends RetryPolicy
+{
+    /**
+     * @var list<RetryContext>
+     */
+    public static array $seen = [];
+
+    public static string $signalName = 'balance-refilled';
+
+    public static ?int $refuseCode = null;
+
+    public static bool $throws = false;
+
+    public static ?int $maxRetries = null;
+
+    public static ?int $waitSeconds = null;
+
+    /**
+     * @var list<class-string<Throwable>>|null
+     */
+    public static ?array $only = null;
+
+    public static function reset(): void
+    {
+        self::$seen = [];
+        self::$signalName = 'balance-refilled';
+        self::$refuseCode = null;
+        self::$throws = false;
+        self::$maxRetries = null;
+        self::$waitSeconds = null;
+        self::$only = null;
+    }
+
+    public static function calls(): int
+    {
+        return count(self::$seen);
+    }
+
+    public static function last(): ?RetryContext
+    {
+        return self::$seen === [] ? null : self::$seen[array_key_last(self::$seen)];
+    }
+
+    public function signal(): string
+    {
+        return self::$signalName;
+    }
+
+    public function maxRetries(): ?int
+    {
+        return self::$maxRetries;
+    }
+
+    public function waitSeconds(): ?int
+    {
+        return self::$waitSeconds;
+    }
+
+    /**
+     * @return list<class-string<Throwable>>|null
+     */
+    public function only(): ?array
+    {
+        return self::$only;
+    }
+
+    public function shouldRetry(RetryContext $context): bool
+    {
+        self::$seen[] = $context;
+
+        if (self::$throws) {
+            throw new RuntimeException('the policy itself is broken');
+        }
+
+        return self::$refuseCode === null || $context->failure->code !== self::$refuseCode;
+    }
+}

--- a/tests/Fixtures/ReentrantRetryCompensationWorkflow.php
+++ b/tests/Fixtures/ReentrantRetryCompensationWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The failing step opts its own side effect into the rollback
+ * (compensateStepOnSelfFailure) and carries a predicate that reaches back into the
+ * workflow DSL. The re-entry has to fail the run — but not at the cost of the
+ * compensation the caller asked for on this very step.
+ */
+final class ReentrantRetryCompensationWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(UndoAction::class, 'a')
+            ->run();
+
+        $this->action(DeclinableChargeAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charge')
+            ->compensateStepOnSelfFailure()
+            ->retryOnSignal(
+                'balance-refilled',
+                when: fn (RetryContext $context): bool => (bool) $this->awaitSignal('second-opinion'),
+            )
+            ->run();
+    }
+}

--- a/tests/Fixtures/RetryPolicySagaWorkflow.php
+++ b/tests/Fixtures/RetryPolicySagaWorkflow.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The same policy object on a step inside a saga() group, so a test can prove the
+ * group builder hands it through unchanged rather than dropping the predicate on
+ * the way to the action builder.
+ */
+final class RetryPolicySagaWorkflow extends Workflow
+{
+    /**
+     * @return list<mixed>
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId): array
+    {
+        return $this->saga()
+            ->step(MakeValueAction::class, 'created')
+            ->compensateWith(UndoAction::class, 'created')
+            ->step(DeclinableChargeAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal(new RecordingRetryPolicy)
+            ->step(MakeValueAction::class, 'shipped')
+            ->run();
+    }
+}

--- a/tests/Fixtures/RetryPolicyWorkflow.php
+++ b/tests/Fixtures/RetryPolicyWorkflow.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The three-step saga of RetryOnSignalWorkflow, with the middle step's policy
+ * expressed as a RetryPolicy object instead of four arguments. The surrounding steps
+ * are compensatable, so a test can prove that a refused failure rolls back exactly
+ * what a policy-less failure would have.
+ */
+final class RetryPolicyWorkflow extends Workflow
+{
+    /**
+     * @return array{created: mixed, charged: mixed, shipped: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId): array
+    {
+        $created = $this->action(MakeValueAction::class, 'created')
+            ->compensateWith(UndoAction::class, 'created')
+            ->run();
+
+        $charged = $this->action(DeclinableChargeAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal(new RecordingRetryPolicy)
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['created' => $created, 'charged' => $charged, 'shipped' => $shipped];
+    }
+}

--- a/tests/Fixtures/RetryWhenWorkflow.php
+++ b/tests/Fixtures/RetryWhenWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The when: shorthand instead of a policy class. The predicate closes over a
+ * workflow argument, which is the only state a replay reproduces — a closure that
+ * captured anything else would answer differently on the next pass.
+ */
+final class RetryWhenWorkflow extends Workflow
+{
+    /**
+     * @return array{charged: mixed, shipped: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId, ?int $refuseCode = null): array
+    {
+        $charged = $this->action(DeclinableChargeAction::class, $orderId)
+            ->compensateWith(UndoAction::class, 'charged')
+            ->retryOnSignal(
+                'balance-refilled',
+                when: fn (RetryContext $context): bool => $context->failure->code !== $refuseCode,
+            )
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['charged' => $charged, 'shipped' => $shipped];
+    }
+}

--- a/tests/Fixtures/SelfCancellingRetryWorkflow.php
+++ b/tests/Fixtures/SelfCancellingRetryWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that cancels the very run it is deciding for. Left to run, the
+ * cancellation would settle the run's open rows and the seam would then park the
+ * step anyway, leaving a live wait under a terminal run.
+ */
+final class SelfCancellingRetryWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal(
+                'balance-refilled',
+                when: function (RetryContext $context): bool {
+                    SagaFlow::loadFlow($context->runId)->cancel('decided against it');
+
+                    return true;
+                },
+            )
+            ->run();
+    }
+}

--- a/tests/Fixtures/SuspendingRetryWorkflow.php
+++ b/tests/Fixtures/SuspendingRetryWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that reaches back into the workflow DSL instead of answering.
+ * The step after it is what makes the attempt harmful: the predicate is not asked
+ * again once the guarded step succeeds, so an ordinal it consumed would be left
+ * unclaimed and this step would land in the wrong slot.
+ */
+final class SuspendingRetryWorkflow extends Workflow
+{
+    /**
+     * @return array{charged: mixed, shipped: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId): array
+    {
+        $charged = $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal(
+                'balance-refilled',
+                when: fn (RetryContext $context): bool => (bool) $this->awaitSignal('second-opinion'),
+            )
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['charged' => $charged, 'shipped' => $shipped];
+    }
+}

--- a/tests/Fixtures/TaggingRetryWorkflow.php
+++ b/tests/Fixtures/TaggingRetryWorkflow.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that tags the run it is deciding for. tag() is the one
+ * workflow-facing write that never takes an ordinal, so the guard in
+ * nextSequence() cannot see it.
+ */
+final class TaggingRetryWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal(
+                'balance-refilled',
+                when: function (RetryContext $context): bool {
+                    $this->tag('decided', 'yes');
+
+                    return true;
+                },
+            )
+            ->run();
+    }
+}


### PR DESCRIPTION
Closes #16

`retryOnSignal()` now takes a `RetryPolicy` object as well as a bare signal name, and gains a
predicate that is handed the failure the row actually recorded.

```php
$this->action(ChargeCard::class, $orderId)
    ->retryOnSignal(new BalanceRefillRecovery)
    ->run();
```

```php
final class BalanceRefillRecovery extends RetryPolicy
{
    public function signal(): string { return 'balance-refilled'; }

    public function maxRetries(): ?int { return 3; }

    public function only(): ?array { return [InsufficientBalanceException::class]; }

    public function shouldRetry(RetryContext $context): bool
    {
        return $context->failure->code !== 422;
    }
}
```

For a one-off decision the same predicate is available inline as `when:`, alongside the four
existing scalar arguments. A policy combined with any of them throws `InvalidArgumentException`
naming the extras. `saga()->step()` mirrors the method.

## How it behaves

The predicate is the **fourth and last** gate, after the budget, the wait timeout and the
`only` filter — so it only ever runs on a failure the cheap structural checks already accepted,
and it decides **whether to park**, never whether to wake. An already-parked step spends its
cycle when the signal arrives without being asked again.

Nothing about a policy is persisted. `ActionBuilder` unwraps it in the setter, so each of the
five methods runs exactly once per replay and every seam below goes on reading a plain string.
The only value that is frozen is `maxRetries()`, onto `action_runs.retry_signal_max_attempts`,
because that is the cap the events and `saga-flow:show` report.

`RetryContext` carries the run and step identity, the signal, the two counters, the cap, and a
`RecordedFailure` read off `action_runs.exception`. It deliberately carries no `ActionRun` model
and no step arguments: a predicate that can reach the row can write to it.

## Purity is enforced, not just documented

A predicate is asked while a failed step decides whether to park, and it is never asked again
once that step succeeds — so an ordinal it consumed would be left unclaimed and the next step
would land in the wrong slot. `FlowRuntime::nextSequence()` is the single ordinal-allocation
point, so one check there covers every seam; `FlowHandle` and `Workflow::tag()` cover the writes
that never take an ordinal. Other runs stay fair game.

A predicate that throws anything else is read as `false` and recorded in the anomaly log under
`retry_policy_threw`: the step then fails exactly as it would have without a policy, and the run
carries the step's own business failure rather than the policy's.

## Testing

`tests/Feature/RetryPolicyTest.php` adds 21 tests, plus two on the queued path proving the
decision is identical there. Every regression test was verified by mutation — reverting its fix
fails it and nothing else. Two pinning tests hold the storage contract: that nothing about a
policy reaches the row, and that the cap comes from the row while the signal name does not.

Six rounds of adversarial review went into this. Three defects it surfaced turned out to
pre-date the branch and are filed separately as #35, #36 and #37 — #37 in particular reproduces
on `main` with a plain `retryOnSignal('name')` and no policy in sight.

Pest 374 passed (1346 assertions) · PHPStan level 5 clean · Pint clean · docs build clean.
