### PR TITLE
Run the same suite on MySQL, where a conditional write answers differently

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -65,3 +65,51 @@ jobs:
 
       - name: Execute tests
         run: vendor/bin/pest --ci
+
+  # A second job rather than a `db` axis on the matrix above: service containers are
+  # declared per job and run on Linux only, and that matrix includes windows-latest.
+  # One combination is enough — the divergence this covers is the driver's, not the
+  # dependency resolution's.
+  test-mysql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    name: MySQL - P8.5 - L13.* - prefer-stable
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: saga
+          MYSQL_DATABASE: saga_test
+          MYSQL_USER: saga
+          MYSQL_PASSWORD: saga
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -u root -psaga"
+          --health-interval=3s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, pdo_mysql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:13.*" "orchestra/testbench:11.*" --no-interaction --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction
+
+      - name: Execute tests
+        env:
+          SAGA_TEST_DB: mysql
+          SAGA_TEST_DB_HOST: 127.0.0.1
+        run: vendor/bin/pest --ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,6 +32,22 @@ docker compose run --rm app composer test
 docker compose run --rm app composer lint
 ```
 
+The suite runs on an in-memory SQLite database, so the command above starts one container and
+no database server. Some of the engine's writes behave differently on MySQL, so there is a second
+command that runs the same suite against one — use it before a commit and before opening a PR:
+
+```bash
+docker compose --profile mysql run --rm app-mysql vendor/bin/pest
+```
+
+The database lives in the `mysql` compose profile: nothing starts it except a command that asks
+for it by name. `SAGA_TEST_DB=mysql` is all the suite reads, so a host with its own server can run
+against that instead — `SAGA_TEST_DB_HOST`, `_PORT`, `_DATABASE`, `_USERNAME` and `_PASSWORD` point
+it there.
+
+**Whatever database it is pointed at is emptied.** The first test drops every table in it and
+rebuilds the schema; each test after that deletes every row. Give the suite a database of its own.
+
 Or, on a matching PHP toolchain, directly:
 
 ```bash
@@ -98,6 +114,13 @@ for the other changes public behaviour and needs its own exception and its own d
   what it guards, that guard has to survive somewhere — move it, don't delete it.
 - **Queued tests** run against a real database queue driven with `queue:work --stop-when-empty`,
   not the `sync` driver.
+- **Run the suite on MySQL before you commit.** SQLite answers a conditional write differently,
+  and a test that fences on one is meaningless there — see `ConditionalWriteFenceTest`, which is
+  load-bearing on MySQL and trivially green on SQLite.
+- **Never assert the key order of a map read back out of a `json` column.** MySQL's `json` type is
+  a binary format that sorts an object's keys; SQLite keeps the text as written. Key order is the
+  driver's business, not the engine's contract — assert key by key with `toBe`, which stays strict
+  about the values, rather than dropping the whole map to a loose `toEqual`.
 
 Run a single test:
 
@@ -108,9 +131,14 @@ vendor/bin/pest --filter="cancels a non-terminal run"
 
 ### What CI does not check
 
-CI runs on **SQLite only**. Anything driver-dependent — row counts, locking, timestamp precision,
-transaction isolation — is invisible to it. Call out such a change in your PR and reason about
-MySQL and PostgreSQL explicitly; a green suite is not evidence there.
+CI runs the suite on SQLite across the `os × stability` matrix, and once more on **MySQL**. Two
+gaps remain, and a green suite is not evidence in either:
+
+- **PostgreSQL.** Untested. It counts matched rows like SQLite, so the fences hold, but a failed
+  statement poisons the transaction it is in for good — and the engine catches exceptions inside
+  its own transactions.
+- **Real concurrency.** Every interleaving in the suite is staged from one process. Nothing runs
+  two workers at once, so a lock held too long or a deadlock retried wrongly would pass.
 
 ## Documentation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,13 @@
 #   docker compose run --rm app composer update
 #   docker compose run --rm app composer test
 #   docker compose run --rm app composer lint
+#
+# The suite runs on SQLite by default and `app` depends on nothing, so the command
+# above starts one container and no database. The MySQL run is a separate command
+# behind a profile, for use before a commit and at a milestone:
+#   docker compose --profile mysql run --rm app-mysql vendor/bin/pest
 services:
-  app:
+  app: &app
     build:
       context: .
       dockerfile: docker/Dockerfile
@@ -14,5 +19,38 @@ services:
       - .:/app
       - composer-cache:/root/.composer
 
