### PR TITLE
Run the same suite on PostgreSQL, where a failed statement kills the transaction

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -35,9 +35,13 @@ Open an issue first for anything breaking or larger than a focused fix.
 - [ ] Reads that decide something use `useWritePdo()`
 - [ ] No new write to `flow_runs.updated_at` as a side effect (it is the repair staleness clock)
 - [ ] Events raised inside a new transaction implement `ShouldDispatchAfterCommit`
+- [ ] No query failure is caught and ignored inside a transaction
+      (PostgreSQL refuses everything after it and turns the commit into a rollback)
 - [ ] Existing lock order (`flow_runs` → `action_runs` / `flow_signals`) is preserved
 
-CI runs on SQLite only. If this change is driver-dependent, explain how it behaves on MySQL and
-PostgreSQL:
+CI runs the suite on SQLite, MySQL and PostgreSQL, so a driver difference shows up on its own —
+but only for behaviour a test actually reaches. Locking, transaction isolation and anything that
+needs two workers at once are still staged from one process and prove nothing. Say which of those
+this change depends on:
 
 <!-- your reasoning here, or "not driver-dependent" -->

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,6 +9,10 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+      # The harness decides which database the suite runs against, so a change to it
+      # is a change to what these jobs prove.
+      - 'docker-compose.yml'
+      - 'docker/**'
   pull_request:
     paths:
       - '**.php'
@@ -17,6 +21,10 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
+      # The harness decides which database the suite runs against, so a change to it
+      # is a change to what these jobs prove.
+      - 'docker-compose.yml'
+      - 'docker/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -111,5 +119,51 @@ jobs:
       - name: Execute tests
         env:
           SAGA_TEST_DB: mysql
+          SAGA_TEST_DB_HOST: 127.0.0.1
+        run: vendor/bin/pest --ci
+
+  # Same shape as test-mysql, for a driver that answers a different question: it counts
+  # matched rows like SQLite, but it refuses every statement after a failed one until the
+  # transaction is rolled back, and it truncates an identifier past 63 bytes.
+  test-pgsql:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    name: PostgreSQL - P8.5 - L13.* - prefer-stable
+
+    services:
+      postgres:
+        image: postgres:18
+        env:
+          POSTGRES_DB: saga_test
+          POSTGRES_USER: saga
+          POSTGRES_PASSWORD: saga
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd="pg_isready -U saga -d saga_test"
+          --health-interval=3s
+          --health-timeout=5s
+          --health-retries=20
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.5
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, pdo_pgsql, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: none
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:13.*" "orchestra/testbench:11.*" --no-interaction --no-update
+          composer update --prefer-stable --prefer-dist --no-interaction
+
+      - name: Execute tests
+        env:
+          SAGA_TEST_DB: pgsql
           SAGA_TEST_DB_HOST: 127.0.0.1
         run: vendor/bin/pest --ci

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,10 +9,9 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
-      # The harness decides which database the suite runs against, so a change to it
-      # is a change to what these jobs prove.
+      # Checked by the harness job below. docker/ is deliberately absent: no job here
+      # builds the image, so a change to it would trigger a run that proves nothing.
       - 'docker-compose.yml'
-      - 'docker/**'
   pull_request:
     paths:
       - '**.php'
@@ -21,16 +20,46 @@ on:
       - 'phpunit.xml.dist'
       - 'composer.json'
       - 'composer.lock'
-      # The harness decides which database the suite runs against, so a change to it
-      # is a change to what these jobs prove.
+      # Checked by the harness job below. docker/ is deliberately absent: no job here
+      # builds the image, so a change to it would trigger a run that proves nothing.
       - 'docker-compose.yml'
-      - 'docker/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
+  # The compose file is what a contributor runs the suite with, and its one hard rule is
+  # invisible to every other job here: the default command must start one container and
+  # no database. Nothing but a person watching `docker ps` enforced that until now.
+  harness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    name: Compose harness
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: The default command starts no database
+        run: |
+          services=$(docker compose config --services | sort | tr '\n' ' ')
+          echo "default profile: ${services}"
+          test "${services}" = "app "
+
+      - name: The default service waits on nothing
+        run: |
+          docker compose config --format json \
+            | python3 -c "import json,sys; d=json.load(sys.stdin)['services']['app'].get('depends_on'); sys.exit(0 if not d else 1)"
+
+      - name: Each server and the toolchain that talks to it live behind one profile
+        run: |
+          for profile in mysql pgsql; do
+            docker compose --profile "${profile}" config --services | grep -qx "${profile}"
+            docker compose --profile "${profile}" config --services | grep -qx "app-${profile}"
+          done
+
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 5

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,17 +33,22 @@ docker compose run --rm app composer lint
 ```
 
 The suite runs on an in-memory SQLite database, so the command above starts one container and
-no database server. Some of the engine's writes behave differently on MySQL, so there is a second
-command that runs the same suite against one — use it before a commit and before opening a PR:
+no database server. Some of the engine's writes behave differently on a real server, so the same
+suite also runs against MySQL and PostgreSQL, each behind a compose profile of its own:
 
 ```bash
 docker compose --profile mysql run --rm app-mysql vendor/bin/pest
