### PR TITLE
Order a run's rows instead of taking whatever the driver returns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,11 +127,13 @@ for the other changes public behaviour and needs its own exception and its own d
 - **Run the suite on MySQL before you commit.** SQLite answers a conditional write differently,
   and a test that fences on one is meaningless there — see `ConditionalWriteFenceTest`, which is
   load-bearing on MySQL and trivially green on SQLite.
-- **Order a relation read before you index into it.** `$run->actions()->first()` is whichever row
-  the driver felt like returning. SQLite and MySQL usually answer in insertion order; PostgreSQL
-  returns physical order, which moves as rows are updated. Say `orderBy('sequence')` — or
-  `orderBy('id')` for signals and events — wherever the run holds more than one row and the
-  assertion cares which.
+- **`FlowRun`'s relations carry their order; don't append one that fights it.** Each reads by the
+  column its rows are meaningful in (see `src/Models/FlowRun.php`), because without one the answer
+  is the driver's to choose — SQLite and MySQL usually give insertion order, PostgreSQL gives
+  physical order, which moves as rows are updated. An order you append lands after the default, so
+  to read in the other direction call `reorder()` first — and before any id-cursor traversal
+  (`chunkById()` and friends), whose cursor the default would otherwise outrank. A relation added
+  later needs an order of its own: `RelationOrderTest` fails until it has one.
 - **A test may be written for one driver, but say so in the file.** `LongTablePrefixTest` skips
   everywhere but PostgreSQL because no other driver truncates an identifier, and
   `TransactionIntegrityTest` skips one case on PostgreSQL against a defect that is filed rather

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -432,6 +432,23 @@ including which signal a parked step will next wait for.
 return your own builder subclass: PHP refuses to load an override whose signature no longer matches,
 so widen it to `RetryPolicy|string $signal` and accept the fifth `?Closure $when` parameter.
 
