### PR TITLE
Verify a claim survived the transaction that made it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -88,6 +88,14 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
   reporting success; SQLite and MySQL carry on. A caught-and-ignored failure therefore commits on
   two drivers and silently discards everything on the third. This reaches listener code too: the
   events the engine fires inside its own transactions run there.
+- **A transaction that runs caller code must verify its own outcome.** The commit reporting success
+  is the caller's word for it, and the paragraph above is why that word is worth nothing. Read the
+  row back afterwards and act on what it says — see `ActionRecorder::claimSurvivedCommit()`. Moving
+  the event out of the transaction is not the same fix: a model observer on a row the transaction
+  writes runs there whatever the event does, which is what `TransactionIntegrityTest`'s observer
+  case pins. What such a read proves is visibility on the writing connection, which equals
+  durability only while the engine's transaction is the outermost one — a host transaction wrapped
+  around a run is out of the engine's reach on every driver, and the docs ask hosts not to open one.
 - **A read that decides something must use `useWritePdo()`.** A lagging replica will answer with the
   very state the fence was guarding against.
 - **Do not `refresh()` a model the caller still holds.** It discards their unsaved attributes;

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -460,6 +460,18 @@ Nothing to do on a database that installed. One that failed part-way on a too-lo
 package tables dropped before `migrate` will get past the first one. The new names reach a fresh
 install only, nothing reads them, and there is no rename migration.
 
+### 20. A claim is verified after the transaction that made it commits
+
+Claiming a step or an undo now reads the row back once its transaction has closed, and does not run
+the body unless the claim is really there. A commit reporting success is not proof: on PostgreSQL a
+failed statement aborts the transaction and turns the commit into a rollback, so a listener on
+`ActionStarted` — or a model observer on the `flow_events` insert — that runs a failing query and
+swallows it used to leave the step executing with nothing recording that it started.
+
+Nothing to do unless your listeners swallow query failures. One that does now stops the step,
+journalled as `claim_not_committed` and raised as `ActionClaimFailedException` in synchronous mode.
+See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -108,7 +108,9 @@ package keeps a second journal for them:
 ```
 
 Grep for `claim_lost`, `outcome_rejected` and `batch_finished_early`; each line carries the run id,
-row id, sequence and class. A refused run transition is journalled here too, as `transition_lost`,
+row id, sequence and class. `claim_not_committed` joins them when a claim did not survive its own
+transaction, which is a defect in listener or observer code rather than a race. A refused run
+transition is journalled here too, as `transition_lost`,
 carrying the status observed, the one intended and the one actually holding the row — it is the one
 entry that is not always quiet, since `FlowHandle` raises rather than absorbing it. None of them are
 written to `flow_events`, which records the run's business history — an abandoned attempt changed

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -220,14 +220,22 @@ journal for them — `AnomalyLog`, alongside the `flow_events` business history:
 ],
 ```
 
-Three reason codes to grep for, each carrying the run id, row id, sequence and class:
+Four reason codes to grep for, each carrying the run id, row id, sequence and class:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
 - **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped.
 - **`batch_finished_early`** — a parallel step completed after a duplicate delivery had closed its batch.
+- **`claim_not_committed`** — a claim was written and was gone once its transaction closed. The line carries both
+  attempt counts, the claimed one and the one the row actually holds.
 
-Raise the level to `warning` to surface them in your alerting. A steady stream of any of the three points to a queue
+Raise the level to `warning` to surface them in your alerting. A steady stream of the first three points to a queue
 timeout tuned shorter than the work takes, or to locks being off.
+
+The fourth is not a race and does not come from tuning: something ran inside the engine's own transaction and left it
+unusable. On PostgreSQL a single failed statement aborts a transaction and turns the eventual commit into a rollback
+while still reporting success, so a listener on `ActionStarted` or a model observer that runs a failing query and
+swallows it discards the claim without anything raising. The claim is read back after the transaction closes for
+exactly this reason, and the step does not run. Fix the listener; nothing on the engine's side is tunable here.
 
 ## Observability
 

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -25,8 +25,9 @@ difference is *who* drives the steps (your worker vs. the current process).
 A step's body runs while your transaction is still open, so a rollback afterwards — yours, or one a
 failed statement forced on you — discards every row the run recorded while the work those rows
 describe is already done. A charge stays charged with nothing left to attribute it to, on every