+docker compose --profile pgsql run --rm app-pgsql vendor/bin/pest
 ```
 
-The database lives in the `mysql` compose profile: nothing starts it except a command that asks
-for it by name. `SAGA_TEST_DB=mysql` is all the suite reads, so a host with its own server can run
-against that instead — `SAGA_TEST_DB_HOST`, `_PORT`, `_DATABASE`, `_USERNAME` and `_PASSWORD` point
-it there.
+Run **MySQL before a commit and before opening a PR** — it is where a conditional write answers
+differently, which is what most of the engine rests on. **PostgreSQL at a milestone**, and whenever
+a change touches transactions, locking or migrations. CI runs both on any pull request that touches
+code or the harness, so a local run buys you the answer sooner, not a different one.
+
+Nothing starts a server except a command that asks for it by name. `SAGA_TEST_DB=mysql` or `=pgsql`
+is all the suite reads, so a host with its own server can run against that instead —
+`SAGA_TEST_DB_HOST`, `_PORT`, `_DATABASE`, `_USERNAME` and `_PASSWORD` point it there.
 
 **Whatever database it is pointed at is emptied.** The first test drops every table in it and
 rebuilds the schema; each test after that deletes every row. Give the suite a database of its own.
@@ -78,6 +83,11 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
   whose every value already equals what is stored reports zero there and one on SQLite and
   PostgreSQL. Never fence on an update whose only written column may already hold its value, and
   refuse only after reading back what actually holds the row. See `FlowStateMachine::write()`.
+- **Never swallow a query failure inside a `transaction()`.** PostgreSQL aborts the whole
+  transaction on the first failed statement and turns the eventual commit into a rollback, while
+  reporting success; SQLite and MySQL carry on. A caught-and-ignored failure therefore commits on
+  two drivers and silently discards everything on the third. This reaches listener code too: the
+  events the engine fires inside its own transactions run there.
 - **A read that decides something must use `useWritePdo()`.** A lagging replica will answer with the
   very state the fence was guarding against.
 - **Do not `refresh()` a model the caller still holds.** It discards their unsaved attributes;
@@ -117,6 +127,10 @@ for the other changes public behaviour and needs its own exception and its own d
 - **Run the suite on MySQL before you commit.** SQLite answers a conditional write differently,
   and a test that fences on one is meaningless there — see `ConditionalWriteFenceTest`, which is
   load-bearing on MySQL and trivially green on SQLite.
+- **A test may be written for one driver, but say so in the file.** `LongTablePrefixTest` skips
+  everywhere but PostgreSQL because no other driver truncates an identifier, and
+  `TransactionIntegrityTest` skips one case on PostgreSQL against a defect that is filed rather
+  than hidden. A skip without a stated reason is indistinguishable from a test nobody runs.
 - **Never assert the key order of a map read back out of a `json` column.** MySQL's `json` type is
   a binary format that sorts an object's keys; SQLite keeps the text as written. Key order is the
   driver's business, not the engine's contract — assert key by key with `toBe`, which stays strict
@@ -131,14 +145,13 @@ vendor/bin/pest --filter="cancels a non-terminal run"
 
 ### What CI does not check
 
-CI runs the suite on SQLite across the `os × stability` matrix, and once more on **MySQL**. Two
-gaps remain, and a green suite is not evidence in either:
+CI runs the suite on SQLite across the `os × stability` matrix, and once more on each of **MySQL**
+and **PostgreSQL**. Two gaps remain, and a green suite is not evidence in either:
 
-- **PostgreSQL.** Untested. It counts matched rows like SQLite, so the fences hold, but a failed
-  statement poisons the transaction it is in for good — and the engine catches exceptions inside
-  its own transactions.
 - **Real concurrency.** Every interleaving in the suite is staged from one process. Nothing runs
   two workers at once, so a lock held too long or a deadlock retried wrongly would pass.
+- **Transaction isolation.** For the same reason: `READ COMMITTED` and `REPEATABLE READ` differ
+  only for a read-back that races another writer, and nothing here races.
 
 ## Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,6 +127,11 @@ for the other changes public behaviour and needs its own exception and its own d
 - **Run the suite on MySQL before you commit.** SQLite answers a conditional write differently,
   and a test that fences on one is meaningless there — see `ConditionalWriteFenceTest`, which is
   load-bearing on MySQL and trivially green on SQLite.
+- **Order a relation read before you index into it.** `$run->actions()->first()` is whichever row
+  the driver felt like returning. SQLite and MySQL usually answer in insertion order; PostgreSQL
+  returns physical order, which moves as rows are updated. Say `orderBy('sequence')` — or
+  `orderBy('id')` for signals and events — wherever the run holds more than one row and the
+  assertion cares which.
 - **A test may be written for one driver, but say so in the file.** `LongTablePrefixTest` skips
   everywhere but PostgreSQL because no other driver truncates an identifier, and
   `TransactionIntegrityTest` skips one case on PostgreSQL against a defect that is filed rather

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,10 @@
 #   docker compose run --rm app composer lint
 #
 # The suite runs on SQLite by default and `app` depends on nothing, so the command
-# above starts one container and no database. The MySQL run is a separate command
-# behind a profile, for use before a commit and at a milestone:
+# above starts one container and no database. Each server run is a separate command
+# behind a profile of its own:
 #   docker compose --profile mysql run --rm app-mysql vendor/bin/pest
+#   docker compose --profile pgsql run --rm app-pgsql vendor/bin/pest
 services:
   app: &app
     build:
@@ -19,8 +20,8 @@ services:
       - .:/app
       - composer-cache:/root/.composer
 
-  # The same toolchain pointed at the MySQL service. Both live in the `mysql`
-  # profile, so neither is started by a command that does not ask for it.
+  # The same toolchain pointed at a server. Each pair lives in a profile of its own,
+  # so neither half is started by a command that does not ask for it.
   app-mysql:
     <<: *app
     profiles: [mysql]
@@ -51,6 +52,39 @@ services:
       retries: 20
       start_period: 30s
 
+  app-pgsql:
+    <<: *app
+    profiles: [pgsql]
+    depends_on:
+      pgsql:
+        condition: service_healthy
+    environment:
+      SAGA_TEST_DB: pgsql
+      SAGA_TEST_DB_HOST: pgsql
+      SAGA_TEST_DB_PORT: 5432
+
+  pgsql:
+    image: postgres:18
+    profiles: [pgsql]
+    # Same trade as the MySQL service: a throwaway test database has nothing to
+    # gain from surviving a power cut, and every write pays for it.
+    command: -c fsync=off -c synchronous_commit=off -c full_page_writes=off
+    environment:
+      POSTGRES_DB: saga_test
+      POSTGRES_USER: saga
+      POSTGRES_PASSWORD: saga
+    volumes:
+      # Postgres 18 wants the mount one level up: the data goes in a subdirectory of
+      # it, and a volume placed at .../data instead makes the image refuse to start.
+      - pgsql-data:/var/lib/postgresql
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U saga -d saga_test"]
+      interval: 3s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+
 volumes:
   composer-cache:
   mysql-data:
+  pgsql-data:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,7 +4,12 @@
 # plus Composer.
 FROM php:8.5-cli
 
-RUN apt-get update \
+# Fetch over HTTPS. Some networks sit behind a transparent HTTP cache that hands apt a
+# body whose hash does not match the index, and the build dies on "Hash Sum mismatch"
+# for a different package each time.
+RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' \
+        /etc/apt/sources.list.d/debian.sources /etc/apt/sources.list 2>/dev/null; \
+    apt-get update \
     && apt-get install -y --no-install-recommends \
         git \
         unzip \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # PHP 8.5 development/test image for the saga-lara-flow package.
 # Provides the extensions Testbench + the package need (pdo_sqlite for the default
-# in-memory suite, pdo_mysql for the MySQL run, intl, zip, bcmath, pcntl, mbstring)
-# plus Composer.
+# in-memory suite, pdo_mysql and pdo_pgsql for the server runs, intl, zip, bcmath,
+# pcntl, mbstring) plus Composer.
 FROM php:8.5-cli
 
 # Fetch over HTTPS. Some networks sit behind a transparent HTTP cache that hands apt a
@@ -17,9 +17,11 @@ RUN sed -i 's|http://deb.debian.org|https://deb.debian.org|g' \
         libicu-dev \
         libonig-dev \
         libsqlite3-dev \
+        libpq-dev \
     && docker-php-ext-install -j"$(nproc)" \
         pdo_sqlite \
         pdo_mysql \
+        pdo_pgsql \
         intl \
         zip \
         bcmath \

--- a/tests/Feature/DatabaseResetTest.php
+++ b/tests/Feature/DatabaseResetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The harness gives each test an empty database: on SQLite by opening a new :memory:
+ * one, and on a server by building the schema once and deleting the rows before each
+ * test. "The database" has to mean the same thing to both halves of that — the initial
+ * dropAllTables() and the reset that follows it — and on PostgreSQL it very nearly did
+ * not. Asked for a table listing without a schema, PostgreSQL answers with every schema
+ * on the server, in bare names, while dropAllTables() only ever clears the search path.
+ *
+ * PostgreSQL only: it is the sole supported driver with more than one schema per
+ * database, so there is nothing for the others to get wrong here.
+ */
+afterEach(function () {
+    if (TestCase::driver() === 'pgsql') {
+        DB::statement('drop schema if exists sibling cascade');
+    }
+});
+
+it('empties the schema it drops and leaves another schema alone', function () {
+    DB::statement('create schema sibling');
+    DB::statement('create table sibling.sentinel (id integer)');
+    // The nastier half: a name the search path already answers for. A bare-name delete
+    // would empty public's copy twice and never touch this one.
+    DB::statement('create table sibling.saga_flow_runs (id integer)');
+
+    DB::table('sibling.sentinel')->insert(['id' => 1]);
+    DB::table('sibling.saga_flow_runs')->insert(['id' => 1]);
+
+    // The reset the harness runs between tests, called directly rather than waited for:
+    // whether it throws is as much the point as what it leaves behind.
+    $this->truncate();
+
+    expect(DB::table('sibling.sentinel')->count())->toBe(1)
+        ->and(DB::table('sibling.saga_flow_runs')->count())->toBe(1);
+})->skip(
+    fn () => TestCase::driver() !== 'pgsql',
+    'Only PostgreSQL puts more than one schema in a database.',
+);

--- a/tests/Feature/LongTablePrefixTest.php
+++ b/tests/Feature/LongTablePrefixTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Both index migrations match an index by the name the driver actually stored, not by
+ * the name Laravel derived, because PostgreSQL truncates an identifier past 63 bytes
+ * and a long table prefix reaches that. Every one of those `existing()` helpers was
+ * written from the documentation and had never been run.
+ *
+ * With this 24-character prefix both names that index_signal_waits owns cross the limit
+ * — 73 and 66 bytes — so what the catalogue holds is not what `$table->index(..., $name)`
+ * asked for, and a migration that compared the two literally would try to create its
+ * index a second time.
+ *
+ * The prefix stops at 24 on purpose. unique_flow_tag_keys needs 32 before its own names
+ * truncate, and at 30 the initial migration cannot install at all: three of
+ * flow_children's index names truncate onto each other. That is issue #42, and until it
+ * is fixed the tag migration's half of this cannot be reached.
+ *
+ * PostgreSQL only, deliberately. MySQL does not truncate a long identifier, it refuses
+ * it outright at 64 bytes, and SQLite has no limit worth reaching: there is no
+ * truncation to exercise on either. Do not "fix" the skip.
+ */
+beforeEach(function () {
+    // Guarded, not left to the per-test skip: a skip stops the test body, not this, and
+    // MySQL rejects an identifier this long outright rather than truncating it.
+    if (TestCase::driver() !== 'pgsql') {
+        return;
+    }
+
+    config()->set('saga-lara-flow.database.table_prefix', 'saga_flow_long_prefix_1_');
+
+    // Read afresh on every call in UsesSagaFlowConnection::getTable(), so the prefix
+    // above is already in force for the migrations this builds the schema with.
+    foreach ($this->packageMigrations() as $path) {
+        (include $path)->up();
+    }
+});
+
+// The schema this leaves behind is not the one the rest of the suite expects.
+afterEach(fn () => TestCase::forgetSchema());
+
+it('finds the indexes it created under the truncated names the driver stored', function () {
+    $names = fn (string $table) => collect(Schema::getIndexes('saga_flow_long_prefix_1_'.$table))
+        ->pluck('name')
+        ->all();
+
+    foreach ($names('action_runs') as $name) {
+        expect(strlen($name))->toBeLessThanOrEqual(63);
+    }
+
+    // Stored under a name shorter than the one asked for, and still recognisably ours.
+    expect($names('action_runs'))->toContain(substr('saga_flow_long_prefix_1_action_runs_status_retry_signal_flow_run_id_index', 0, 63))
+        ->and($names('flow_signals'))->toContain(substr('saga_flow_long_prefix_1_flow_signals_status_name_flow_run_id_index', 0, 63))
+        ->and(strlen('saga_flow_long_prefix_1_action_runs_status_retry_signal_flow_run_id_index'))->toBeGreaterThan(63);
+})->skip(fn () => TestCase::driver() !== 'pgsql', 'Only PostgreSQL truncates an identifier past 63 bytes.');
+
+it('re-runs over its own work rather than creating a second index under the same name', function () {
+    $indexes = fn (string $table) => collect(Schema::getIndexes('saga_flow_long_prefix_1_'.$table))
+        ->pluck('columns');
+
+    $waits = include __DIR__.'/../../database/migrations/2026_08_26_000000_index_signal_waits.php';
+    $tags = include __DIR__.'/../../database/migrations/2026_08_26_000001_unique_flow_tag_keys.php';
+
+    // Idempotent in both directions, which is what the name matching is for: a truncated
+    // name that failed to match would make the second up() try to create an index the
+    // catalogue already holds.
+    $waits->up();
+    $waits->up();
+    $tags->up();
+    $tags->up();
+
+    expect($indexes('flow_signals'))->toContain(['status', 'name', 'flow_run_id'])
+        ->and($indexes('action_runs'))->toContain(['status', 'retry_signal', 'flow_run_id'])
+        ->and($indexes('flow_tags')->all())->toContain(['flow_run_id', 'key']);
+
+    $waits->down();
+    $waits->down();
+
+    expect($indexes('flow_signals'))->not->toContain(['status', 'name', 'flow_run_id']);
+})->skip(fn () => TestCase::driver() !== 'pgsql', 'Only PostgreSQL truncates an identifier past 63 bytes.');

--- a/tests/Feature/MigrationLoadingTest.php
+++ b/tests/Feature/MigrationLoadingTest.php
@@ -11,6 +11,14 @@ use Illuminate\Support\Facades\Schema;
 // outlives the test, so hand the next one a rebuild.
 afterEach(fn () => TestCase::forgetSchema());
 
+// flow_run_id is a ulid, which is char(26). PostgreSQL pads a shorter value out to the
+// full width and hands the padding back on the way out; MySQL trims it on read and
+// SQLite ignores the width. Nothing in the engine can put a short value there — every
+// id comes from HasUlids — so these stand in for one at its real length rather than
+// leaning on a value the column cannot hold faithfully.
+const RUN_ONE = 'run-1-00000000000000000000';
+const RUN_TWO = 'run-2-00000000000000000000';
+
 // The provider calls runsMigrations(), so a host app installs with just
 // `php artisan migrate` — no vendor:publish step. Two things must hold, and each
 // has bitten us before:
@@ -133,10 +141,10 @@ it('collapses tag keys that the wider unique had let diverge', function (): void
     $migration->down();
 
     DB::table('saga_flow_tags')->insert([
-        ['flow_run_id' => 'run-1', 'key' => 'stage', 'value' => 'charged'],
-        ['flow_run_id' => 'run-1', 'key' => 'stage', 'value' => 'shipped'],
-        ['flow_run_id' => 'run-1', 'key' => 'tenant', 'value' => 'acme'],
-        ['flow_run_id' => 'run-2', 'key' => 'stage', 'value' => 'charged'],
+        ['flow_run_id' => RUN_ONE, 'key' => 'stage', 'value' => 'charged'],
+        ['flow_run_id' => RUN_ONE, 'key' => 'stage', 'value' => 'shipped'],
+        ['flow_run_id' => RUN_ONE, 'key' => 'tenant', 'value' => 'acme'],
+        ['flow_run_id' => RUN_TWO, 'key' => 'stage', 'value' => 'charged'],
     ]);
 
     $migration->up();
@@ -144,7 +152,11 @@ it('collapses tag keys that the wider unique had let diverge', function (): void
     // Only the diverged key loses a row, and the newest write is the one kept.
     expect(DB::table('saga_flow_tags')->orderBy('id')->get()->map(
         fn ($tag): string => "{$tag->flow_run_id}:{$tag->key}={$tag->value}",
-    )->all())->toBe(['run-1:stage=shipped', 'run-1:tenant=acme', 'run-2:stage=charged']);
+    )->all())->toBe([
+        RUN_ONE.':stage=shipped',
+        RUN_ONE.':tenant=acme',
+        RUN_TWO.':stage=charged',
+    ]);
 });
 
 it('carries on from whichever half of the tag key swap already happened', function (): void {
@@ -179,8 +191,8 @@ it('keeps the tag value written last, not the row inserted last', function (): v
     $migration->down();
 
     DB::table('saga_flow_tags')->insert([
-        ['id' => 1, 'flow_run_id' => 'run-1', 'key' => 'stage', 'value' => 'charged', 'updated_at' => now()],
-        ['id' => 2, 'flow_run_id' => 'run-1', 'key' => 'stage', 'value' => 'shipped', 'updated_at' => now()],
+        ['id' => 1, 'flow_run_id' => RUN_ONE, 'key' => 'stage', 'value' => 'charged', 'updated_at' => now()],
+        ['id' => 2, 'flow_run_id' => RUN_ONE, 'key' => 'stage', 'value' => 'shipped', 'updated_at' => now()],
     ]);
 
     // updateOrCreate rewrites the row it matched instead of inserting a new one, so

--- a/tests/Feature/ReclaimStaleRunningTest.php
+++ b/tests/Feature/ReclaimStaleRunningTest.php
@@ -111,7 +111,9 @@ it('lets a per-action explicit threshold win regardless of the enabled flags', f
         ->withArguments(42)
         ->runSync();
 
-    expect($run->actions()->first()->reclaim_stale_after_seconds)->toBe(42);
+    // Ordered, not just first: ReclaimOverrideWorkflow schedules a second step that
+    // carries no override, and an unordered read is free to hand it back instead.
+    expect($run->actions()->orderBy('sequence')->first()->reclaim_stale_after_seconds)->toBe(42);
 });
 
 it('lets a per-action override force-enable reclaim (config default seconds) even when config is off', function () {
@@ -119,7 +121,7 @@ it('lets a per-action override force-enable reclaim (config default seconds) eve
         ->withArguments(null, true)
         ->runSync();
 
-    expect($run->actions()->first()->reclaim_stale_after_seconds)
+    expect($run->actions()->orderBy('sequence')->first()->reclaim_stale_after_seconds)
         ->toBe((int) config('saga-lara-flow.actions.reclaim.stale_running.after_seconds'));
 });
 
@@ -130,7 +132,7 @@ it('lets a per-action override force-disable reclaim even when config is globall
         ->withArguments(null, false)
         ->runSync();
 
-    expect($run->actions()->first()->reclaim_stale_after_seconds)->toBeNull();
+    expect($run->actions()->orderBy('sequence')->first()->reclaim_stale_after_seconds)->toBeNull();
 });
 
 it('resolves the compensation-side reclaim threshold independently of the action-side one', function () {
@@ -141,8 +143,8 @@ it('resolves the compensation-side reclaim threshold independently of the action
         ->runSync();
 
     expect($run->status)->toBe(FlowStatus::Failed)
-        ->and($run->actions()->first()->reclaim_stale_after_seconds)->toBe(42)
-        ->and($run->compensations()->first()->reclaim_stale_after_seconds)->toBe(77);
+        ->and($run->actions()->orderBy('sequence')->first()->reclaim_stale_after_seconds)->toBe(42)
+        ->and($run->compensations()->orderBy('sequence')->first()->reclaim_stale_after_seconds)->toBe(77);
 });
 
 it('gives RunCompensationJob its own WithoutOverlapping lock, independent of the action lock', function () {

--- a/tests/Feature/TransactionIntegrityTest.php
+++ b/tests/Feature/TransactionIntegrityTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CountedActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * ActionRecorder::startAction() claims the row, records action.started and fires the
+ * ActionStarted event in one transaction, so a listener cannot leave the row Running
+ * with nothing executing it. That listener is the one place a caller's code runs inside
+ * a transaction the engine opened, and the drivers do not agree about what a failed
+ * statement does to one: PostgreSQL aborts the whole transaction and turns the eventual
+ * COMMIT into a rollback, reporting success either way, while SQLite and MySQL let the
+ * caller carry on.
+ *
+ * A listener that throws is already handled — the claim rolls back with it. The shape
+ * that gets past the guarantee is one that runs a failing query and SWALLOWS it.
+ */
+beforeEach(function () {
+    FlakyPaymentAction::reset();
+});
+
+function swallowAQueryFailureOnStart(): void
+{
+    Event::listen(ActionStarted::class, function (): void {
+        try {
+            DB::connection('testing')->statement('insert into no_such_table (id) values (1)');
+        } catch (Throwable) {
+            // A listener that eats its own failure — broken, but nothing stops it.
+        }
+    });
+}
+
+it('never records a claim without its event', function () {
+    swallowAQueryFailureOnStart();
+
+    $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
+
+    $step = $run->actions()->first();
+    $started = $run->events()->where('type', FlowEventType::ActionStarted)->exists();
+
+    // Both halves of the claim or neither: the row's own marks and the event that
+    // announces them are written in the same transaction and cannot come apart.
+    expect($started)->toBe($step->status !== ActionStatus::Pending)
+        ->and($step->attempts)->toBe($started ? 1 : 0);
+});
+
+it('does not execute a step it failed to claim', function () {
+    swallowAQueryFailureOnStart();
+
+    $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
+
+    $step = $run->actions()->first();
+
+    // The half that at-least-once rests on. A body that ran under a claim the database
+    // never kept is a charge nobody can attribute, and the next replay makes a second
+    // one.
+    expect(FlakyPaymentAction::$calls)->toBe($step->status === ActionStatus::Pending ? 0 : 1);
+})->skip(
+    fn () => TestCase::driver() === 'pgsql',
+    'Known defect on PostgreSQL, tracked in #41: the claim is rolled back by the poisoned '
+    .'transaction, COMMIT reports success anyway, and the body runs regardless.',
+);

--- a/tests/Fixtures/CountedActionWorkflow.php
+++ b/tests/Fixtures/CountedActionWorkflow.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * One step, and a counter on the action that says whether its body ran. Used where a
+ * test has to tell "the engine recorded the step" apart from "the engine executed it".
+ */
+final class CountedActionWorkflow extends Workflow
+{
+    /**
+     * @return array{charged: string, calls: int}
+     */
+    public function handle(string $orderId = 'order-1'): array
+    {
+        return $this->action(FlakyPaymentAction::class, $orderId)->run();
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -33,11 +33,12 @@ class TestCase extends Orchestra
     }
 
     /**
-     * SQLite is the default and needs nothing running; SAGA_TEST_DB=mysql points the
-     * suite at a server instead — one whose database is the suite's own, since the first
-     * test drops every table in it. The engine fences on `update() === 1`, and MySQL counts
-     * the rows it changed rather than the rows it matched — a whole class of defect is
-     * invisible until the suite has been over both.
+     * SQLite is the default and needs nothing running; SAGA_TEST_DB=mysql or =pgsql
+     * points the suite at a server instead — one whose database is the suite's own, since
+     * the first test drops every table in it. Each server answers something the others do
+     * not: MySQL counts the rows an update changed rather than the rows it matched, and
+     * PostgreSQL refuses every statement after a failed one until the transaction is
+     * rolled back. Neither is visible to a suite that has only ever run on SQLite.
      *
      * The name is the package's own rather than DB_CONNECTION, which Testbench and a
      * host .env both have opinions about.
@@ -56,6 +57,20 @@ class TestCase extends Orchestra
                 'password' => env('SAGA_TEST_DB_PASSWORD', 'saga'),
                 'charset' => 'utf8mb4',
                 'collation' => 'utf8mb4_unicode_ci',
+                'prefix' => '',
+            ],
+            'pgsql' => [
+                'driver' => 'pgsql',
+                'host' => env('SAGA_TEST_DB_HOST', '127.0.0.1'),
+                'port' => env('SAGA_TEST_DB_PORT', '5432'),
+                'database' => env('SAGA_TEST_DB_DATABASE', 'saga_test'),
+                'username' => env('SAGA_TEST_DB_USERNAME', 'saga'),
+                'password' => env('SAGA_TEST_DB_PASSWORD', 'saga'),
+                'charset' => 'utf8',
+                // Named rather than left to the server's own: getTableListing() reads
+                // every schema on the path, and the reset below empties what it lists.
+                'search_path' => 'public',
+                'sslmode' => 'prefer',
                 'prefix' => '',
             ],
             default => [
@@ -158,13 +173,20 @@ class TestCase extends Orchestra
      * they outlive the test that made them — along with any job it left unworked, which
      * the next drainQueue() would happily run.
      *
+     * Scoped to the schemas dropAllTables() clears, so the two halves of the reset agree
+     * on what "the database" means. Left unscoped, PostgreSQL lists every schema on the
+     * server and hands back bare names: a table outside the search path is then either
+     * missing when the delete resolves the name, or shadowed by a same-named one in
+     * public, which gets emptied twice while the real rows stay put.
+     *
      * The schema declares no foreign keys, so nothing constrains the order.
      */
-    private function truncate(): void
+    protected function truncate(): void
     {
         $connection = DB::connection('testing');
+        $schema = Schema::connection('testing');
 
-        foreach (Schema::connection('testing')->getTableListing(schemaQualified: false) as $table) {
+        foreach ($schema->getTableListing($schema->getCurrentSchemaListing(), schemaQualified: false) as $table) {
             $connection->table($table)->delete();
         }
     }


### PR DESCRIPTION
Closes #39.

PostgreSQL is a supported driver the suite had never been run against. It is worth doing for a
different reason than MySQL was: it counts matched rows like SQLite, so the fences hold there by
construction. What it brings instead is that a failed statement aborts the whole transaction — every
later statement is refused, and the eventual `COMMIT` is turned into a rollback while still
reporting success.

## The harness

A third `match` arm and a service, as #33 was built to allow. The rest of the harness — the
schema-once-then-empty-the-rows reset, the connection purge, the refusal to run in parallel against
a server — needed no change.

```bash
docker compose --profile pgsql run --rm app-pgsql vendor/bin/pest
```

SQLite is still the default and still starts nothing. Run **MySQL before a commit** — it is where a
conditional write answers differently — and **PostgreSQL at a milestone**, or when a change touches
transactions, locking or migrations. CI runs both.

`docker-compose.yml` and `docker/**` now trigger `run-tests.yml`: the harness decides which database
the suite runs against, so a change to it is a change to what those jobs prove.

## What the first run found

Two engine defects, filed rather than fixed here, per the rule that a defect a new driver uncovers
gets its own issue and its own PR:

- **#41** — a listener on `ActionStarted` that runs a failing query and *swallows* it leaves the
  claim rolled back while `startAction()` returns true. The action body executes, the row stays
  `Pending` with `attempts = 0`, no `action.started` event exists, and the run parks `Waiting`. A
  replay runs the body again. Unaffected on SQLite and MySQL.
- **#42** — a table prefix of 30 characters or more makes the initial migration fail: three
  `flow_children` index names share a 33-byte head and truncate onto each other. Bisected: 29
  installs, 30 fails.

One harness defect, fixed here: `MigrationLoadingTest` put `'run-1'` in a `ulid` column. PostgreSQL
pads `char(26)` and hands the padding back; MySQL trims on read; SQLite ignores the width. The ids
are now full width, which is what `HasUlids` produces anyway.

## New tests

- **`TransactionIntegrityTest`** — the claim and its event are inseparable, and a step the engine
  failed to claim must not have executed. The second case is skipped on PostgreSQL against #41;
  removing that skip is #41's acceptance criterion. Mutation: move `events->record()` outside the
  claim's transaction and the first case fails on PostgreSQL with the event present and the row
  `Pending`.
- **`LongTablePrefixTest`** — PostgreSQL only, deliberately: nothing else truncates an identifier,
  and MySQL refuses a long one outright. It is the first run of the truncated-name matching in
  `index_signal_waits`, written from the documentation and never executed. Mutation: compare names
  strictly and the second case fails with `42P07`. The prefix stops at 24 because #42 blocks
  anything from 30 up.
- **`DatabaseResetTest`** — the between-test reset must mean the same thing as the initial drop.
  Asked for a table listing without a schema, PostgreSQL answers with every schema on the server in
  bare names, while `dropAllTables()` only clears the search path; a table outside it then either
  breaks the reset or shadows one inside it. Mutation: drop the schema scope and the test fails with
  `42P01`.

## Verification

| | SQLite | MySQL | PostgreSQL |
|---|---|---|---|
| | 384 passed, 3 skipped | 384 passed, 3 skipped | 386 passed, 1 skipped |

387 tests on every driver; every skip names its reason. Three PostgreSQL seeds plus a cold start
after `docker compose --profile pgsql down -v`. The default command was checked against `docker ps`
and starts no server. PHPStan level 5 clean, Pint clean over 347 files.

## The first commit

`02f131c` is unrelated to PostgreSQL and is separated for that reason: on a network behind a
transparent HTTP cache, apt was handed bodies whose hashes did not match the index and the image
would not build at all. Fetching over HTTPS builds.