+  # The same toolchain pointed at the MySQL service. Both live in the `mysql`
+  # profile, so neither is started by a command that does not ask for it.
+  app-mysql:
+    <<: *app
+    profiles: [mysql]
+    depends_on:
+      mysql:
+        condition: service_healthy
+    environment:
+      SAGA_TEST_DB: mysql
+      SAGA_TEST_DB_HOST: mysql
+
+  mysql:
+    image: mysql:8.4
+    profiles: [mysql]
+    # Durability buys nothing for a throwaway test database and costs an fsync on
+    # every one of the suite's writes.
+    command: --innodb-flush-log-at-trx-commit=0 --innodb-doublewrite=0
+    environment:
+      MYSQL_ROOT_PASSWORD: saga
+      MYSQL_DATABASE: saga_test
+      MYSQL_USER: saga
+      MYSQL_PASSWORD: saga
+    volumes:
+      - mysql-data:/var/lib/mysql
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-u", "root", "-psaga"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
 volumes:
   composer-cache:
+  mysql-data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,7 @@
 # PHP 8.5 development/test image for the saga-lara-flow package.
-# Provides the extensions Testbench + the package need (pdo_sqlite for in-memory tests,
-# intl, zip, bcmath, pcntl, mbstring) plus Composer.
+# Provides the extensions Testbench + the package need (pdo_sqlite for the default
+# in-memory suite, pdo_mysql for the MySQL run, intl, zip, bcmath, pcntl, mbstring)
+# plus Composer.
 FROM php:8.5-cli
 
 RUN apt-get update \
@@ -13,6 +14,7 @@ RUN apt-get update \
         libsqlite3-dev \
     && docker-php-ext-install -j"$(nproc)" \
         pdo_sqlite \
+        pdo_mysql \
         intl \
         zip \
         bcmath \

--- a/tests/Feature/ConditionalWriteFenceTest.php
+++ b/tests/Feature/ConditionalWriteFenceTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Carbon\Carbon;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Every fence in the engine reads `=== 1` off an UPDATE, and the drivers do not agree
+ * about what an UPDATE reports: MySQL counts the rows it CHANGED, not the rows it
+ * MATCHED, since Laravel never sets PDO::MYSQL_ATTR_FOUND_ROWS. An update whose every
+ * value already equals what is stored therefore reports zero there and one on SQLite and
+ * PostgreSQL.
+ *
+ * FlowStateMachine::write() carries an escape hatch for exactly that, and on SQLite no
+ * test can reach it — the guard returns on the first branch. These tests are written to
+ * pass on both drivers and to be load-bearing on MySQL, which is why they run there
+ * before a commit:
+ *
+ *   docker compose --profile mysql run --rm app-mysql vendor/bin/pest
+ *
+ * Time is frozen at the timestamp the run's last write left, so the same-value update is
+ * exact rather than a race with the second boundary: without it the UPDATE would
+ * sometimes move updated_at, report one row on MySQL as well, and quietly test nothing.
+ */
+afterEach(function () {
+    Carbon::setTestNow();
+});
+
+/**
+ * A run parked in Waiting, re-read the way a second caller would hold it, with the clock
+ * standing at the moment of its last write.
+ */
+function fenceSubject(): object
+{
+    $run = SagaFlow::create(SignalOnlyWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting);
+
+    $fresh = SagaFlow::findRun($run->id);
+
+    Carbon::setTestNow($fresh->updated_at);
+
+    return $fresh;
+}
+
+it('runs against the driver the harness was asked for', function () {
+    // The worst outcome this harness could produce is a green MySQL run that quietly
+    // fell back to SQLite. It cannot: a driver the connection does not report is a
+    // failure, not a default.
+    expect(DB::connection('testing')->getDriverName())->toBe(TestCase::driver());
+});
+
+it('counts a same-state transition with nothing of its own to write as a success', function () {
+    $run = fenceSubject();
+
+    // status is already waiting and the clock has not moved, so every value in the SET
+    // equals what the row holds: zero changed rows on MySQL, one matched row on SQLite.
+    // The guard did not fail — there was nothing to change.
+    app(StateMachine::class)->transition($run, FlowStatus::Waiting);
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Waiting);
+});
+
+it('leaves the terminal marks alone when a terminal transition arrives twice', function () {
+    $run = fenceSubject();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    // At-least-once delivery does reach this: a duplicated batch callback lands a run
+    // that is already Cancelled, and it must not move the moment the run ended. The
+    // clock is advanced so a rewrite would be visible — which also means updated_at
+    // genuinely changes, so this one says nothing about the driver.
+    $cancelled = SagaFlow::findRun($run->id);
+
+    Carbon::setTestNow($cancelled->updated_at->copy()->addMinute());
+
+    app(StateMachine::class)->transition($cancelled, FlowStatus::Cancelled);
+
+    $after = SagaFlow::findRun($run->id);
+
+    expect($after->status)->toBe(FlowStatus::Cancelled)
+        ->and($after->cancelled_at->equalTo($cancelled->cancelled_at))->toBeTrue()
+        ->and($after->finished_at->equalTo($cancelled->finished_at))->toBeTrue();
+});
+
+it('counts a duplicate terminal transition landing in the same instant as a success', function () {
+    $run = fenceSubject();
+
+    SagaFlow::loadFlow($run->id)->cancel('operator');
+
+    // The same shape as the test above, on the other path out of transition(): a
+    // terminal target goes through finish(), which writes the run inside the settling
+    // transaction. Nothing has moved and nothing is left to write, so MySQL reports zero
+    // changed rows here too.
+    $cancelled = SagaFlow::findRun($run->id);
+
+    Carbon::setTestNow($cancelled->updated_at);
+
+    app(StateMachine::class)->transition($cancelled, FlowStatus::Cancelled);
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled);
+});
+
+it('still refuses a same-state transition when the row has moved on', function () {
+    $stale = fenceSubject();
+
+    SagaFlow::loadFlow($stale->id)->cancel('operator');
+
+    // The mutation pair to the two above: reading zero rows as success unconditionally
+    // would pass them and lose this one, which is the whole point of the fence.
+    expect(fn () => app(StateMachine::class)->transition($stale, FlowStatus::Waiting))
+        ->toThrow(ConcurrentFlowTransitionException::class);
+
+    expect(SagaFlow::findRun($stale->id)->status)->toBe(FlowStatus::Cancelled);
+});