-driver. The queued path has no such problem: `queue.after_commit` holds the jobs until your
-transaction commits.
+driver. The queued path is clear of this while `saga-lara-flow.queue.after_commit` is on, as it is
+by default: it holds the jobs until your transaction commits, and turning it off gives them the
+same problem.
 :::
 
 ## When to use which

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -21,6 +21,14 @@ $run->result;   // the value handle() returned
 The queued and synchronous paths are guaranteed to reach the **same** final database state — the only
 difference is *who* drives the steps (your worker vs. the current process).
 
+:::warning Do not call `runSync()` inside a transaction of your own
+A step's body runs while your transaction is still open, so a rollback afterwards — yours, or one a
+failed statement forced on you — discards every row the run recorded while the work those rows
+describe is already done. A charge stays charged with nothing left to attribute it to, on every
+driver. The queued path has no such problem: `queue.after_commit` holds the jobs until your
+transaction commits.
+:::
+
 ## When to use which
 
 | | `run()` (queued) | `runSync()` |

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -162,12 +162,14 @@ final readonly class ActionRecorder
      *
      * The claim and its two records share one transaction: a listener throwing on
      * ActionStarted would otherwise leave the row Running with nothing executing it.
+     * A commit is not proof the claim survived one, so the row is read back afterwards
+     * — see claimSurvivedCommit().
      *
      * @throws Throwable
      */
     public function startAction(ActionRun $actionRun, ?int $expectedRetryGeneration = null): bool
     {
-        return $actionRun->getConnection()->transaction(
+        $claimed = $actionRun->getConnection()->transaction(
             function () use ($actionRun, $expectedRetryGeneration): bool {
                 $now = Carbon::now();
 
@@ -226,6 +228,64 @@ final readonly class ActionRecorder
                 return true;
             }
         );
+
+        return $claimed && $this->claimSurvivedCommit($actionRun);
+    }
+
+    /**
+     * Whether the claim is on record now the transaction that made it has closed. A
+     * commit reporting success is not proof: PostgreSQL aborts a transaction on the
+     * first failed statement and turns the eventual COMMIT into a rollback, reporting
+     * success either way, so any caller code running inside it — a listener on
+     * ActionStarted, a model observer on the flow_events insert — that runs a failing
+     * query and swallows it discards the claim while the caller is told it holds one.
+     * The row is the only answer that covers every such shape: the claim is visible or
+     * it is not.
+     *
+     * Refusing a row a second worker legitimately took between the commit and this read
+     * is the same answer for the same reason — it is no longer ours to execute.
+     *
+     * What the read proves is that the claim is visible on the connection that wrote it,
+     * which is durability only while the engine's transaction is the outermost one. A
+     * host transaction wrapped around a run can still discard every row the run recorded
+     * with its side effects already spent — on any driver, and whatever this check said —
+     * which is why the documentation asks hosts not to open one.
+     */
+    private function claimSurvivedCommit(ActionRun $actionRun): bool
+    {
+        $claimedAttempts = $actionRun->attempts;
+
+        // Read from the writer: this read decides whether the step body runs, and a
+        // lagging replica would answer with the very state the claim replaced.
+        $stored = $actionRun->newQuery()
+            ->useWritePdo()
+            ->whereKey($actionRun->getKey())
+            ->first(['status', 'attempts']);
+
+        if ($stored?->status === ActionStatus::Running && $stored->attempts === $claimedAttempts) {
+            return true;
+        }
+
+        // `attempts` is only ever incremented, and by the database, so a stored count
+        // below the one this claim produced can only be that increment undone. Anything
+        // else is the ordinary race the row lost after it was won.
+        $this->anomalies->log(
+            $stored === null || $stored->attempts < $claimedAttempts
+                ? AnomalyLog::REASON_CLAIM_NOT_COMMITTED
+                : AnomalyLog::REASON_CLAIM_LOST,
+            [
+                'entity' => 'action',
+                'flow_run_id' => $actionRun->flow_run_id,
+                'action_run_id' => $actionRun->id,
+                'sequence' => $actionRun->sequence,
+                'action_class' => $actionRun->action_class,
+                'claimed_attempts' => $claimedAttempts,
+                'stored_attempts' => $stored?->attempts,
+                'stored_status' => $stored?->status->value,
+            ]
+        );
+
+        return false;
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -243,7 +243,11 @@ final readonly class ActionRecorder
      * it is not.
      *
      * Refusing a row a second worker legitimately took between the commit and this read
-     * is the same answer for the same reason — it is no longer ours to execute.
+     * is the same answer for the same reason — it is no longer ours to execute. The row
+     * is what answers, though, not a token: a claim of ours that rolled back and a second
+     * worker's claim that replaced it read alike, so a claim lost to that race is
+     * narrowed rather than caught. Telling those two apart needs a value per claim that a
+     * rollback cannot reproduce, which the schema does not carry.
      *
      * What the read proves is that the claim is visible on the connection that wrote it,
      * which is durability only while the engine's transaction is the outermost one. A

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -10,12 +10,13 @@ use Throwable;
  *
  * EventLog records what happened to a run in business terms. This records the moments
  * where the world turned out not to be what the engine assumed — a claim lost to
- * whoever already owned the row, an outcome write refused because the row had changed
- * hands, a batch already closed by a duplicate before its own job reported, a run
- * transition refused because the row had moved on, a retry policy that threw. Most are
- * ordinary consequences of at-least-once delivery and of nothing serialising an operator
- * against a worker; the last is a defect in the caller's own code, journalled here for
- * the same reason as the rest — the engine carried on, so nothing else records it.
+ * whoever already owned the row, a claim the transaction that made it did not keep, an
+ * outcome write refused because the row had changed hands, a batch already closed by a
+ * duplicate before its own job reported, a run transition refused because the row had
+ * moved on, a retry policy that threw. Most are ordinary consequences of at-least-once
+ * delivery and of nothing serialising an operator against a worker; the second and the
+ * last are defects in the caller's own code, journalled here for the same reason as the
+ * rest — the engine carried on, so nothing else records it.
  *
  * None of them fails a job. A refused transition also reaches its caller: the engine
  * absorbs it and stops, but FlowHandle lets it surface, because an operator whose
@@ -29,6 +30,8 @@ use Throwable;
 final readonly class AnomalyLog
 {
     public const string REASON_CLAIM_LOST = 'claim_lost';
+
+    public const string REASON_CLAIM_NOT_COMMITTED = 'claim_not_committed';
 
     public const string REASON_OUTCOME_REJECTED = 'outcome_rejected';
 

--- a/src/Runtime/CompensationRecorder.php
+++ b/src/Runtime/CompensationRecorder.php
@@ -108,13 +108,14 @@ final readonly class CompensationRecorder
      * deadline. Mirrors ActionRecorder::startAction() in every respect: the same
      * compare-and-swap shape, the same enclosing transaction, the same absence of
      * Eloquent model events (CompensationStepStarted and the flow_events entry are the
-     * supported way to observe it), and the same attempts counter.
+     * supported way to observe it), and the same attempts counter — including the
+     * read-back that proves the claim survived its own commit.
      *
      * @throws Throwable
      */
     public function startCompensation(CompensationRun $compensation): bool
     {
-        return $compensation->getConnection()->transaction(function () use ($compensation): bool {
+        $claimed = $compensation->getConnection()->transaction(function () use ($compensation): bool {
             $now = Carbon::now();
 
             $staleAfter = $compensation->reclaim_stale_after_seconds;
@@ -163,6 +164,45 @@ final readonly class CompensationRecorder
 
             return true;
         });
+
+        return $claimed && $this->claimSurvivedCommit($compensation);
+    }
+
+    /**
+     * The undo half of ActionRecorder::claimSurvivedCommit(), which carries the
+     * reasoning: a commit reporting success is not proof the claim is on record, so the
+     * row answers for itself — and what it answers is what this connection can see.
+     */
+    private function claimSurvivedCommit(CompensationRun $compensation): bool
+    {
+        $claimedAttempts = $compensation->attempts;
+
+        $stored = $compensation->newQuery()
+            ->useWritePdo()
+            ->whereKey($compensation->getKey())
+            ->first(['status', 'attempts']);
+
+        if ($stored?->status === CompensationStatus::Running && $stored->attempts === $claimedAttempts) {
+            return true;
+        }
+
+        $this->anomalies->log(
+            $stored === null || $stored->attempts < $claimedAttempts
+                ? AnomalyLog::REASON_CLAIM_NOT_COMMITTED
+                : AnomalyLog::REASON_CLAIM_LOST,
+            [
+                'entity' => 'compensation',
+                'flow_run_id' => $compensation->flow_run_id,
+                'compensation_run_id' => $compensation->id,
+                'sequence' => $compensation->sequence,
+                'compensation_class' => $compensation->compensation_class,
+                'claimed_attempts' => $claimedAttempts,
+                'stored_attempts' => $stored?->attempts,
+                'stored_status' => $stored?->status->value,
+            ]
+        );
+
+        return false;
     }
 
     /**

--- a/tests/Feature/TransactionIntegrityTest.php
+++ b/tests/Feature/TransactionIntegrityTest.php
@@ -93,6 +93,8 @@ it('journals a claim its own transaction discarded', function () {
     $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
 
     $step = $run->actions()->first();
+    $started = claimIsOnRecord($run);
+
     // No anomaly means no file at all: the channel writes lazily, and a driver where
     // the claim held has nothing to journal.
     $log = is_file($path) ? (string) file_get_contents($path) : '';
@@ -101,8 +103,8 @@ it('journals a claim its own transaction discarded', function () {
     // without it an operator sees a run that stopped for no stated reason. Which of the
     // two outcomes a driver produces is its own business — but they are the only two,
     // and the journal accounts for the one that lost the claim.
-    expect(str_contains($log, AnomalyLog::REASON_CLAIM_NOT_COMMITTED))->toBe(! claimIsOnRecord($run))
-        ->and(str_contains($log, $step->id))->toBe(! claimIsOnRecord($run));
+    expect(str_contains($log, AnomalyLog::REASON_CLAIM_NOT_COMMITTED))->toBe(! $started)
+        ->and(str_contains($log, $step->id))->toBe(! $started);
 });
 
 it('does not execute an undo it failed to claim', function () {

--- a/tests/Feature/TransactionIntegrityTest.php
+++ b/tests/Feature/TransactionIntegrityTest.php
@@ -1,12 +1,18 @@
 <?php
 
-use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStepStarted;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CountedActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FailedStepWithCompensationWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
-use DiscoveryUkraine\SagaLaraFlow\Tests\TestCase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 
@@ -20,10 +26,16 @@ use Illuminate\Support\Facades\Event;
  * caller carry on.
  *
  * A listener that throws is already handled — the claim rolls back with it. The shape
- * that gets past the guarantee is one that runs a failing query and SWALLOWS it.
+ * that gets past the guarantee is one that runs a failing query and SWALLOWS it, which
+ * is why the claim is read back after the transaction closes rather than trusted to the
+ * commit that reported success.
+ *
+ * The tests below say the same thing on every driver: whether the claim held is the
+ * driver's business, but the step body and the event that announces it agree with it.
  */
 beforeEach(function () {
     FlakyPaymentAction::reset();
+    CompensationLog::reset();
 });
 
 function swallowAQueryFailureOnStart(): void
@@ -37,17 +49,27 @@ function swallowAQueryFailureOnStart(): void
     });
 }
 
+function claimIsOnRecord(FlowRun $run): bool
+{
+    return $run->events()->where('type', FlowEventType::ActionStarted)->exists();
+}
+
 it('never records a claim without its event', function () {
     swallowAQueryFailureOnStart();
 
     $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
 
     $step = $run->actions()->first();
-    $started = $run->events()->where('type', FlowEventType::ActionStarted)->exists();
+    $started = claimIsOnRecord($run);
 
     // Both halves of the claim or neither: the row's own marks and the event that
     // announces them are written in the same transaction and cannot come apart.
-    expect($started)->toBe($step->status !== ActionStatus::Pending)
+    //
+    // `attempts` is what says whether the row was marked, because only the claim's own
+    // UPDATE increments it. The status does not: a run that ends loudly because its
+    // claim was discarded settles its open steps on the way out, so an unclaimed step
+    // is Cancelled by then rather than still Pending.
+    expect($started)->toBe($step->attempts > 0)
         ->and($step->attempts)->toBe($started ? 1 : 0);
 });
 
@@ -56,14 +78,82 @@ it('does not execute a step it failed to claim', function () {
 
     $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
 
-    $step = $run->actions()->first();
-
     // The half that at-least-once rests on. A body that ran under a claim the database
     // never kept is a charge nobody can attribute, and the next replay makes a second
     // one.
-    expect(FlakyPaymentAction::$calls)->toBe($step->status === ActionStatus::Pending ? 0 : 1);
-})->skip(
-    fn () => TestCase::driver() === 'pgsql',
-    'Known defect on PostgreSQL, tracked in #41: the claim is rolled back by the poisoned '
-    .'transaction, COMMIT reports success anyway, and the body runs regardless.',
-);
+    expect(FlakyPaymentAction::$calls)->toBe(claimIsOnRecord($run) ? 1 : 0);
+});
+
+it('journals a claim its own transaction discarded', function () {
+    $path = sys_get_temp_dir().'/saga-anomaly-'.uniqid().'.log';
+    logToFile($path);
+
+    swallowAQueryFailureOnStart();
+
+    $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
+
+    $step = $run->actions()->first();
+    // No anomaly means no file at all: the channel writes lazily, and a driver where
+    // the claim held has nothing to journal.
+    $log = is_file($path) ? (string) file_get_contents($path) : '';
+
+    // Nothing fails the job, so this line is the only place the cause is written down:
+    // without it an operator sees a run that stopped for no stated reason. Which of the
+    // two outcomes a driver produces is its own business — but they are the only two,
+    // and the journal accounts for the one that lost the claim.
+    expect(str_contains($log, AnomalyLog::REASON_CLAIM_NOT_COMMITTED))->toBe(! claimIsOnRecord($run))
+        ->and(str_contains($log, $step->id))->toBe(! claimIsOnRecord($run));
+});
+
+it('does not execute an undo it failed to claim', function () {
+    Event::listen(CompensationStepStarted::class, function (): void {
+        try {
+            DB::connection('testing')->statement('insert into no_such_table (id) values (1)');
+        } catch (Throwable) {
+            // The same broken listener, on the rollback half of the engine.
+        }
+    });
+
+    $failure = null;
+
+    try {
+        SagaFlow::create(FailedStepWithCompensationWorkflow::class)->runSync();
+    } catch (ActionClaimFailedException $e) {
+        $failure = $e;
+    }
+
+    $undo = CompensationRun::query()->orderBy('sequence')->first();
+
+    // An undo that ran under a claim the database never kept is worse than a step that
+    // did: the row says the rollback never happened, so a later pass runs it again and
+    // one charge is refunded twice.
+    expect(CompensationLog::all())->toHaveCount($undo->attempts)
+        // And a rollback that cannot record its undo stops loudly instead of reporting
+        // itself finished. Sync compensation claims a row it created in the same call,
+        // so a claim it does not end up holding is a broken invariant, not a race.
+        ->and($failure !== null)->toBe($undo->attempts === 0);
+});
+
+/**
+ * The listener is not the only caller code inside that transaction, and the fix has to
+ * cover the rest of it. Moving ActionStarted to ShouldDispatchAfterCommit would make
+ * every test above green and leave this one red: the action.started row is written
+ * inside the transaction whatever the event does, and a model observer on it runs
+ * there too.
+ */
+it('never records a claim without its event, poisoned through a model observer', function () {
+    FlowEvent::created(function (): void {
+        try {
+            DB::connection('testing')->statement('insert into no_such_table (id) values (1)');
+        } catch (Throwable) {
+            // No listener anywhere; the engine's own insert carries the failure in.
+        }
+    });
+
+    $run = SagaFlow::create(CountedActionWorkflow::class)->runSync();
+
+    $step = $run->actions()->first();
+
+    expect(FlakyPaymentAction::$calls)->toBe($step->attempts)
+        ->and($step->attempts)->toBe(claimIsOnRecord($run) ? 1 : 0);
+});


