### PR TITLE
Name the indexes whose derived names cap the table prefix

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,10 +112,11 @@ for the other changes public behaviour and needs its own exception and its own d
   listeners will act on a delivery that may still roll back — while holding your row locks.
 - **Keep the lock order.** Existing writers take `flow_runs` first, then `action_runs` and
   `flow_signals`. Do not reverse it.
-- **A new index has to leave room for the table prefix.** The documented ceiling is 24 bytes, which
-  is 64 minus the longest name the schema asks for. A longer name lowers that ceiling for everyone,
-  so name the index explicitly instead of letting Laravel derive one — `TablePrefixCeilingTest`
-  fails on MySQL when it does not fit.
+- **A new index has to leave room for the table prefix.** With the documented ceiling of 24 bytes a
+  name has 40 left: MySQL refuses an identifier past 64 characters, and PostgreSQL truncates one
+  past 63 bytes, where two names on a table can meet. A longer name lowers that ceiling for
+  everyone, so name the index explicitly rather than letting Laravel derive one —
+  `TablePrefixCeilingTest` fails on MySQL when it does not fit.
 
 ## Tests
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -112,6 +112,10 @@ for the other changes public behaviour and needs its own exception and its own d
   listeners will act on a delivery that may still roll back — while holding your row locks.
 - **Keep the lock order.** Existing writers take `flow_runs` first, then `action_runs` and
   `flow_signals`. Do not reverse it.
+- **A new index has to leave room for the table prefix.** The documented ceiling is 24 bytes, which
+  is 64 minus the longest name the schema asks for. A longer name lowers that ceiling for everyone,
+  so name the index explicitly instead of letting Laravel derive one — `TablePrefixCeilingTest`
+  fails on MySQL when it does not fit.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,9 @@ Every setting lives in `config/saga-lara-flow.php`. The most common ones:
 
 - **Dedicated database connection.** `database.connection` (env `SAGA_LARA_FLOW_DB_CONNECTION`) keeps
   the engine's tables on their own connection; `null` uses the app default. `database.table_prefix`