--- a/tests/Feature/MigrationLoadingTest.php
+++ b/tests/Feature/MigrationLoadingTest.php
@@ -1,8 +1,15 @@
 <?php
 
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
+
+// The only file that changes the schema rather than reading it: it rolls single
+// migrations up and down, drops the tables, and adds and removes uniques. On SQLite
+// whatever it leaves behind dies with the in-memory database. On a server the schema
+// outlives the test, so hand the next one a rebuild.
+afterEach(fn () => TestCase::forgetSchema());
 
 // The provider calls runsMigrations(), so a host app installs with just
 // `php artisan migrate` — no vendor:publish step. Two things must hold, and each

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -77,8 +77,14 @@ it('retries only the parked step when the signal arrives', function () {
 
     $final = refillAndDrive($run);
 
+    // Read key by key rather than comparing the map whole: a map read back out of a
+    // json column comes back in whatever order the driver stored it, and MySQL's json
+    // type is a binary format that sorts an object's keys. Comparing the whole map
+    // would have to drop to a loose ==, which would stop noticing an int that turned
+    // into a string.
     expect($final->status)->toBe(FlowStatus::Completed)
-        ->and($final->result['charged'] ?? null)->toBe(['charged' => 'order-2', 'calls' => 2]);
+        ->and($final->result['charged']['charged'] ?? null)->toBe('order-2')
+        ->and($final->result['charged']['calls'] ?? null)->toBe(2);
 
     $actions = $final->actions()->orderBy('sequence')->get();
 

--- a/tests/Feature/RetryOnSignalTest.php
+++ b/tests/Feature/RetryOnSignalTest.php
@@ -81,10 +81,14 @@ it('retries only the parked step when the signal arrives', function () {
     // json column comes back in whatever order the driver stored it, and MySQL's json
     // type is a binary format that sorts an object's keys. Comparing the whole map
     // would have to drop to a loose ==, which would stop noticing an int that turned
-    // into a string.
+    // into a string. The count keeps what the whole-map comparison also said: these
+    // two keys and no third.
+    $charged = $final->result['charged'] ?? null;
+
     expect($final->status)->toBe(FlowStatus::Completed)
-        ->and($final->result['charged']['charged'] ?? null)->toBe('order-2')
-        ->and($final->result['charged']['calls'] ?? null)->toBe(2);
+        ->and($charged)->toHaveCount(2)
+        ->and($charged['charged'] ?? null)->toBe('order-2')
+        ->and($charged['calls'] ?? null)->toBe(2);
 
     $actions = $final->actions()->orderBy('sequence')->get();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,22 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Tests;
 
 use DiscoveryUkraine\SagaLaraFlow\SagaLaraFlowServiceProvider;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
 use Orchestra\Testbench\TestCase as Orchestra;
+use RuntimeException;
 
 class TestCase extends Orchestra
 {
+    /**
+     * Whether this process has already built the schema on a database that outlives a
+     * test. SQLite never sets it: every test there opens its own :memory: database.
+     *
+     * The suite is run one process at a time on such a database; a parallel run is
+     * refused rather than left to corrupt itself.
+     */
+    private static bool $schemaBuilt = false;
+
     protected function getPackageProviders($app): array
     {
         return [
@@ -17,19 +29,143 @@ class TestCase extends Orchestra
     protected function defineEnvironment($app): void
     {
         $app['config']->set('database.default', 'testing');
-        $app['config']->set('database.connections.testing', [
-            'driver' => 'sqlite',
-            'database' => ':memory:',
-            'prefix' => '',
-        ]);
+        $app['config']->set('database.connections.testing', self::connectionConfig());
+    }
+
+    /**
+     * SQLite is the default and needs nothing running; SAGA_TEST_DB=mysql points the
+     * suite at a server instead — one whose database is the suite's own, since the first
+     * test drops every table in it. The engine fences on `update() === 1`, and MySQL counts
+     * the rows it changed rather than the rows it matched — a whole class of defect is
+     * invisible until the suite has been over both.
+     *
+     * The name is the package's own rather than DB_CONNECTION, which Testbench and a
+     * host .env both have opinions about.
+     *
+     * @return array<string, mixed>
+     */
+    private static function connectionConfig(): array
+    {
+        return match (self::driver()) {
+            'mysql' => [
+                'driver' => 'mysql',
+                'host' => env('SAGA_TEST_DB_HOST', '127.0.0.1'),
+                'port' => env('SAGA_TEST_DB_PORT', '3306'),
+                'database' => env('SAGA_TEST_DB_DATABASE', 'saga_test'),
+                'username' => env('SAGA_TEST_DB_USERNAME', 'saga'),
+                'password' => env('SAGA_TEST_DB_PASSWORD', 'saga'),
+                'charset' => 'utf8mb4',
+                'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+            ],
+            default => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+            ],
+        };
+    }
+
+    /**
+     * The driver the harness was asked for, which is not the same question as the driver
+     * a connection reports: a test asserts the two agree, so a MySQL run that quietly
+     * fell back to SQLite fails instead of passing.
+     */
+    public static function driver(): string
+    {
+        return (string) env('SAGA_TEST_DB', 'sqlite');
+    }
+
+    /**
+     * Hand the next test a freshly built schema. For a test that changes the schema
+     * itself: on SQLite its damage dies with the in-memory database, on a server it
+     * would be inherited by whatever random order runs next.
+     */
+    public static function forgetSchema(): void
+    {
+        self::$schemaBuilt = false;
+    }
+
+    /**
+     * Every test boots its own Testbench app, and each one opens its own connection. On
+     * :memory: that costs nothing and the database goes with it; against a server the
+     * connections pile up until MySQL refuses the next one with "Too many connections"
+     * somewhere past the two hundredth test. Hand the connection back before the app
+     * that owns it is thrown away.
+     */
+    protected function tearDown(): void
+    {
+        if (self::driver() !== 'sqlite' && $this->app !== null) {
+            $this->app['db']->purge('testing');
+        }
+
+        parent::tearDown();
     }
 
     protected function defineDatabaseMigrations(): void
+    {
+        if (self::driver() === 'sqlite') {
+            $this->migrate();
+
+            return;
+        }
+
+        // ParaTest gives every worker the same database while the flag below is per
+        // process: one worker would rebuild the schema under another's feet, and the
+        // symptom would be a random test failing for no reason it can name.
+        //
+        // PARATEST is the variable to ask for, not TEST_TOKEN: --no-test-tokens turns the
+        // token off and leaves PARATEST set (Options::assembleEnvironmentVariables()), and
+        // it is what Pest's own worker detection reads.
+        if (env('PARATEST') !== null) {
+            throw new RuntimeException(
+                'The suite runs one process at a time on '.self::driver().'; re-run without --parallel.',
+            );
+        }
+
+        // A server keeps the database between tests, so running the migrations again
+        // would fail on the tables the last test left behind. Build the schema once and
+        // empty it afterwards — what a test needs from a fresh database is no rows, and
+        // rebuilding the schema for each of them costs a DDL round trip per table per
+        // test.
+        if (! self::$schemaBuilt) {
+            // Every table, including any the database already held: the target is the
+            // suite's own, as connectionConfig() and CONTRIBUTING both say.
+            Schema::connection('testing')->dropAllTables();
+
+            $this->migrate();
+
+            self::$schemaBuilt = true;
+
+            return;
+        }
+
+        $this->truncate();
+    }
+
+    private function migrate(): void
     {
         // Every shipped migration, in filename order — the package now ships more
         // than one, and a suite that only ran the first would be missing columns.
         foreach ($this->packageMigrations() as $path) {
             (include $path)->up();
+        }
+    }
+
+    /**
+     * Every table, not only the package's: useDatabaseQueue() creates `jobs` and
+     * `job_batches` on first use and guards the create with hasTable(), so on a server
+     * they outlive the test that made them — along with any job it left unworked, which
+     * the next drainQueue() would happily run.
+     *
+     * The schema declares no foreign keys, so nothing constrains the order.
+     */
+    private function truncate(): void
+    {
+        $connection = DB::connection('testing');
+
+        foreach (Schema::connection('testing')->getTableListing(schemaQualified: false) as $table) {
+            $connection->table($table)->delete();
         }
     }
 


### PR DESCRIPTION
Closes #33.

The engine fences on `update() === 1`. MySQL counts the rows an `UPDATE` **changed**, not the rows
it **matched** — Laravel sets `PDO::MYSQL_ATTR_FOUND_ROWS` nowhere — so an update whose every value
already equals what is stored reports zero there and one on SQLite. `FlowStateMachine::write()` has
carried an escape hatch for that since #14, and no test in this repository could reach it.

## The harness

SQLite stays the default and starts no database: `docker compose run --rm app vendor/bin/pest` is
unchanged, and `app` gains no `depends_on`. MySQL is a second, explicit command, for use before a
commit and before opening a PR:

```bash
docker compose --profile mysql run --rm app-mysql vendor/bin/pest
```

Both the server and the container that talks to it live in the `mysql` compose profile, so nothing
starts them except a command that names them. `SAGA_TEST_DB=mysql` is all the suite reads, so a
host server works too.

On a database that outlives a test, `TestCase` builds the schema once per process and deletes the
rows of every table before each test after that — every table, not only the package's, because
`useDatabaseQueue()` creates `jobs` and `job_batches` on first use and a leftover job would be
worked by the next `drainQueue()`. `MigrationLoadingTest` is the one file that changes the schema
itself, so it hands the next test a rebuild.

CI gets a separate `test-mysql` job rather than a `db` axis: service containers are declared per
job and run on Linux only, and the existing matrix includes `windows-latest`. The SQLite matrix is
untouched.

## The tests that only mean something on MySQL

`ConditionalWriteFenceTest` freezes the clock at the timestamp of a run's last write, so the
same-value `UPDATE` is exact rather than a race with the second boundary. Two of its cases cover
the two paths out of `transition()` — `write()` directly, and `finish()` → `write()` — and a third
is their mutation pair: the row moved on, and the fence must still refuse.

It also asserts that the connection reports the driver the harness was asked for. The worst outcome
this work could produce is a green MySQL job that quietly ran on SQLite.

**Mutation proof.** With the escape hatch removed (`$ambiguous = false`):

| | SQLite | MySQL |
|---|---|---|
| `ConditionalWriteFenceTest` | 5 passed | **2 failed**, 3 passed |

## What running on MySQL turned up

Both were harness defects; `src/` is untouched.

- **`SQLSTATE[HY000] [1040] Too many connections`.** Every test boots its own Testbench app and
  opens its own connection; on `:memory:` that costs nothing, on a server they accumulate. Order
  dependent — four clean runs, then a fifth with twenty failures. `tearDown()` now hands the
  connection back.
- **Key order through a `json` column.** MySQL's `json` type is a binary format that sorts an
  object's keys; SQLite keeps the text as written. One assertion compared a two-key map whole; it
  now reads the keys individually, which is both order-free and stricter about the values than
  comparing the map ever was.

A parallel run against a server is refused: ParaTest gives every worker the same database while the
schema flag is per process. The check reads `PARATEST`, not `TEST_TOKEN` — `--no-test-tokens`
suppresses the token and leaves `PARATEST` set. `--parallel` on SQLite still works.

## Verification

| | SQLite | MySQL |
|---|---|---|
| suite | 382 passed (1371 assertions), 7s | 382 passed (1371 assertions), 28s |

Five random-order seeds on MySQL plus a cold start after `docker compose --profile mysql down -v`.
PHPStan level 5 clean, Pint clean over 343 files.

PostgreSQL is deliberately not here: it counts matched rows like SQLite, so it does not cover this
class, and it brings its own — a failed statement poisons the transaction it is in, and the engine
catches exceptions inside its own transactions. Filed as #39.