### PR DESCRIPTION
Closes #41.

## The defect

`ActionRecorder::startAction()` claims the row, writes `action.started` and fires `ActionStarted`
in one transaction, so a listener that throws rolls the claim back. PostgreSQL aborts a transaction
on the first failed statement and turns the eventual COMMIT into a ROLLBACK **reporting success**,
so a listener that runs a failing query and *swallows* it discards the claim while `startAction()`
returns `true`. The body then executes with nothing on record that the step started, and the doctor
replays it. On a payment step that is a charge nobody can attribute, followed by a second one.

## Measured before choosing, not reasoned

Inside the poisoned transaction on PostgreSQL 18:

| signal | value | verdict |
|---|---|---|
| `PDO::inTransaction()` | `true` | useless |
| `Connection::transactionLevel()` | `1` | useless |
| `PDO::errorCode()` | `'00000'` | useless |
| probe `SELECT 1` | throws `25P02` | works, but driver-specific and a round trip |
| re-read of the row after commit | `pending` / `attempts = 0` | **decisive** |

Two further measurements corrected the plan this was built from:

- **`ActionBuilder::park()` is not a third site.** `ActionAwaitingRetry` already implements
  `ShouldDispatchAfterCommit`; a swallowing listener leaves the parking intact. #41 is two sites.