-  (default `saga_`) prefixes every table.
+  (default `saga_`) prefixes every table, and is capped at 24 bytes — it rides along in every index
+  name, and PostgreSQL truncates an identifier past 63 bytes while MySQL refuses one past 64
+  characters.
 - **Swappable models.** Every row model under `models.*` can be pointed at your own subclass.
 - **Queue.** `queue.connection` / `queue.queue` control where workflow and action jobs run;
   `queue.after_commit` dispatches after the surrounding DB transaction commits.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -449,6 +449,17 @@ $run->actions()->reorder()->chunkById(500, fn ($actions) => ...);
 Eager loads, `withCount()`, `whereHas()` and plain `chunk()` need nothing. See
 [Configuration](https://sagalaraflow.dev/configuration).
 
+### 19. The table prefix is capped at 24 bytes
+
+`database.table_prefix` rides along in every derived index name, and past a point the driver refuses
+one outright (MySQL, at 7 characters) or truncates two onto each other (PostgreSQL, at 29). Six
+indexes are now named explicitly rather than derived, which lifts the supported prefix to **24
+bytes** — 24 characters of ASCII, fewer if you use anything else. The default `saga_` is five.
+
+Nothing to do on a database that installed. One that failed part-way on a too-long prefix needs its
+package tables dropped before `migrate` will get past the first one. The new names reach a fresh
+install only, nothing reads them, and there is no rename migration.
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/config/saga-lara-flow.php
+++ b/config/saga-lara-flow.php
@@ -13,7 +13,9 @@ return [
     | Database
     |--------------------------------------------------------------------------
     | Dedicated connection/schema for the package tables. A null connection
-    | falls back to the application's default database connection.
+    | falls back to the application's default database connection. The prefix
+    | is capped at 24 bytes: it rides along in every index name, which MySQL
+    | caps at 64 characters and PostgreSQL truncates past 63 bytes.
     */
     'database' => [
         'connection' => env('SAGA_LARA_FLOW_DB_CONNECTION'),

--- a/database/migrations/2026_07_02_000000_create_saga_lara_flow_initial_tables.php
+++ b/database/migrations/2026_07_02_000000_create_saga_lara_flow_initial_tables.php
@@ -4,6 +4,13 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
+/**
+ * An index whose name Laravel derives carries the table prefix, and the longest of them
+ * decides how long a prefix may be: MySQL refuses an identifier past 64 characters, and
+ * PostgreSQL truncates at 63 bytes, where two names on one table can meet. The four
+ * longest are therefore named here rather than derived; with the two in
+ * index_signal_waits that leaves 24 bytes for a prefix, which the documentation states.
+ */
 return new class extends Migration
 {
     public function up(): void
@@ -12,7 +19,7 @@ return new class extends Migration
 
         $prefix = $this->prefix();
 
-        $schema->create($prefix.'flow_runs', function (Blueprint $table): void {
+        $schema->create($prefix.'flow_runs', function (Blueprint $table) use ($prefix): void {
             $table->ulid('id')->primary();
             $table->string('workflow_class');
             $table->string('workflow_name')->nullable();
@@ -36,7 +43,7 @@ return new class extends Migration
             $table->timestamps();
 
             $table->index(['status', 'expires_at']);
-            $table->index(['status', 'repair_available_at']);
+            $table->index(['status', 'repair_available_at'], $prefix.'flow_runs_status_repair_index');
             $table->index(['workflow_class', 'status']);
         });
 
@@ -76,7 +83,7 @@ return new class extends Migration
             $table->timestamps();
         });
 
-        $schema->create($prefix.'flow_signals', function (Blueprint $table): void {
+        $schema->create($prefix.'flow_signals', function (Blueprint $table) use ($prefix): void {
             $table->ulid('id')->primary();
             $table->ulid('flow_run_id')->index();
             $table->string('name');
@@ -88,7 +95,7 @@ return new class extends Migration
             $table->timestamp('consumed_at')->nullable();
             $table->timestamps();
 
-            $table->index(['flow_run_id', 'name', 'status']);
+            $table->index(['flow_run_id', 'name', 'status'], $prefix.'flow_signals_run_name_status_index');
         });
 
         $schema->create($prefix.'compensation_runs', function (Blueprint $table): void {
@@ -130,7 +137,7 @@ return new class extends Migration
             $table->unique(['flow_run_id', 'key', 'value']);
         });
 
-        $schema->create($prefix.'flow_children', function (Blueprint $table): void {
+        $schema->create($prefix.'flow_children', function (Blueprint $table) use ($prefix): void {
             $table->id();
             $table->ulid('parent_flow_run_id')->index();
             $table->ulid('child_flow_run_id')->index();
@@ -141,8 +148,8 @@ return new class extends Migration
             $table->string('status')->index();
             $table->timestamps();
 
-            $table->unique(['parent_flow_run_id', 'sequence']);
-            $table->unique(['parent_flow_run_id', 'child_flow_run_id']);
+            $table->unique(['parent_flow_run_id', 'sequence'], $prefix.'flow_children_parent_sequence_unique');
+            $table->unique(['parent_flow_run_id', 'child_flow_run_id'], $prefix.'flow_children_parent_child_unique');
         });
     }
 

--- a/database/migrations/2026_08_26_000000_index_signal_waits.php
+++ b/database/migrations/2026_08_26_000000_index_signal_waits.php
@@ -7,20 +7,32 @@ use Illuminate\Support\Facades\Schema;
 return new class extends Migration
 {
     /**
+     * Table => columns, index name. The name is given rather than derived: a derived
+     * one here would be the longest identifier the package asks for, and MySQL
+     * refuses one past 64 characters.
+     */
+    private const array INDEXES = [
+        'flow_signals' => [['status', 'name', 'flow_run_id'], 'flow_signals_status_name_run_index'],
+        'action_runs' => [['status', 'retry_signal', 'flow_run_id'], 'action_runs_status_signal_run_index'],
+    ];
+
+    /**
      * The shipped indexes on both tables lead with flow_run_id, which answers "what
      * is this run waiting for" — the opposite of what the FlowQuery wait filters
      * ask.
      */
     public function up(): void
     {
-        $this->add('flow_signals', ['status', 'name', 'flow_run_id']);
-        $this->add('action_runs', ['status', 'retry_signal', 'flow_run_id']);
+        foreach (self::INDEXES as $table => [$columns, $name]) {
+            $this->add($table, $columns, $name);
+        }
     }
 
     public function down(): void
     {
-        $this->drop('action_runs', ['status', 'retry_signal', 'flow_run_id']);
-        $this->drop('flow_signals', ['status', 'name', 'flow_run_id']);
+        foreach (array_reverse(self::INDEXES, preserve_keys: true) as $table => [$columns, $name]) {
+            $this->drop($table, $columns, $name);
+        }
     }
 
     /**
@@ -29,22 +41,22 @@ return new class extends Migration
      *
      * @param  list<string>  $columns
      */
-    private function add(string $table, array $columns): void
+    private function add(string $table, array $columns, string $name): void
     {
-        if ($this->existing($table, $columns) === null) {
-            $this->change($table, fn (Blueprint $blueprint) => $blueprint->index($columns, $this->name($table, $columns)));
+        if ($this->existing($table, $columns, $name) === null) {
+            $this->change($table, fn (Blueprint $blueprint) => $blueprint->index($columns, $this->prefix().$name));
         }
     }
 
     /**
      * @param  list<string>  $columns
      */
-    private function drop(string $table, array $columns): void
+    private function drop(string $table, array $columns, string $name): void
     {
-        $name = $this->existing($table, $columns);
+        $existing = $this->existing($table, $columns, $name);
 
-        if ($name !== null) {
-            $this->change($table, fn (Blueprint $blueprint) => $blueprint->dropIndex($name));
+        if ($existing !== null) {
+            $this->change($table, fn (Blueprint $blueprint) => $blueprint->dropIndex($existing));
         }
     }
 
@@ -62,33 +74,22 @@ return new class extends Migration
      *
      * @param  list<string>  $columns
      */
-    private function existing(string $table, array $columns): ?string
+    private function existing(string $table, array $columns, string $name): ?string
     {
-        $wanted = $this->name($table, $columns);
+        $wanted = strtolower($this->prefix().$name);
 
         foreach (Schema::connection($this->connection())->getIndexes($this->prefix().$table) as $index) {
-            $name = (string) $index['name'];
+            $stored = (string) $index['name'];
 
-            $sameName = strcasecmp($name, $wanted) === 0
-                || (strlen($name) < strlen($wanted) && str_starts_with(strtolower($wanted), strtolower($name)));
+            $sameName = strcasecmp($stored, $wanted) === 0
+                || (strlen($stored) < strlen($wanted) && str_starts_with($wanted, strtolower($stored)));
 
             if ($sameName && $index['columns'] === $columns && ! $index['unique']) {
-                return $name;
+                return $stored;
             }
         }
 
         return null;
-    }
-
-    /**
-     * The name Laravel would derive on its own, so an index created before this
-     * migration started naming them explicitly is still recognised.
-     *
-     * @param  list<string>  $columns
-     */
-    private function name(string $table, array $columns): string
-    {
-        return strtolower($this->prefix().$table.'_'.implode('_', $columns).'_index');
     }
 
     private function connection(): ?string

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -19,7 +19,12 @@ likely to touch.
 ```
 
 Point the engine at a dedicated connection to keep its tables separate from your domain data. The
-prefix is applied to every table. The package tables always use *this* connection (via
+prefix is applied to every table, and to every index name derived from one, so it is capped at
+**24 bytes** — 24 characters of ASCII, fewer if you use anything else. MySQL refuses an identifier
+past 64 characters and PostgreSQL truncates one past 63 bytes, and the longest name the schema asks
+for is 40. A longer prefix fails part-way through the initial migration; drop the package tables it
+did create before running `migrate` again, or the retry stops on the first table that already
+exists. The package tables always use *this* connection (via
 `UsesSagaFlowConnection`), so they are unaffected by tenant DB switching unless you leave the
 connection `null`.
 

--- a/tests/Feature/LongTablePrefixTest.php
+++ b/tests/Feature/LongTablePrefixTest.php
@@ -5,22 +5,17 @@ use Illuminate\Support\Facades\Schema;
 
 /**
  * Both index migrations match an index by the name the driver actually stored, not by
- * the name Laravel derived, because PostgreSQL truncates an identifier past 63 bytes
- * and a long table prefix reaches that. Every one of those `existing()` helpers was
- * written from the documentation and had never been run.
+ * the name they asked for, because PostgreSQL truncates an identifier past 63 bytes and
+ * a long table prefix reaches that. Every one of those `existing()` helpers was written
+ * from the documentation and had never been run.
  *
- * With this 24-character prefix both names that index_signal_waits owns cross the limit
- * — 73 and 66 bytes — so what the catalogue holds is not what `$table->index(..., $name)`
- * asked for, and a migration that compared the two literally would try to create its
- * index a second time.
- *
- * The prefix stops at 24 on purpose. unique_flow_tag_keys needs 32 before its own names
- * truncate, and at 30 the initial migration cannot install at all: three of
- * flow_children's index names truncate onto each other. That is issue #42, and until it
- * is fixed the tag migration's half of this cannot be reached.
+ * This 30-character prefix reaches both halves: index_signal_waits' two names cross the
+ * limit at 65 and 64 bytes, and so does the wide unique that unique_flow_tag_keys drops,
+ * at 68. It is past the documented ceiling of 24 bytes, which PostgreSQL alone has the
+ * room for — the point here is truncation, not a supported install.
  *
  * PostgreSQL only, deliberately. MySQL does not truncate a long identifier, it refuses
- * it outright at 64 bytes, and SQLite has no limit worth reaching: there is no
+ * it outright at 64 characters, and SQLite has no limit worth reaching: there is no
  * truncation to exercise on either. Do not "fix" the skip.
  */
 beforeEach(function () {
@@ -30,7 +25,7 @@ beforeEach(function () {
         return;
     }
 
-    config()->set('saga-lara-flow.database.table_prefix', 'saga_flow_long_prefix_1_');
+    config()->set('saga-lara-flow.database.table_prefix', 'saga_thirty_characters_prefix_');
 
     // Read afresh on every call in UsesSagaFlowConnection::getTable(), so the prefix
     // above is already in force for the migrations this builds the schema with.
@@ -43,7 +38,7 @@ beforeEach(function () {
 afterEach(fn () => TestCase::forgetSchema());
 
 it('finds the indexes it created under the truncated names the driver stored', function () {
-    $names = fn (string $table) => collect(Schema::getIndexes('saga_flow_long_prefix_1_'.$table))
+    $names = fn (string $table) => collect(Schema::getIndexes('saga_thirty_characters_prefix_'.$table))
         ->pluck('name')
         ->all();
 
@@ -52,13 +47,13 @@ it('finds the indexes it created under the truncated names the driver stored', f
     }
 
     // Stored under a name shorter than the one asked for, and still recognisably ours.
-    expect($names('action_runs'))->toContain(substr('saga_flow_long_prefix_1_action_runs_status_retry_signal_flow_run_id_index', 0, 63))
-        ->and($names('flow_signals'))->toContain(substr('saga_flow_long_prefix_1_flow_signals_status_name_flow_run_id_index', 0, 63))
-        ->and(strlen('saga_flow_long_prefix_1_action_runs_status_retry_signal_flow_run_id_index'))->toBeGreaterThan(63);
+    expect($names('action_runs'))->toContain(substr('saga_thirty_characters_prefix_action_runs_status_signal_run_index', 0, 63))
+        ->and($names('flow_signals'))->toContain(substr('saga_thirty_characters_prefix_flow_signals_status_name_run_index', 0, 63))
+        ->and(strlen('saga_thirty_characters_prefix_action_runs_status_signal_run_index'))->toBeGreaterThan(63);
 })->skip(fn () => TestCase::driver() !== 'pgsql', 'Only PostgreSQL truncates an identifier past 63 bytes.');
 
 it('re-runs over its own work rather than creating a second index under the same name', function () {
-    $indexes = fn (string $table) => collect(Schema::getIndexes('saga_flow_long_prefix_1_'.$table))
+    $indexes = fn (string $table) => collect(Schema::getIndexes('saga_thirty_characters_prefix_'.$table))
         ->pluck('columns');
 
     $waits = include __DIR__.'/../../database/migrations/2026_08_26_000000_index_signal_waits.php';
@@ -72,9 +67,12 @@ it('re-runs over its own work rather than creating a second index under the same
     $tags->up();
     $tags->up();
 
+    // The wide unique is gone, which is the tag migration's own half of the matching:
+    // its name truncates at this prefix, so a literal comparison would have left it.
     expect($indexes('flow_signals'))->toContain(['status', 'name', 'flow_run_id'])
         ->and($indexes('action_runs'))->toContain(['status', 'retry_signal', 'flow_run_id'])
-        ->and($indexes('flow_tags')->all())->toContain(['flow_run_id', 'key']);
+        ->and($indexes('flow_tags')->all())->toContain(['flow_run_id', 'key'])
+        ->and($indexes('flow_tags')->all())->not->toContain(['flow_run_id', 'key', 'value']);
 
     $waits->down();
     $waits->down();

--- a/tests/Feature/TablePrefixCeilingTest.php
+++ b/tests/Feature/TablePrefixCeilingTest.php
@@ -50,8 +50,10 @@ it('installs every table at the documented prefix ceiling', function () {
 });
 
 it('spends the ceiling in bytes, not in characters', function () {
+    // Named encoding: mb_strlen() otherwise reads default_charset, and a host that has
+    // set it to something single-byte would be told this prefix is 24 characters long.
     expect(strlen(SAGA_PREFIX_MULTIBYTE))->toBe(24)
-        ->and(mb_strlen(SAGA_PREFIX_MULTIBYTE))->toBe(13);
+        ->and(mb_strlen(SAGA_PREFIX_MULTIBYTE, 'UTF-8'))->toBe(13);
 
     installAtPrefix(SAGA_PREFIX_MULTIBYTE);
 

--- a/tests/Feature/TablePrefixCeilingTest.php
+++ b/tests/Feature/TablePrefixCeilingTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * The ceiling the configuration documentation states, enforced rather than trusted. It is
+ * measured in bytes, because the two servers cap different things: MySQL refuses an
+ * identifier past 64 characters, PostgreSQL truncates one past 63 bytes. The longest name
+ * the schema asks for is 40, leaving 24.
+ *
+ * A prefix over the ceiling fails part-way through the initial migration, so these cover
+ * the whole install rather than one table.
+ */
+const SAGA_PREFIX_ASCII = 'saga_documented_ceiling_';
+
+// Thirteen characters, twenty-four bytes: the same ceiling, spent differently.
+const SAGA_PREFIX_MULTIBYTE = 'сага_вимірка_';
+
+// The schema these leave behind is not the one the rest of the suite expects.
+afterEach(fn () => TestCase::forgetSchema());
+
+function installAtPrefix(string $prefix): void
+{
+    Schema::connection('testing')->dropAllTables();
+
+    config()->set('saga-lara-flow.database.table_prefix', $prefix);
+
+    foreach ((fn () => $this->packageMigrations())->call(test()) as $path) {
+        (include $path)->up();
+    }
+}
+
+function tablesExistUnder(string $prefix): void
+{
+    foreach ([
+        'flow_runs', 'action_runs', 'flow_events', 'flow_signals',
+        'compensation_runs', 'side_effects', 'flow_tags', 'flow_children',
+    ] as $table) {
+        expect(Schema::connection('testing')->hasTable($prefix.$table))->toBeTrue();
+    }
+}
+
+it('installs every table at the documented prefix ceiling', function () {
+    expect(strlen(SAGA_PREFIX_ASCII))->toBe(24);
+
+    installAtPrefix(SAGA_PREFIX_ASCII);
+
+    tablesExistUnder(SAGA_PREFIX_ASCII);
+});
+
+it('spends the ceiling in bytes, not in characters', function () {
+    expect(strlen(SAGA_PREFIX_MULTIBYTE))->toBe(24)
+        ->and(mb_strlen(SAGA_PREFIX_MULTIBYTE))->toBe(13);
+
+    installAtPrefix(SAGA_PREFIX_MULTIBYTE);
+
+    tablesExistUnder(SAGA_PREFIX_MULTIBYTE);
+});
+
+it('names the indexes that would otherwise derive a name too long to install', function () {
+    installAtPrefix(SAGA_PREFIX_ASCII);
+
+    $names = fn (string $table) => collect(Schema::connection('testing')->getIndexes(SAGA_PREFIX_ASCII.$table))
+        ->pluck('name')
+        ->all();
+
+    // Given rather than derived, and short enough that the prefix above still fits.
+    expect($names('flow_runs'))->toContain(SAGA_PREFIX_ASCII.'flow_runs_status_repair_index')
+        ->and($names('flow_signals'))->toContain(SAGA_PREFIX_ASCII.'flow_signals_run_name_status_index')
+        ->and($names('flow_signals'))->toContain(SAGA_PREFIX_ASCII.'flow_signals_status_name_run_index')
+        ->and($names('action_runs'))->toContain(SAGA_PREFIX_ASCII.'action_runs_status_signal_run_index')
+        ->and($names('flow_children'))->toContain(SAGA_PREFIX_ASCII.'flow_children_parent_sequence_unique')
+        ->and($names('flow_children'))->toContain(SAGA_PREFIX_ASCII.'flow_children_parent_child_unique');
+});


### PR DESCRIPTION
Closes #42.

## The problem

The table prefix rides along in every index name Laravel derives, and the longest derived name
decides how long a prefix may be. Measured by bisection, running every package migration at each
prefix length:

| driver | longest prefix that installs | what happens past it |
|---|---|---|
| MySQL | **7** | `1059 Identifier name '…flow_children_parent_flow_run_id_child_flow_run_id_unique' is too long` |
| PostgreSQL | **29** | `42P07 relation "…flow_children_parent_flow_run_id_" already exists` |
| SQLite | no limit worth reaching | — |

The default prefix is `saga_`, five characters. On MySQL that left two characters of headroom, and
nothing said so. Either failure lands part-way through the initial migration.

## The change

Six indexes are given explicit short names instead of letting Laravel derive one:

| migration | table | columns | name |
|---|---|---|---|
| initial | `flow_runs` | status, repair_available_at | `flow_runs_status_repair_index` |
| initial | `flow_signals` | flow_run_id, name, status | `flow_signals_run_name_status_index` |
| initial | `flow_children` | parent_flow_run_id, sequence | `flow_children_parent_sequence_unique` |
| initial | `flow_children` | parent_flow_run_id, child_flow_run_id | `flow_children_parent_child_unique` |
| `index_signal_waits` | `flow_signals` | status, name, flow_run_id | `flow_signals_status_name_run_index` |
| `index_signal_waits` | `action_runs` | status, retry_signal, flow_run_id | `action_runs_status_signal_run_index` |

The issue named four of these, all from the initial migration. Four is not enough:
`index_signal_waits` derives `action_runs_status_retry_signal_flow_run_id_index` at 49 bytes, longer
than everything in the initial migration bar two, so four renames would have left the ceiling at
`64 - 49 = 15`. The two extra renames cost nothing — `index_signal_waits` is new in 1.2.0 and has
never been in a tagged release, so no database holds its old names.

After the renames the longest name is 40 bytes, and the ceiling was measured again on all three:

| driver | ceiling | first failure past it |
|---|---|---|
| MySQL | **24** | `side_effects_flow_run_id_sequence_unique` at 25 |
| PostgreSQL | 36 | the `flow_tags_flow_run_id_key_…` pair at 37 |
| SQLite | none | — |

The supported ceiling is the lower of the two, **24 bytes**, and it is stated in the configuration
docs, the README, the config file and UPGRADING rather than discovered by a failed install.

### Bytes, not characters

The two servers cap different things, and this is measured, not assumed:

| prefix | bytes | characters | MySQL | PostgreSQL |
|---|---|---|---|---|
| 24× Cyrillic | 48 | 24 | installs | **fails**, `42P07` |
| 12× Cyrillic | 24 | 12 | installs | installs |

MySQL refuses an identifier past 64 **characters**; PostgreSQL truncates one past 63 **bytes**. So
on ASCII the MySQL wall binds, and on anything else the PostgreSQL one does. One conservative number
covers both: 24 bytes.

## Existing installations

Nothing to do on a database that installed. The new names reach a fresh install only, and nothing in
the package reads a derived index name except the `existing()` helper in each of the two 1.2.0 index
migrations, which match on columns as well as name. There is no rename migration: SQLite cannot
rename an index, and a database that installed already has a prefix that fits.

A database whose install *failed* on a too-long prefix is a different case, and it is now documented:
the partial state must be dropped before `migrate` will get past the first table it already created.

## Tests

`TablePrefixCeilingTest` is new and runs on all three drivers — it installs the whole schema at
exactly 24 bytes, once as 24 ASCII characters and once as 13 Cyrillic ones, and asserts all six
explicit names are present. The number in the documentation is now the number the suite enforces.

`LongTablePrefixTest` moves from a 24-character prefix to a 30-character one, the acceptance
criterion in the issue. At 30 both of `index_signal_waits`' names still cross PostgreSQL's 63-byte
limit, and so does the wide unique `unique_flow_tag_keys` drops — which was unreachable at 24, so a
new assertion covers that half of the name matching for the first time.

### Mutation verification

| mutation | result |
|---|---|
| drop the `flow_children_parent_child_unique` rename | MySQL: both ceiling tests fail on install. SQLite: the name assertion fails |
| restore the derived name in `index_signal_waits` | MySQL: both ceiling tests fail on install |
| drop the multibyte prefix case's rename | MySQL: the multibyte test fails (13 + 57 > 64 characters) |
| reduce `unique_flow_tag_keys::existing()` to `strcasecmp` only | PostgreSQL: the new wide-unique assertion fails |

### Runs

| | before | after |
|---|---|---|
| SQLite | 389 passed, 3 skipped | **392 passed, 3 skipped** |
| MySQL | 389 passed, 3 skipped | **392 passed, 3 skipped** |
| PostgreSQL | 391 passed, 1 skipped | **394 passed, 1 skipped** |

PHPStan level 5 clean, Pint clean over 349 files.

## Note on `index_signal_waits`

Its table/columns/name triples moved into one `private const INDEXES` that `up()` and `down()`
iterate. A `match` over the table name failed PHPStan with `match.unhandled`, and a `default => throw`
branch in a migration is dead code; the map also removes the column lists `up()` and `down()` each
carried separately.