+### 18. A run's relations read in a defined order
+
+`FlowRun`'s relations no longer come back in whatever order the driver chose: `actions()`,
+`compensations()`, `sideEffects()` and `children()` read by `sequence`, `events()` by
+`recorded_at`, and `signals()` and `tags()` by `id`.
+
+Nothing that was correct before changes. What to check is a read that appends its own order, or
+one that pages by id — both now land behind the default, so clear it first:
+
+```php
+$run->signals()->reorder()->orderByDesc('id')->first();
+$run->actions()->reorder()->chunkById(500, fn ($actions) => ...);
+```
+
+Eager loads, `withCount()`, `whereHas()` and plain `chunk()` need nothing. See
+[Configuration](https://sagalaraflow.dev/configuration).
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -35,6 +35,12 @@ connection `null`.
 
 Swap any model for your own subclass to extend behaviour (casts, relations, scopes).
 
+`FlowRun`'s relations read in the order their rows are meaningful in: `actions()`,
+`compensations()`, `sideEffects()` and `children()` by `sequence`, `events()` by `recorded_at` then
+`id`, and `signals()` and `tags()` by `id`. An order you append lands *after* that one — call
+`reorder()` first to read against it, and also before `chunkById()`, `lazyById()` or `eachById()`,
+whose cursor the default order would otherwise outrank.
+
 ## Queue
 
 ```php

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -62,39 +62,61 @@ class FlowRun extends Model
         ];
     }
 
+    /**
+     * Every relation below states the order its rows are meaningful in; without one the
+     * driver picks, and PostgreSQL picks physical order, which moves as rows are updated.
+     *
+     * Reading against it — a reverse order, or the id-cursor paging of chunkById() and
+     * friends, which keeps any order on another column and lets it outrank the cursor —
+     * needs reorder() first.
+     */
     public function actions(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.action_run'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.action_run'), 'flow_run_id')
+            ->orderBy('sequence');
     }
 
     public function events(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.flow_event'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.flow_event'), 'flow_run_id')
+            ->orderBy('recorded_at')
+            ->orderBy('id');
     }
 
     public function signals(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.flow_signal'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.flow_signal'), 'flow_run_id')
+            ->orderBy('id');
     }
 
     public function tags(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.flow_tag'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.flow_tag'), 'flow_run_id')
+            ->orderBy('id');
     }
 
+    /**
+     * By id as well: compensation_runs carries no unique on (flow_run_id, sequence), and
+     * the counter behind it reads before it writes, so two overlapping rollbacks of one
+     * run could number their rows alike.
+     */
     public function compensations(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.compensation_run'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.compensation_run'), 'flow_run_id')
+            ->orderBy('sequence')
+            ->orderBy('id');
     }
 
     public function sideEffects(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.side_effect'), 'flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.side_effect'), 'flow_run_id')
+            ->orderBy('sequence');
     }
 
     public function children(): HasMany
     {
-        return $this->hasMany(config('saga-lara-flow.models.flow_child'), 'parent_flow_run_id');
+        return $this->hasMany(config('saga-lara-flow.models.flow_child'), 'parent_flow_run_id')
+            ->orderBy('sequence');
     }
 
     public function parent(): BelongsTo

--- a/tests/Feature/RelationOrderTest.php
+++ b/tests/Feature/RelationOrderTest.php
@@ -1,0 +1,171 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * Issue #44. A relation read with no order lets the driver choose the answer. SQLite
+ * and MySQL happen to answer in insertion order, which is why nobody noticed;
+ * PostgreSQL answers in physical order, and an updated row moves to the end of the
+ * heap, so a run whose first step was rewritten hands back its second step first.
+ *
+ * That is not hypothetical: ReclaimStaleRunningTest went red in CI on PostgreSQL with
+ * "Failed asserting that 900 is null", having been handed the second step of a
+ * two-step workflow.
+ *
+ * Physical order is the wrong thing to reproduce, though: it depends on whether the
+ * update was HOT, on page fill, on autovacuum and on the plan the driver picked, none
+ * of which a test controls. Insertion order it does control — so every case below
+ * writes its rows backwards. Without an order on the relation each driver hands them
+ * back backwards, which is the same defect stated in a way that is deterministic on
+ * all three.
+ */
+function orderProbeRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+}
+
+it('reads a run\'s steps by ordinal, not by the order they were written', function () {
+    $run = orderProbeRun();
+
+    foreach ([2, 0, 1] as $sequence) {
+        ActionRun::create([
+            'flow_run_id' => $run->id,
+            'sequence' => $sequence,
+            'action_class' => MakeValueAction::class,
+            'status' => ActionStatus::Pending,
+        ]);
+    }
+
+    $fresh = SagaFlow::findRun($run->id);
+
+    expect($fresh->actions()->pluck('sequence')->all())->toBe([0, 1, 2])
+        ->and($fresh->actions()->first()->sequence)->toBe(0);
+});
+
+it('reads a run\'s events in recorded order, not in the order they were written', function () {
+    $run = orderProbeRun();
+
+    // Recorded out of order on purpose: `recorded_at` is what History reads by, and it
+    // is set by the recorder rather than by the insert, so the two can disagree.
+    foreach ([120, 0, 60] as $offset) {
+        FlowEvent::create([
+            'flow_run_id' => $run->id,
+            'type' => FlowEventType::FlowStarted,
+            'recorded_at' => now()->addSeconds($offset),
+        ]);
+    }
+
+    $recorded = SagaFlow::findRun($run->id)->events()->pluck('recorded_at')->all();
+    $sorted = $recorded;
+    sort($sorted);
+
+    expect($recorded)->toHaveCount(3)->and($recorded)->toBe($sorted);
+});
+
+it('reads a run\'s signals in arrival order, not in the order they were written', function () {
+    $run = orderProbeRun();
+
+    // Written newest-first, with the ulid given rather than generated: left to itself a
+    // ulid is monotonic, so insertion order and id order would agree and this would
+    // prove nothing.
+    foreach (['01K0000000000000000000000C', '01K0000000000000000000000A', '01K0000000000000000000000B'] as $id) {
+        FlowSignal::create([
+            'id' => $id,
+            'flow_run_id' => $run->id,
+            'name' => 'approval',
+            'status' => SignalStatus::Waiting,
+            'wait_sequence' => 0,
+        ]);
+    }
+
+    expect(SagaFlow::findRun($run->id)->signals()->pluck('id')->all())->toBe([
+        '01K0000000000000000000000A',
+        '01K0000000000000000000000B',
+        '01K0000000000000000000000C',
+    ]);
+});
+
+/**
+ * The cost of the default order, recorded rather than discovered later.
+ *
+ * chunkById(), lazyById() and eachById() page by a cursor on the key, and clear an
+ * existing order only on the cursor column itself
+ * (Query\Builder::removeExistingOrdersFor). An order on any other column therefore
+ * survives and outranks `id`, and the traversal — which pages with `where id > last` —
+ * can revisit a row and skip another.
+ *
+ * It does not bite the rows the engine writes: those are inserted in ordinal order and
+ * their ulids ascend with them, so `order by sequence, id` and `order by id` agree. It
+ * bites rows written in some other order, which is what this test builds.
+ */
+it('lets an id-cursor traversal outrank the default order, and reorder() restores it [pinning]', function () {
+    $run = orderProbeRun();
+
+    // Ids descending while sequences ascend — the disagreement the engine's own writes
+    // never produce, and a backfill or an import can.
+    foreach ([[0, 'C'], [1, 'B'], [2, 'A']] as [$sequence, $letter]) {
+        ActionRun::create([
+            'id' => '01K'.str_repeat('0', 22).$letter,
+            'flow_run_id' => $run->id,
+            'sequence' => $sequence,
+            'action_class' => MakeValueAction::class,
+            'status' => ActionStatus::Pending,
+        ]);
+    }
+
+    $walk = function (bool $reorder) use ($run): array {
+        $relation = SagaFlow::findRun($run->id)->actions();
+        $seen = [];
+
+        ($reorder ? $relation->reorder() : $relation)->chunkById(2, function ($chunk) use (&$seen): void {
+            foreach ($chunk as $row) {
+                $seen[] = $row->sequence;
+            }
+        });
+
+        return $seen;
+    };
+
+    // Sequence 0 twice, sequence 2 never: `order by sequence, id` fights `where id > ?`.
+    expect($walk(reorder: false))->toBe([0, 1, 0])
+        ->and($walk(reorder: true))->toBe([2, 1, 0]);
+});
+
+/**
+ * A pinning test over the wiring rather than over one read: every relation FlowRun
+ * exposes states an order, so a relation added later cannot quietly reintroduce the
+ * defect for whichever call site reads it first.
+ */
+it('declares an order on every relation it exposes [pinning]', function () {
+    $run = new FlowRun;
+
+    $relations = collect((new ReflectionClass(FlowRun::class))->getMethods(ReflectionMethod::IS_PUBLIC))
+        ->filter(fn (ReflectionMethod $method) => (string) $method->getReturnType() === HasMany::class)
+        ->map(fn (ReflectionMethod $method) => $method->getName());
+
+    expect($relations)->toHaveCount(7);
+
+    foreach ($relations as $name) {
+        /** @var HasMany $relation */
+        $relation = $run->{$name}();
+
+        expect($relation->getQuery()->getQuery()->orders)
+            ->not->toBeEmpty("FlowRun::{$name}() reads in whatever order the driver chooses.");
+    }
+});

--- a/tests/Feature/RetryOnSignalOperatorTest.php
+++ b/tests/Feature/RetryOnSignalOperatorTest.php
@@ -352,7 +352,7 @@ it('carries a signal payload from saga-flow:signal into the retried run', functi
 
     // The delivery that ended the wait is the marker at the step's own ordinal, and
     // it kept the payload the operator sent.
-    $marker = $final->signals()->orderByDesc('id')->first();
+    $marker = $final->signals()->reorder()->orderByDesc('id')->first();
 
     expect($marker->wait_sequence)->toBe(1)
         ->and($marker->payload)->toBe(['topped_up' => 500]);

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -925,7 +925,7 @@ it('rolls the consumption back when the retry transition fails', function () {
         // The explosion is the setup; the rows it leaves behind are the assertion.
     }
 
-    $signal = SagaFlow::findRun($run->id)->signals()->orderByDesc('id')->first();
+    $signal = SagaFlow::findRun($run->id)->signals()->reorder()->orderByDesc('id')->first();
     $step = SagaFlow::findRun($run->id)->actions()->where('sequence', 1)->first();
 
     expect($signal->status)->toBe(SignalStatus::Received)


### PR DESCRIPTION
## What this changes

`FlowRun`'s seven `hasMany` relations now state the order their rows are meaningful in, instead of
leaving it to the driver: `actions()`, `compensations()`, `sideEffects()` and `children()` by
`sequence`, `events()` by `recorded_at` then `id`, and `signals()` and `tags()` by `id`.

Closes #44.

Those are the orders the engine already reads by (`Runtime\History`, `saga-flow:show`), so this
states an order rather than picking one. The alternative the issue offers — auditing the call sites
— was measured and rejected: the suite makes 213 relation reads with no order, 123 of which index
into the result, while 26 already append one. Of those 26, 24 match the proposed default exactly
and **2** want the opposite direction. Both are in this diff, rewritten with `reorder()`.

## Checklist

- [x] One feature/fix; the diff is focused
- [x] `composer lint` passes (Pint + PHPStan level 5)
- [x] `composer test` passes
- [x] `CHANGELOG.md` is untouched
- [x] README **and** `/docs` updated if public behaviour changed, and `cd docs && npm run build` passes
- [x] Breaking changes are described in `UPGRADING.md`, under the section for the version in progress

## Tests

`tests/Feature/RelationOrderTest.php`, five cases.

Three read one relation each — steps, events, signals — after writing its rows **backwards**
(sequences 2,0,1; `recorded_at` +120,0,+60; explicit ulids C,A,B), and assert they come back
forwards. Insertion order is what a test controls; physical order is not, and an earlier version of
this test that tried to force it stayed green under mutation, because a HOT update keeps the row's
line pointer where it was. The ulids are given rather than generated, and are exactly 26 characters:
a generated ulid is monotonic, so insertion order and id order would have agreed and proved nothing,
and the column is `char(26)`, which PostgreSQL pads and returns padded.

One pins the wiring: every relation `FlowRun` exposes declares an order, so one added later cannot
quietly reintroduce the defect.

One records the cost. `chunkById()`, `lazyById()` and `eachById()` page with `where id > <last>` and
clear an existing order only on the cursor column
(`Query\Builder::removeExistingOrdersFor`), so an order on any other column outranks the cursor and
the traversal can hand back a row twice and skip another. With ids anti-correlated to sequence that
is `[0,1,0]` instead of `[0,1,2]`; `reorder()` restores it. It does not reach the rows the engine
writes, whose ids ascend with their ordinals — verified on real runs for both steps and
compensations — and it is documented in `UPGRADING.md` and `docs/configuration.md`.

- [x] Every regression test was verified to fail without its own fix
- [x] No existing assertion was deleted or weakened to fit the new behaviour
- [x] No mocks; faults are injected through model config or a fixture static

Mutation: with the orders removed from `actions()`, `events()` and `signals()`, all four
order-reading tests fail on **both** SQLite and PostgreSQL.

## Concurrency and drivers

- [x] No decision is taken from a model's in-memory status where the row could have moved
- [x] Conditional updates do not fence on a column that may already hold the value written
- [x] Reads that decide something use `useWritePdo()`
- [x] No new write to `flow_runs.updated_at` as a side effect
- [x] Events raised inside a new transaction implement `ShouldDispatchAfterCommit`
- [x] No query failure is caught and ignored inside a transaction
- [x] Existing lock order (`flow_runs` → `action_runs` / `flow_signals`) is preserved

No write path changes — this is read ordering only. It is driver-dependent in the sense that
prompted it: PostgreSQL returns rows in physical order, which is how the defect first showed up, as
`ReclaimStaleRunningTest` going red in CI with "Failed asserting that 900 is null" after being
handed the second step of a two-step workflow.

Checked for what an order inside a relation can leak into. `whereHas()` (used at
`Queries/FlowQuery.php:75,97`), `has()` and `withCount()` build their subqueries **without** it —
confirmed from the generated SQL. `events()` orders by `recorded_at` first, which is `NOT NULL` in
the schema and always written by `Runtime/EventLog.php:38`, so there is no null-ordering difference
between the drivers to worry about.

Suite: SQLite 389 passed / 3 skipped, MySQL 389 / 3, PostgreSQL 391 / 1.