- **The listener is not the only caller code in that transaction.** A model observer on
  `FlowEvent::created`, with no listener on `ActionStarted` anywhere, reproduces the defect in full.
  That rules out option 1 from the issue: moving the event past the commit would not close the hole,
  because the `flow_events` insert is inside the transaction whatever the event does.

`startCompensation()` has the identical defect — measured, and fixed here too.

## The change

Option 2 from the issue. The transaction is untouched; its result becomes intermediate, and both
recorders return `$claimed && $this->claimSurvivedCommit($row)`.

`claimSurvivedCommit()` re-reads through `newQuery()->useWritePdo()` and passes only when the status
is `Running` **and** `attempts` equals what the claim produced. `useWritePdo()` is required:
`Connection::getReadPdo()` returns the writer only while `transactions > 0`, and this read is past
the commit — the same shape `FlowStateMachine::write()` already uses, for the same reason.

Callers are unchanged: `false` still means `StepExecution::ClaimLost`, which sync mode already turns
into `ActionClaimFailedException` and queued mode absorbs. Cost is one `SELECT` per claim.

New anomaly reason `claim_not_committed`, kept apart from `claim_lost` because the operator's
response differs — one is an ordinary at-least-once race, the other is a defect in the host's own
listener or observer. The discrimination rests on a checked fact: every write to `attempts` in
`src/` is either `0` on a fresh row or `DB::raw('attempts + 1')`, so a stored count *below* the
claimed one can only be that increment undone.

## Tests — the PostgreSQL skip is gone, which was the acceptance criterion

Five in `TransactionIntegrityTest`, none carrying a skip:

1. `never records a claim without its event`
2. `does not execute a step it failed to claim` — the criterion from the issue
3. `journals a claim its own transaction discarded` — against a real log file, no mocks
4. `does not execute an undo it failed to claim` — the compensation half
5. `…poisoned through a model observer` — the surface that decided the design; moving `ActionStarted`
   past the commit would leave exactly this one red

Tests 1 and 2 changed predicate from `status` to `attempts`. Not a weakening: with the fix in place
and the tests otherwise untouched both went red, because a run that now ends loudly settles its open
steps and the unclaimed step reads `cancelled` rather than `pending`. `attempts` is what only the
claim's own UPDATE increments.

**Mutation:** removing `claimSurvivedCommit()` from both recorders turns 4 of the 5 red on
PostgreSQL. Test 1 survives correctly — it guards the integrity of the two halves, not the execution
of the body; test 2 is the one that guards #41.

## What the read-back does and does not prove

It proves the claim is visible on the connection that wrote it, which is durability only while the
engine's transaction is the outermost one. A host transaction wrapped around a run can still discard
every row the run recorded with the side effects already spent — measured on SQLite with no
poisoning at all, just an ordinary rollback. That is out of this change's reach on every driver, so
the second commit says so on `synchronous-execution.md`, where a host reads before calling
`runSync()`, instead of leaving it buried on the retry-on-signal page.

## Runs

| driver | before | after |
|---|---|---|
| SQLite | 392 / 3 skipped | **395 passed** / 3 skipped |
| MySQL | 392 / 3 skipped | **395 passed** / 3 skipped |
| PostgreSQL | 394 / 1 skipped | **398 passed** / **0 skipped** |

Pint clean over 349 files; PHPStan level 5 clean; `cd docs && npm run build` passes.