### PR TITLE
Make collectCompensations() a read that cannot quietly shorten a rollback

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -477,9 +477,9 @@ See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
 Planning a manual rollback replays `handle()` to find the compensations. That replay no longer
 settles a spent optional step (`action.optional_failed`, with the `OptionalActionFailed` event), and
 no longer schedules and dispatches a parallel block it had only reached to read — both are the next
-ordinary replay's work. Nor does it treat every throw as the end of the stack: one the engine did
-not raise itself now surfaces out of `compensate()`, run untouched, instead of rolling back a
-truncated plan and reporting a complete unwind.
+ordinary replay's work. Nor is every throw the end of the stack now: four classes end it — the
+frontier, a step failure, an expiry, a signal timeout — and an unexpected throw surfaces out of
+`compensate()`, run untouched, instead of rolling back a truncated plan and reporting it complete.
 
 Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. See
 [Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -472,6 +472,18 @@ Nothing to do unless your listeners swallow query failures. One that does now st
 journalled as `claim_not_committed` and raised as `ActionClaimFailedException` in synchronous mode.
 See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
 
+### 21. `compensate()` plans the rollback without starting work, and stops if it cannot finish
+
+Planning a manual rollback replays `handle()` to find the compensations. That replay no longer
+settles a spent optional step (`action.optional_failed`, with the `OptionalActionFailed` event), and
+no longer schedules and dispatches a parallel block it had only reached to read — both are the next
+ordinary replay's work. Nor does it treat every throw as the end of the stack: one the engine did
+not raise itself now surfaces out of `compensate()`, run untouched, instead of rolling back a
+truncated plan and reporting a complete unwind.
+
+Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. See
+[Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation).
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -475,13 +475,13 @@ See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
 ### 21. `compensate()` plans the rollback without starting work, and stops if it cannot finish
 
 Planning a manual rollback replays `handle()` to find the compensations. That replay no longer
-settles a spent optional step (`action.optional_failed`, with the `OptionalActionFailed` event), and
-no longer schedules and dispatches a parallel block it had only reached to read — both are the next
-ordinary replay's work. Nor is every throw the end of the stack now: four classes end it — the
-frontier, a step failure, an expiry, a signal timeout — and an unexpected throw surfaces out of
-`compensate()`, run untouched, instead of rolling back a truncated plan and reporting it complete.
+settles a spent optional step (`action.optional_failed`, with its `OptionalActionFailed` event) and
+no longer schedules a parallel block it had only reached to read. Nor is every throw the end of the
+stack now: four classes end it, and an unexpected throw surfaces out of `compensate()`, run
+untouched, rather than rolling back a truncated plan and reporting it complete.
 
-Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. See
+Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. The expiry
+sweep absorbs such a throw instead, journalling `expiry_failed` and stepping over the run. See
 [Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation).
 
 ### Recommended while you are here

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -109,7 +109,8 @@ package keeps a second journal for them:
 
 Grep for `claim_lost`, `outcome_rejected` and `batch_finished_early`; each line carries the run id,
 row id, sequence and class. `claim_not_committed` joins them when a claim did not survive its own
-transaction, which is a defect in listener or observer code rather than a race. A refused run
+transaction, which is a defect in listener or observer code rather than a race, and `expiry_failed`
+when the sweep could not plan an overdue run's rollback and stepped over it. A refused run
 transition is journalled here too, as `transition_lost`,
 carrying the status observed, the one intended and the one actually holding the row — it is the one
 entry that is not always quiet, since `FlowHandle` raises rather than absorbing it. None of them are

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -220,18 +220,24 @@ journal for them — `AnomalyLog`, alongside the `flow_events` business history:
 ],
 ```
 
-Four reason codes to grep for, each carrying the run id, row id, sequence and class:
+Five reason codes to grep for, each carrying the run id, row id, sequence and class:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
 - **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped.
 - **`batch_finished_early`** — a parallel step completed after a duplicate delivery had closed its batch.
 - **`claim_not_committed`** — a claim was written and was gone once its transaction closed. The line carries both
   attempt counts, the claimed one and the one the row actually holds.
+- **`expiry_failed`** — the sweep could not plan an overdue run's rollback, so it left the run alone and moved on to
+  the next. The line carries the throw. The run stays overdue and is tried again on the next sweep.
 
 Raise the level to `warning` to surface them in your alerting. A steady stream of the first three points to a queue
 timeout tuned shorter than the work takes, or to locks being off.
 
-The fourth is not a race and does not come from tuning: something ran inside the engine's own transaction and left it
+The last two are not races and do not come from tuning. `expiry_failed` means the run's own `handle()` threw while the
+sweep was replaying it to find the compensations — a workflow reading something that has since gone, most often. Until
+that is fixed the run cannot be expired, but nothing else in the sweep is held up by it.
+
+`claim_not_committed` is the other one: something ran inside the engine's own transaction and left it
 unusable. On PostgreSQL a single failed statement aborts a transaction and turns the eventual commit into a rollback
 while still reporting success, so a listener on `ActionStarted` or a model observer that runs a failing query and
 swallows it discards the claim without anything raising. The claim is read back after the transaction closes for

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -220,7 +220,8 @@ journal for them — `AnomalyLog`, alongside the `flow_events` business history:
 ],
 ```
 
-Five reason codes to grep for, each carrying the run id, row id, sequence and class:
+Five reason codes to grep for. The first four carry the run id, row id, sequence and class; the fifth
+is about a run rather than a row, and carries the run id, its workflow class and the throw:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
 - **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped.

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -94,9 +94,10 @@ SagaFlow::loadFlow($runId)->compensate(); // roll back completed steps, then can
 The rollback is planned before anything is undone: the handle replays `handle()` only to learn which
 completed steps carry compensations. Every seam is guarded for that pass, so it runs no business
 logic, starts no work, and settles no step — one it has not seen is a place to stop, not a place to
-schedule. (Your own `tag()` calls still rewrite their rows, as they do on every replay.) If the
-replay throws for a reason the engine did not put there — an
-argument expression reading a record that has since been deleted, say — the plan is incomplete, so
+schedule. (Your own `tag()` calls still rewrite their rows, as they do on every replay.) Four
+exception classes end that pass — the frontier it stopped at, and a step failure, an expiry or a
+signal timeout already in the run's history. Anything else is a fault, not an ending: an argument
+expression reading a record that has since been deleted, say. The plan is then incomplete, so
 `compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
 it and reporting a finished rollback. Fix the cause and call it again.
 

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -91,6 +91,15 @@ You can trigger a rollback from outside the workflow through the handle:
 SagaFlow::loadFlow($runId)->compensate(); // roll back completed steps, then cancel
 ```
 
+The rollback is planned before anything is undone: the handle replays `handle()` only to learn which
+completed steps carry compensations. Every seam is guarded for that pass, so it runs no business
+logic, starts no work, and settles no step — one it has not seen is a place to stop, not a place to
+schedule. (Your own `tag()` calls still rewrite their rows, as they do on every replay.) If the
+replay throws for a reason the engine did not put there — an
+argument expression reading a record that has since been deleted, say — the plan is incomplete, so
+`compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
+it and reporting a finished rollback. Fix the cause and call it again.
+
 ## Postponing a rollback
 
 Not every failure deserves a rollback. When a step failed only because the world was not ready — a

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -826,20 +826,29 @@ class ActionBuilder
      * The retry policy is over (budget spent, wait timed out, or the failure fell
      * outside only): resolve the step exactly as it would have resolved without the
      * policy. An optional step is marked OptionalFailed here — the queued give-up
-     * hook deliberately leaves that to the seam for a step with a retry signal.
+     * hook deliberately leaves that to the seam for a step with a retry signal —
+     * unless this pass is only collecting compensations, which writes nothing.
      */
     private function giveUpAfterRetry(ActionRun $step, int $sequence): mixed
     {
+        // Suspending here instead would be the obvious guard and the wrong one: the
+        // replay would stop at this step, and every compensation after it — the whole
+        // point of collecting — would be missing from the rollback. So the give-up is
+        // resolved from the row as it stands and written by the next ordinary replay.
+        $collecting = $this->runtime->isCollecting();
+
         if (! $this->resolvedContinueOnFailure()) {
             // A timed-out wait arrives here on an AwaitingRetry row (the other ways
             // in are already Failed); leaving it would show a compensated run still
             // holding a step that claims to be waiting.
-            app(ActionRecorder::class)->settleAwaitingRetry($step);
+            if (! $collecting) {
+                app(ActionRecorder::class)->settleAwaitingRetry($step);
+            }
 
             $this->resolveFailed($step, $sequence);
         }
 
-        if ($step->status !== ActionStatus::OptionalFailed) {
+        if (! $collecting && $step->status !== ActionStatus::OptionalFailed) {
             app(ActionRecorder::class)->optionalFail($step);
         }
 

--- a/src/Exceptions/ExpirationNotPlannedException.php
+++ b/src/Exceptions/ExpirationNotPlannedException.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use Throwable;
+
+/**
+ * An overdue run whose rollback could not be planned: the compensation-only replay
+ * threw before anything was written, so the run is exactly where it was found.
+ *
+ * It exists so the monitor's sweep can tell that failure from every other one by its
+ * type rather than by guessing from the run's status afterwards — Cancelling is
+ * written by a manual compensate() too, and a run finished by somebody else in the
+ * meantime looks like neither. A sweep may step over this one and carry on; anything
+ * else happened after the run had already been moved, and belongs to its caller.
+ */
+class ExpirationNotPlannedException extends FlowException
+{
+    public static function for(FlowRun $flowRun, Throwable $cause): self
+    {
+        return new self(
+            sprintf(
+                'Rollback for expiring flow %s [%s] could not be planned: %s',
+                $flowRun->workflow_class,
+                $flowRun->id,
+                $cause->getMessage(),
+            ),
+            previous: $cause,
+        );
+    }
+}

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -95,7 +95,10 @@ class CancelChildWorkflowJob implements ShouldQueue
             // Plan once before taking control, and throw the result away. Planning
             // starts no work of its own, so a child whose rollback cannot be planned
             // is left where this job found it instead of in Cancelling, which the
-            // monitor and the doctor both pass over on purpose.
+            // monitor and the doctor both pass over on purpose. One already Cancelling
+            // was fenced by an earlier attempt that then failed to plan: both plans
+            // fail or neither does, so a retry recovers it once the replay can read
+            // what it could not.
             if ($this->withCompensation) {
                 $executor->collectCompensations($child);
             }

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -92,6 +92,13 @@ class CancelChildWorkflowJob implements ShouldQueue
             $lifecycle,
             $child,
         ): void {
+            // Plan before taking control. Collecting is a read, and a fault in it must
+            // not leave the child sitting in Cancelling with nothing coming to move it
+            // on: the monitor and the doctor both pass over a Cancelling run on
+            // purpose. Losing the child to somebody else between the two is the
+            // ordinary race the transition's own guard already refuses.
+            $entries = $this->withCompensation ? $executor->collectCompensations($child) : [];
+
             // Take control of the child from any non-terminal state (Pending/Running/
             // Waiting) — the state machine allows each into Cancelling.
             $stateMachine->transition($child, FlowStatus::Cancelling);
@@ -99,8 +106,6 @@ class CancelChildWorkflowJob implements ShouldQueue
             $cause = $this->cause($repository, $child);
 
             if ($this->withCompensation) {
-                $entries = $executor->collectCompensations($child);
-
                 // Roll back inline (Sync), inside THIS job, rather than dispatching another
                 // queued Bus::batch: we are already on a worker, we just collected the stack
                 // synchronously, and a single in-process pass keeps the finalize + the

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -92,12 +92,13 @@ class CancelChildWorkflowJob implements ShouldQueue
             $lifecycle,
             $child,
         ): void {
-            // Plan before taking control. Planning starts no work of its own, and a
-            // fault in it must not leave the child sitting in Cancelling with nothing
-            // coming to move it on: the monitor and the doctor both pass over a
-            // Cancelling run on purpose. Losing the child to somebody else between the
-            // two is the ordinary race the transition's own guard already refuses.
-            $entries = $this->withCompensation ? $executor->collectCompensations($child) : [];
+            // Plan once before taking control, and throw the result away. Planning
+            // starts no work of its own, so a child whose rollback cannot be planned
+            // is left where this job found it instead of in Cancelling, which the
+            // monitor and the doctor both pass over on purpose.
+            if ($this->withCompensation) {
+                $executor->collectCompensations($child);
+            }
 
             // Take control of the child from any non-terminal state (Pending/Running/
             // Waiting) — the state machine allows each into Cancelling.
@@ -106,6 +107,14 @@ class CancelChildWorkflowJob implements ShouldQueue
             $cause = $this->cause($repository, $child);
 
             if ($this->withCompensation) {
+                // The plan that is acted on is made here, with the child fenced:
+                // Cancelling is a state no drive() can leave, so nothing can complete
+                // another compensatable step under it. A plan made before the fence
+                // can go stale — the transition guard reads status alone, so a child
+                // resumed and re-parked in between still matches — and unwinding it
+                // would leave that step standing under a run reported as rolled back.
+                $entries = $executor->collectCompensations($child);
+
                 // Roll back inline (Sync), inside THIS job, rather than dispatching another
                 // queued Bus::batch: we are already on a worker, we just collected the stack
                 // synchronously, and a single in-process pass keeps the finalize + the

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -92,11 +92,11 @@ class CancelChildWorkflowJob implements ShouldQueue
             $lifecycle,
             $child,
         ): void {
-            // Plan before taking control. Collecting is a read, and a fault in it must
-            // not leave the child sitting in Cancelling with nothing coming to move it
-            // on: the monitor and the doctor both pass over a Cancelling run on
-            // purpose. Losing the child to somebody else between the two is the
-            // ordinary race the transition's own guard already refuses.
+            // Plan before taking control. Planning starts no work of its own, and a
+            // fault in it must not leave the child sitting in Cancelling with nothing
+            // coming to move it on: the monitor and the doctor both pass over a
+            // Cancelling run on purpose. Losing the child to somebody else between the
+            // two is the ordinary race the transition's own guard already refuses.
             $entries = $this->withCompensation ? $executor->collectCompensations($child) : [];
 
             // Take control of the child from any non-terminal state (Pending/Running/

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -13,9 +13,10 @@ use Throwable;
  * whoever already owned the row, a claim the transaction that made it did not keep, an
  * outcome write refused because the row had changed hands, a batch already closed by a
  * duplicate before its own job reported, a run transition refused because the row had
- * moved on, a retry policy that threw. Most are ordinary consequences of at-least-once
- * delivery and of nothing serialising an operator against a worker; the second and the
- * last are defects in the caller's own code, journalled here for the same reason as the
+ * moved on, a retry policy that threw, an overdue run whose rollback could not be
+ * planned. Most are ordinary consequences of at-least-once delivery and of nothing
+ * serialising an operator against a worker; the claim that did not commit and the last
+ * two are defects in the caller's own code, journalled here for the same reason as the
  * rest — the engine carried on, so nothing else records it.
  *
  * None of them fails a job. A refused transition also reaches its caller: the engine
@@ -40,6 +41,8 @@ final readonly class AnomalyLog
     public const string REASON_TRANSITION_LOST = 'transition_lost';
 
     public const string REASON_RETRY_POLICY_THREW = 'retry_policy_threw';
+
+    public const string REASON_EXPIRY_FAILED = 'expiry_failed';
 
     /**
      * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -11,6 +11,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ExpirationNotPlannedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
@@ -317,7 +318,14 @@ class FlowExecutor
     {
         $primary = $this->exceptionToArray(FlowExpiredException::forFlowRun($flowRun));
 
-        $entries = $this->collectCompensations($flowRun);
+        // Named, because what the sweep does about a failure depends entirely on
+        // whether it happened here. Nothing has been written yet, so a run whose
+        // rollback cannot be planned is still exactly where it was found.
+        try {
+            $entries = $this->collectCompensations($flowRun);
+        } catch (Throwable $planning) {
+            throw ExpirationNotPlannedException::for($flowRun, $planning);
+        }
 
         if ($entries === []) {
             $flowRun->exception = $primary;

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -8,6 +8,8 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
@@ -141,14 +143,17 @@ class FlowExecutor
     }
 
     /**
-     * Rebuild the compensation stack for a run without executing any business
-     * logic: replay handle() in collecting mode so completed steps register their
-     * compensations and the replay stops at the live frontier. Used by the manual
-     * FlowHandle::compensate() path.
+     * Rebuild the compensation stack for a run: replay handle() in collecting mode
+     * so completed steps register their compensations and the replay stops at the
+     * live frontier. Every seam is guarded, so the pass starts no work and settles
+     * no step; a workflow's own tag() calls still rewrite their rows, as they do on
+     * every replay. Used by FlowHandle::compensate(). A throw the
+     * replay did not expect is a fault, not a frontier, and leaves rather than
+     * shortening the stack behind the caller's back.
      *
      * @return list<CompensationEntry>
      *
-     * @throws HistoryContractMismatchException
+     * @throws Throwable
      */
     public function collectCompensations(FlowRun $flowRun): array
     {
@@ -164,7 +169,7 @@ class FlowExecutor
     /**
      * @return list<CompensationEntry>
      *
-     * @throws HistoryContractMismatchException
+     * @throws Throwable
      */
     private function collectCompensationsInner(FlowRun $flowRun): array
     {
@@ -172,29 +177,34 @@ class FlowExecutor
         $this->runtime->reset();
         $this->runtime->beginCollecting();
 
+        // Every exit unbinds, including the ones that leave by throwing: the runtime
+        // is a singleton, and a pass that left it collecting would make the next
+        // ordinary drive of any run refuse to start work.
         try {
-            $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
+            try {
+                $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
 
-            /** @var array<int, mixed> $arguments */
-            $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
+                /** @var array<int, mixed> $arguments */
+                $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
 
-            $this->callWithDependencies($workflow, 'handle', $arguments);
-        } catch (HistoryContractMismatchException $mismatch) {
+                $this->callWithDependencies($workflow, 'handle', $arguments);
+            } catch (InternalFlowControl|ActionFailedException|FlowExpiredException|AwaitSignalTimeoutException) {
+                // The frontier, or a failure already recorded in this run's history
+                // replaying as a throw: a seam decided the replay ends here.
+                //
+                // Nothing else did. A throw from a builder argument, a workflow helper
+                // or anything else the replay runs is a fault, and swallowing it hands
+                // back a stack truncated at that point for compensate() to roll back
+                // and report as a complete unwind. It leaves here instead, before the
+                // run has been touched, so the operator sees the cause and still has a
+                // run to retry the rollback on.
+            }
+
+            return $this->runtime->sagaStack()->entries();
+        } finally {
             $this->runtime->endCollecting();
             $this->runtime->clear();
-
-            throw $mismatch;
-        } catch (Throwable) {
-            // FlowSuspended at the frontier, or a recorded business failure replaying
-            // as a throw — either way the stack is complete up to this point.
         }
-
-        $entries = $this->runtime->sagaStack()->entries();
-
-        $this->runtime->endCollecting();
-        $this->runtime->clear();
-
-        return $entries;
     }
 
     private function suspend(FlowRun $flowRun): FlowRun

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -189,15 +189,17 @@ class FlowExecutor
 
                 $this->callWithDependencies($workflow, 'handle', $arguments);
             } catch (InternalFlowControl|ActionFailedException|FlowExpiredException|AwaitSignalTimeoutException) {
-                // The frontier, or a failure already recorded in this run's history
-                // replaying as a throw: a seam decided the replay ends here.
+                // The four classes that end a replay: the frontier, and a step failure,
+                // an expiry or a signal timeout already recorded in this run's history.
+                // Membership is all this tests — a caller raising one of these itself
+                // is read as an ending too, which is why the set is kept small.
                 //
-                // Nothing else did. A throw from a builder argument, a workflow helper
-                // or anything else the replay runs is a fault, and swallowing it hands
-                // back a stack truncated at that point for compensate() to roll back
-                // and report as a complete unwind. It leaves here instead, before the
-                // run has been touched, so the operator sees the cause and still has a
-                // run to retry the rollback on.
+                // Nothing else ends it. A throw from a builder argument, a workflow
+                // helper or anything else the replay runs is a fault, and swallowing it
+                // hands back a stack truncated at that point for compensate() to roll
+                // back and report as a complete unwind. It leaves here instead, before
+                // the run has been touched, so the operator sees the cause and still
+                // has a run to retry the rollback on.
             }
 
             return $this->runtime->sagaStack()->entries();

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -106,11 +106,16 @@ final readonly class FlowMonitor
      * back queued, finalize as Expired) lives on FlowExecutor — the owner of every
      * run-terminal transition — and is shared with the lazy drive() deadline check.
      *
-     * A run the sweep cannot expire is journalled and stepped over. Letting the throw
-     * out would cost far more than the run it came from: the batch is read oldest
-     * first and a run that failed to expire is still overdue, so the same one would
-     * come back every sweep, and the signal and action passes below never run at all.
+     * A run whose rollback the sweep could not plan is journalled and stepped over.
+     * Letting that throw out would cost far more than the run it came from: the batch
+     * is read oldest first and the run is still overdue, so the same one would come
+     * back every sweep and the signal and action passes below would never run at all.
      * The lazy check inside drive() has one run to answer for and still surfaces it.
+     *
+     * Only that failure, though. A run this pass already took into Cancelling has left
+     * the candidate set on its own, so its failure cannot wedge anything — and it is
+     * not a plan that could not be made but a rollback that started and did not, which
+     * leaves the run where no sweep returns. That belongs to whoever is watching.
      */
     private function expireRun(FlowRun $run): bool
     {
@@ -119,11 +124,17 @@ final readonly class FlowMonitor
 
             return true;
         } catch (Throwable $failure) {
+            $current = $this->flows->find($run->id)?->status;
+
+            if ($current !== FlowStatus::Running && $current !== FlowStatus::Waiting) {
+                throw $failure;
+            }
+
             app(AnomalyLog::class)->log(AnomalyLog::REASON_EXPIRY_FAILED, [
                 'entity' => 'flow',
                 'flow_run_id' => $run->id,
                 'workflow_class' => $run->workflow_class,
-                'status' => $run->status->value,
+                'status' => $current->value,
                 'exception' => $this->exceptionToArray($failure),
             ]);
 

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -124,7 +124,13 @@ final readonly class FlowMonitor
 
             return true;
         } catch (Throwable $failure) {
-            $current = $this->flows->find($run->id)?->status;
+            // From the writer: this read decides whether the throw is absorbed, and a
+            // lagging replica would answer with the status the transition replaced.
+            /** @var ?FlowStatus $current */
+            $current = $run->newQuery()
+                ->useWritePdo()
+                ->whereKey($run->getKey())
+                ->value('status');
 
             if ($current !== FlowStatus::Running && $current !== FlowStatus::Waiting) {
                 throw $failure;

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -7,6 +7,7 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ExpirationNotPlannedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
@@ -112,11 +113,9 @@ final readonly class FlowMonitor
      * back every sweep and the signal and action passes below would never run at all.
      * The lazy check inside drive() has one run to answer for and still surfaces it.
      *
-     * Only that failure, though. Cancelling is the one status this pass produces and
-     * nothing returns to — no sweep lists it and the doctor skips it — so a run left
-     * there did not fail to be planned, it failed to be unwound, and that is not the
-     * sweep's to swallow. A run somebody else finished meanwhile is not that: it is
-     * done, it cannot be a candidate again, and the throw is journalled like the rest.
+     * Only that failure, and it says so by its type. Everything else happened after
+     * the run had already been moved — by this pass or by whoever else was holding it
+     * — and swallowing it would hide a rollback that started and did not finish.
      */
     private function expireRun(FlowRun $run): bool
     {
@@ -124,25 +123,13 @@ final readonly class FlowMonitor
             $this->executor->expireRun($run);
 
             return true;
-        } catch (Throwable $failure) {
-            // From the writer: this read decides whether the throw is absorbed, and a
-            // lagging replica would answer with the status the transition replaced.
-            /** @var ?FlowStatus $current */
-            $current = $run->newQuery()
-                ->useWritePdo()
-                ->whereKey($run->getKey())
-                ->value('status');
-
-            if ($current === FlowStatus::Cancelling) {
-                throw $failure;
-            }
-
+        } catch (ExpirationNotPlannedException $failure) {
             app(AnomalyLog::class)->log(AnomalyLog::REASON_EXPIRY_FAILED, [
                 'entity' => 'flow',
                 'flow_run_id' => $run->id,
                 'workflow_class' => $run->workflow_class,
-                'status' => $current?->value,
-                'exception' => $this->exceptionToArray($failure),
+                'status' => $run->status->value,
+                'exception' => $this->exceptionToArray($failure->getPrevious() ?? $failure),
             ]);
 
             return false;

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -93,9 +93,9 @@ final readonly class FlowMonitor
         $count = 0;
 
         foreach ($this->flows->dueForExpiration($limit) as $run) {
-            $this->expireRun($run);
-
-            $count++;
+            if ($this->expireRun($run)) {
+                $count++;
+            }
         }
 
         return $count;
@@ -106,11 +106,29 @@ final readonly class FlowMonitor
      * back queued, finalize as Expired) lives on FlowExecutor — the owner of every
      * run-terminal transition — and is shared with the lazy drive() deadline check.
      *
-     * @throws Throwable
+     * A run the sweep cannot expire is journalled and stepped over. Letting the throw
+     * out would cost far more than the run it came from: the batch is read oldest
+     * first and a run that failed to expire is still overdue, so the same one would
+     * come back every sweep, and the signal and action passes below never run at all.
+     * The lazy check inside drive() has one run to answer for and still surfaces it.
      */
-    private function expireRun(FlowRun $run): void
+    private function expireRun(FlowRun $run): bool
     {
-        $this->executor->expireRun($run);
+        try {
+            $this->executor->expireRun($run);
+
+            return true;
+        } catch (Throwable $failure) {
+            app(AnomalyLog::class)->log(AnomalyLog::REASON_EXPIRY_FAILED, [
+                'entity' => 'flow',
+                'flow_run_id' => $run->id,
+                'workflow_class' => $run->workflow_class,
+                'status' => $run->status->value,
+                'exception' => $this->exceptionToArray($failure),
+            ]);
+
+            return false;
+        }
     }
 
     private function timeoutSignals(int $limit): int

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -112,10 +112,11 @@ final readonly class FlowMonitor
      * back every sweep and the signal and action passes below would never run at all.
      * The lazy check inside drive() has one run to answer for and still surfaces it.
      *
-     * Only that failure, though. A run this pass already took into Cancelling has left
-     * the candidate set on its own, so its failure cannot wedge anything — and it is
-     * not a plan that could not be made but a rollback that started and did not, which
-     * leaves the run where no sweep returns. That belongs to whoever is watching.
+     * Only that failure, though. Cancelling is the one status this pass produces and
+     * nothing returns to — no sweep lists it and the doctor skips it — so a run left
+     * there did not fail to be planned, it failed to be unwound, and that is not the
+     * sweep's to swallow. A run somebody else finished meanwhile is not that: it is
+     * done, it cannot be a candidate again, and the throw is journalled like the rest.
      */
     private function expireRun(FlowRun $run): bool
     {
@@ -132,7 +133,7 @@ final readonly class FlowMonitor
                 ->whereKey($run->getKey())
                 ->value('status');
 
-            if ($current !== FlowStatus::Running && $current !== FlowStatus::Waiting) {
+            if ($current === FlowStatus::Cancelling) {
                 throw $failure;
             }
 
@@ -140,7 +141,7 @@ final readonly class FlowMonitor
                 'entity' => 'flow',
                 'flow_run_id' => $run->id,
                 'workflow_class' => $run->workflow_class,
-                'status' => $current->value,
+                'status' => $current?->value,
                 'exception' => $this->exceptionToArray($failure),
             ]);
 

--- a/src/Runtime/ParallelRunner.php
+++ b/src/Runtime/ParallelRunner.php
@@ -68,6 +68,13 @@ final readonly class ParallelRunner
 
         // First encounter (nothing recorded yet): dispatch the whole block, then suspend.
         if (! $anyScheduled) {
+            // Compensation-only planning never starts new work: stop at the frontier.
+            // Without this the block writes a row per step and dispatches its batch —
+            // live jobs started by the one pass whose whole purpose is to read.
+            if ($runtime->isCollecting()) {
+                $this->suspender->suspend('parallel', $slots[0]['sequence']);
+            }
+
             return $runtime->mode() === RunMode::Sync
                 ? $this->dispatchSync($flowRun, $slots, $policy, $groupId)
                 : $this->dispatchQueued($flowRun, $slots, $policy, $groupId);

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
@@ -182,4 +184,21 @@ it('does not strand a child whose rollback it could not plan', function () {
     // Cancelling is the one state nothing recovers: the monitor and the doctor both
     // pass over it. The child is left where the close found it, for a retry to close.
     expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Waiting);
+});
+
+it('fences a child before planning the rollback it will act on', function () {
+    config()->set('saga-lara-flow.queue.after_commit', false);
+
+    $run = SagaFlow::create(ParentOfVanishingChildWorkflow::class)->runSync();
+    $child = SagaFlow::findRun($run->children()->first()->child_flow_run_id);
+
+    app(StateMachine::class)->transition($child, FlowStatus::Cancelling);
+
+    // This is what makes a plan made after the transition final, and a plan made
+    // before it a guess: nothing can drive a Cancelling run, so no further step can
+    // complete under one. The close plans on this side of the fence for that reason
+    // — the transition's own guard reads status alone, so a child resumed and
+    // re-parked while an earlier plan was being made would still match it.
+    expect(fn () => app(FlowExecutor::class)->drive(SagaFlow::findRun($child->id), RunMode::Queued))
+        ->toThrow(InvalidTransitionException::class);
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -18,6 +18,7 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ManualCompensateWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParentOfVanishingChildWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SelfCancellingThenThrowingWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
 use Illuminate\Database\QueryException;
@@ -257,4 +258,31 @@ it('surfaces a sweep failure that already took the run into cancelling', functio
     // It cannot wedge the sweep the way a planning failure would: Cancelling is not
     // a candidate status, so the run is gone from the batch on its own.
     expect(app(FlowMonitor::class)->sweep())->toBe(['runs' => 0, 'signals' => 0, 'actions' => 0]);
+});
+
+it('does not abort the sweep over a run somebody else finished meanwhile', function () {
+    useDatabaseQueue();
+    logToFile($path = sys_get_temp_dir().'/saga-race-'.bin2hex(random_bytes(6)).'.log');
+    SelfCancellingThenThrowingWorkflow::reset();
+
+    $run = SagaFlow::create(SelfCancellingThenThrowingWorkflow::class)->run();
+    drainQueue();
+    $run = SagaFlow::findRun($run->id);
+    $run->expires_at = now()->subMinute();
+    $run->save();
+
+    // The replay finishes the run and then faults — one process doing what two would.
+    SelfCancellingThenThrowingWorkflow::$interfere = true;
+
+    // The run is terminal, so it cannot be a candidate again and this attempt never
+    // began a rollback. Only a run left in Cancelling is worth aborting the sweep for.
+    expect(app(FlowMonitor::class)->sweep())->toBe(['runs' => 0, 'signals' => 0, 'actions' => 0])
+        ->and(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled);
+
+    $log = is_file($path) ? (string) file_get_contents($path) : '';
+
+    expect($log)->toContain(AnomalyLog::REASON_EXPIRY_FAILED)
+        ->and($log)->toContain($run->id);
+
+    SelfCancellingThenThrowingWorkflow::reset();
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
+
+/**
+ * collectCompensations() is the read half of a rollback: it replays handle() only to
+ * learn what has to be undone. It wrote, though — an optional step whose retry budget
+ * was spent was settled by the replay that was only supposed to look at it, and the
+ * give-up was recorded by a pass that does not own the row.
+ */
+beforeEach(fn () => CompensationLog::reset());
+
+/**
+ * The state the engine reaches on its own: the queue gave up on this cycle and the
+ * retry budget is spent, but no ordinary replay has resolved the row yet. Whoever
+ * calls compensate() at that moment gets there first.
+ */
+function spentOptionalRetry(): array
+{
+    FlakyPaymentAction::reset(failures: 99);
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+
+    $run = SagaFlow::create(OptionalRetryCompensatedWorkflow::class)
+        ->withArguments('order-1')
+        ->runSync();
+
+    $step = $run->actions()->where('sequence', 0)->first();
+    $step->status = ActionStatus::Failed;
+    $step->queue_attempts_exhausted = true;
+    $step->retry_signal_max_attempts = 0;
+    $step->save();
+
+    return [$run, $step->fresh()];
+}
+
+it('collects the compensation of a spent optional step without writing to it', function () {
+    [$run, $step] = spentOptionalRetry();
+
+    $before = $step->getAttributes();
+    $eventsBefore = $run->events()->count();
+
+    $entries = app(FlowExecutor::class)->collectCompensations(SagaFlow::findRun($run->id));
+
+    // The replay resolved the give-up rather than stopping at it: the step's own
+    // compensation is in the stack, which is the only way past that fork.
+    expect($entries)->toHaveCount(1)
+        ->and($entries[0]->sequence)->toBe(0)
+        ->and($run->actions()->where('sequence', 0)->first()->getAttributes())->toBe($before)
+        ->and($run->fresh()->events()->count())->toBe($eventsBefore);
+});
+
+it('leaves the optional_failed write to the next ordinary replay', function () {
+    [$run] = spentOptionalRetry();
+
+    app(FlowExecutor::class)->collectCompensations(SagaFlow::findRun($run->id));
+
+    // Not withheld, only deferred: the pass that owns the row still records it.
+    app(FlowExecutor::class)->drive(SagaFlow::findRun($run->id), RunMode::Sync);
+
+    expect($run->actions()->where('sequence', 0)->first()->status)
+        ->toBe(ActionStatus::OptionalFailed);
+});

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -1,20 +1,28 @@
 <?php
 
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
 
 /**
  * collectCompensations() is the read half of a rollback: it replays handle() only to
- * learn what has to be undone. It wrote, though — an optional step whose retry budget
- * was spent was settled by the replay that was only supposed to look at it, and the
- * give-up was recorded by a pass that does not own the row.
+ * learn what has to be undone. Two things used to break that. It wrote — an optional
+ * step whose retry budget was spent was settled by the replay that was only supposed
+ * to look at it. And it decided by catching, which cannot tell the frontier it was
+ * looking for from a fault it was not: any throw ended the stack, and compensate()
+ * rolled back the truncated result and reported a complete unwind.
  */
-beforeEach(fn () => CompensationLog::reset());
+beforeEach(function (): void {
+    CompensationLog::reset();
+    VanishedArgumentWorkflow::reset();
+});
 
 /**
  * The state the engine reaches on its own: the queue gave up on this cycle and the
@@ -65,4 +73,32 @@ it('leaves the optional_failed write to the next ordinary replay', function () {
 
     expect($run->actions()->where('sequence', 0)->first()->status)
         ->toBe(ActionStatus::OptionalFailed);
+});
+
+it('refuses to report a rollback it could not finish planning', function () {
+    $run = SagaFlow::create(VanishedArgumentWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Waiting)
+        ->and($run->actions()->count())->toBe(2);
+
+    // Whatever the second step's argument was read from is gone by the time the
+    // operator rolls back. The replay now throws where the original pass did not.
+    VanishedArgumentWorkflow::$label = null;
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->compensate())
+        ->toThrow(RuntimeException::class, 'the order this run was built from is gone');
+
+    // Nothing half-done: the fault surfaces before the run is touched, so the
+    // rollback is still there to be retried once the cause is fixed. The runtime is
+    // a singleton, so leaving by throwing has to unbind it too — a pass that stayed
+    // in collecting mode would park the next ordinary drive of any run at its first
+    // unscheduled step.
+    expect(CompensationLog::all())->toBe([])
+        ->and($run->fresh()->status)->toBe(FlowStatus::Waiting)
+        ->and(app(FlowRuntime::class)->isCollecting())->toBeFalse();
+
+    VanishedArgumentWorkflow::reset();
+
+    expect(SagaFlow::loadFlow($run->id)->compensate()->status)->toBe(FlowStatus::Cancelled)
+        ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -4,12 +4,16 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CaughtTimeoutThenParallelWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
+use Illuminate\Support\Facades\DB;
 
 /**
  * collectCompensations() is the read half of a rollback: it replays handle() only to
@@ -101,4 +105,25 @@ it('refuses to report a rollback it could not finish planning', function () {
 
     expect(SagaFlow::loadFlow($run->id)->compensate()->status)->toBe(FlowStatus::Cancelled)
         ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
+});
+
+it('does not schedule or dispatch a parallel block it has only reached to read', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(CaughtTimeoutThenParallelWorkflow::class)->run();
+    drainQueue();
+
+    // The monitor times the wait out, so the next replay walks past the catch. The
+    // resume job has not run yet, which is the window an operator's rollback lands in.
+    app(FlowMonitor::class)->sweep();
+
+    $rows = ActionRun::query()->count();
+    $jobs = DB::connection('testing')->table('jobs')->count();
+
+    $entries = app(FlowExecutor::class)->collectCompensations(SagaFlow::findRun($run->id));
+
+    expect($entries)->toHaveCount(1)
+        ->and(ActionRun::query()->count())->toBe($rows)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs)
+        ->and(DB::connection('testing')->table('job_batches')->count())->toBe(0);
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -6,6 +6,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\CancelChildWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -201,4 +202,32 @@ it('fences a child before planning the rollback it will act on', function () {
     // re-parked while an earlier plan was being made would still match it.
     expect(fn () => app(FlowExecutor::class)->drive(SagaFlow::findRun($child->id), RunMode::Queued))
         ->toThrow(InvalidTransitionException::class);
+});
+
+it('retries a child close that failed after it had taken control', function () {
+    // A real queue: finalizing the child notifies the parent, which batches its own
+    // rollback. Nothing drains it — the assertions here are about the child.
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(ParentOfVanishingChildWorkflow::class)->runSync();
+    $child = SagaFlow::findRun($run->children()->first()->child_flow_run_id);
+
+    // The window the two plans leave: the first succeeded, the child was fenced, and
+    // the second met a world that had moved. The child is Cancelling and owned.
+    app(StateMachine::class)->transition($child, FlowStatus::Cancelling);
+    VanishedArgumentWorkflow::$label = null;
+
+    expect(fn () => dispatch_sync(new CancelChildWorkflowJob($child->id, FlowStatus::Cancelled, true)))
+        ->toThrow(RuntimeException::class)
+        ->and(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Cancelling);
+
+    // Cancelling has no way back — allowedFrom() lists only terminal states — so the
+    // child sits there until the replay can read what it could not. It is not stuck
+    // for good, though: the retry recovers it once the cause is fixed.
+    VanishedArgumentWorkflow::reset();
+
+    dispatch_sync(new CancelChildWorkflowJob($child->id, FlowStatus::Cancelled, true));
+
+    expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Cancelled)
+        ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -260,7 +260,7 @@ it('surfaces a sweep failure that already took the run into cancelling', functio
     expect(app(FlowMonitor::class)->sweep())->toBe(['runs' => 0, 'signals' => 0, 'actions' => 0]);
 });
 
-it('does not abort the sweep over a run somebody else finished meanwhile', function () {
+it('does not abort the sweep over a run somebody else was moving meanwhile', function (FlowStatus $moveTo) {
     useDatabaseQueue();
     logToFile($path = sys_get_temp_dir().'/saga-race-'.bin2hex(random_bytes(6)).'.log');
     SelfCancellingThenThrowingWorkflow::reset();
@@ -271,13 +271,13 @@ it('does not abort the sweep over a run somebody else finished meanwhile', funct
     $run->expires_at = now()->subMinute();
     $run->save();
 
-    // The replay finishes the run and then faults — one process doing what two would.
-    SelfCancellingThenThrowingWorkflow::$interfere = true;
+    // The replay moves the run and then faults — one process doing what two would.
+    // Cancelling is the operator's own compensate(), so the sweep cannot read that
+    // status as evidence of its own doing; what it goes on is the type of the throw.
+    SelfCancellingThenThrowingWorkflow::$moveTo = $moveTo;
 
-    // The run is terminal, so it cannot be a candidate again and this attempt never
-    // began a rollback. Only a run left in Cancelling is worth aborting the sweep for.
     expect(app(FlowMonitor::class)->sweep())->toBe(['runs' => 0, 'signals' => 0, 'actions' => 0])
-        ->and(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelled);
+        ->and(SagaFlow::findRun($run->id)->status)->toBe($moveTo);
 
     $log = is_file($path) ? (string) file_get_contents($path) : '';
 
@@ -285,4 +285,7 @@ it('does not abort the sweep over a run somebody else finished meanwhile', funct
         ->and($log)->toContain($run->id);
 
     SelfCancellingThenThrowingWorkflow::reset();
-});
+})->with([
+    'finished outright' => FlowStatus::Cancelled,
+    'taken by a manual compensate()' => FlowStatus::Cancelling,
+]);

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -15,10 +15,12 @@ use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CaughtTimeoutThenParallelWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ManualCompensateWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParentOfVanishingChildWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
+use Illuminate\Database\QueryException;
 use Illuminate\Support\Facades\DB;
 
 /**
@@ -230,4 +232,29 @@ it('retries a child close that failed after it had taken control', function () {
 
     expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Cancelled)
         ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
+});
+
+it('surfaces a sweep failure that already took the run into cancelling', function () {
+    // Sync driver and no job_batches table: the plan succeeds, the run is taken to
+    // Cancelling, and dispatching the rollback batch is what throws.
+    config()->set('saga-lara-flow.queue.after_commit', false);
+    logToFile($path = sys_get_temp_dir().'/saga-sweep-'.bin2hex(random_bytes(6)).'.log');
+
+    $run = SagaFlow::create(ManualCompensateWorkflow::class)->runSync();
+    $run = SagaFlow::findRun($run->id);
+    $run->expires_at = now()->subMinute();
+    $run->save();
+
+    expect(fn () => app(FlowMonitor::class)->sweep())->toThrow(QueryException::class)
+        ->and(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Cancelling);
+
+    // Not journalled as a plan that could not be made, because that is not what it
+    // was, and not absorbed either: nothing returns to a run left mid-cancellation.
+    $log = is_file($path) ? (string) file_get_contents($path) : '';
+
+    expect($log)->not->toContain(AnomalyLog::REASON_EXPIRY_FAILED);
+
+    // It cannot wedge the sweep the way a planning failure would: Cancelling is not
+    // a candidate status, so the run is gone from the batch on its own.
+    expect(app(FlowMonitor::class)->sweep())->toBe(['runs' => 0, 'signals' => 0, 'actions' => 0]);
 });

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -5,6 +5,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
@@ -12,6 +13,8 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CaughtTimeoutThenParallelWorkfl
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OptionalRetryCompensatedWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParentOfVanishingChildWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
 use Illuminate\Support\Facades\DB;
 
@@ -22,6 +25,10 @@ use Illuminate\Support\Facades\DB;
  * to look at it. And it decided by catching, which cannot tell the frontier it was
  * looking for from a fault it was not: any throw ended the stack, and compensate()
  * rolled back the truncated result and reported a complete unwind.
+ *
+ * Surfacing that fault instead has a blast radius of its own, because compensations are
+ * planned from three places, not one. The two the operator did not ask for — the
+ * expiration sweep and a parent closing its child — have to absorb it where it lands.
  */
 beforeEach(function (): void {
     CompensationLog::reset();
@@ -126,4 +133,53 @@ it('does not schedule or dispatch a parallel block it has only reached to read',
         ->and(ActionRun::query()->count())->toBe($rows)
         ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs)
         ->and(DB::connection('testing')->table('job_batches')->count())->toBe(0);
+});
+
+it('steps over a run whose rollback it cannot plan and journals it', function () {
+    useDatabaseQueue();
+    logToFile($path = sys_get_temp_dir().'/saga-expiry-'.bin2hex(random_bytes(6)).'.log');
+
+    // Oldest deadline, so dueForExpiration() hands this one back first, every sweep.
+    $stuck = SagaFlow::create(VanishedArgumentWorkflow::class)->run();
+    drainQueue();
+    $stuck = SagaFlow::findRun($stuck->id);
+    $stuck->expires_at = now()->subHours(2);
+    $stuck->save();
+
+    $healthy = SagaFlow::create(SignalOnlyWorkflow::class)->run();
+    drainQueue();
+    $healthy = SagaFlow::findRun($healthy->id);
+    $healthy->expires_at = now()->subMinute();
+    $healthy->save();
+
+    VanishedArgumentWorkflow::$label = null;
+
+    // The sweep reads oldest first and runs before the signal and action passes, so a
+    // throw let out here would cost every run behind this one and both passes below.
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1)
+        ->and(SagaFlow::findRun($healthy->id)->status)->toBe(FlowStatus::Expired)
+        ->and(SagaFlow::findRun($stuck->id)->status)->toBe(FlowStatus::Waiting);
+
+    $log = is_file($path) ? (string) file_get_contents($path) : '';
+
+    expect($log)->toContain(AnomalyLog::REASON_EXPIRY_FAILED)
+        ->and($log)->toContain($stuck->id);
+});
+
+it('does not strand a child whose rollback it could not plan', function () {
+    config()->set('saga-lara-flow.queue.after_commit', false);
+
+    $run = SagaFlow::create(ParentOfVanishingChildWorkflow::class)->runSync();
+    $child = $run->children()->first()->child;
+
+    expect($child->status)->toBe(FlowStatus::Waiting);
+
+    VanishedArgumentWorkflow::$label = null;
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->compensate())
+        ->toThrow(RuntimeException::class, 'the order this run was built from is gone');
+
+    // Cancelling is the one state nothing recovers: the monitor and the doctor both
+    // pass over it. The child is left where the close found it, for a retry to close.
+    expect(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Waiting);
 });

--- a/tests/Fixtures/CaughtTimeoutThenParallelWorkflow.php
+++ b/tests/Fixtures/CaughtTimeoutThenParallelWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Catches a signal timeout and carries on into a parallel block. The catch is what
+ * makes the block reachable by a collecting replay: the timeout is surfaced during
+ * collection precisely so a workflow that handles it still registers its later
+ * compensations, which walks the replay into a block nothing has scheduled yet.
+ */
+final class CaughtTimeoutThenParallelWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(UndoAction::class, 'a')
+            ->run();
+
+        try {
+            $this->awaitSignal('approval', timeout: now()->subMinute());
+        } catch (AwaitSignalTimeoutException) {
+            // The block below is what the run does instead.
+        }
+
+        $this->parallel()
+            ->action(MakeValueAction::class, 'p1')
+            ->action(MakeValueAction::class, 'p2')
+            ->run();
+    }
+}

--- a/tests/Fixtures/OptionalRetryCompensatedWorkflow.php
+++ b/tests/Fixtures/OptionalRetryCompensatedWorkflow.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * OptionalRetryOnSignalWorkflow with a compensation on the optional step itself.
+ * The compensation is what makes a collecting replay observable: it lands in the
+ * stack only if the replay resolved the give-up rather than stopping at it.
+ */
+final class OptionalRetryCompensatedWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId, ?int $maxRetries = null): mixed
+    {
+        return $this->action(FlakyPaymentAction::class, $orderId)
+            ->continueOnFailure()
+            ->fallbackValueOnFail('unpaid')
+            ->compensateWith(UndoAction::class, 'charge')
+            ->compensateStepOnSelfFailure()
+            ->retryOnSignal('balance-refilled', maxRetries: $maxRetries)
+            ->run();
+    }
+}

--- a/tests/Fixtures/ParentOfVanishingChildWorkflow.php
+++ b/tests/Fixtures/ParentOfVanishingChildWorkflow.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ChildClosePolicy;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+
+/**
+ * Awaits a child that parks, under the Cancel close policy, so closing the parent
+ * cascades into a child close that has to plan the child's rollback first. The
+ * child is the one whose replay can be made to throw.
+ */
+final class ParentOfVanishingChildWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'parent')
+            ->compensateWith(UndoAction::class, 'parent')
+            ->run();
+
+        $this->child(VanishedArgumentWorkflow::class)
+            ->closePolicy(ChildClosePolicy::Cancel)
+            ->run();
+    }
+}

--- a/tests/Fixtures/SelfCancellingThenThrowingWorkflow.php
+++ b/tests/Fixtures/SelfCancellingThenThrowingWorkflow.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use RuntimeException;
+
+/**
+ * Parks, and on a later replay finishes its own run and then throws. It stands in for
+ * the two things happening at once that no single-process test can otherwise stage: a
+ * planning replay that faults while somebody else finalizes the run under it.
+ */
+final class SelfCancellingThenThrowingWorkflow extends Workflow
+{
+    public static bool $interfere = false;
+
+    public static function reset(): void
+    {
+        self::$interfere = false;
+    }
+
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->run();
+
+        if (self::$interfere) {
+            SagaFlow::loadFlow($this->runId())->cancel();
+
+            throw new RuntimeException('planning faulted while the run was being finished');
+        }
+
+        $this->awaitSignal('go');
+    }
+}

--- a/tests/Fixtures/SelfCancellingThenThrowingWorkflow.php
+++ b/tests/Fixtures/SelfCancellingThenThrowingWorkflow.php
@@ -2,32 +2,37 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
 
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Workflow;
 use RuntimeException;
 
 /**
- * Parks, and on a later replay finishes its own run and then throws. It stands in for
- * the two things happening at once that no single-process test can otherwise stage: a
- * planning replay that faults while somebody else finalizes the run under it.
+ * Parks, and on a later replay moves its own run and then throws. It stands in for the
+ * two things happening at once that no single-process test can otherwise stage: a
+ * planning replay that faults while somebody else is moving the run under it — a
+ * manual compensate() taking it to Cancelling, or a cancel() finishing it outright.
  */
 final class SelfCancellingThenThrowingWorkflow extends Workflow
 {
-    public static bool $interfere = false;
+    public static ?FlowStatus $moveTo = null;
 
     public static function reset(): void
     {
-        self::$interfere = false;
+        self::$moveTo = null;
     }
 
     public function handle(): void
     {
         $this->action(MakeValueAction::class, 'a')->run();
 
-        if (self::$interfere) {
-            SagaFlow::loadFlow($this->runId())->cancel();
+        if (self::$moveTo !== null) {
+            self::$moveTo === FlowStatus::Cancelled
+                ? SagaFlow::loadFlow($this->runId())->cancel()
+                : app(StateMachine::class)->transition(SagaFlow::findRun($this->runId()), self::$moveTo);
 
-            throw new RuntimeException('planning faulted while the run was being finished');
+            throw new RuntimeException('planning faulted while the run was being moved');
         }
 
         $this->awaitSignal('go');

--- a/tests/Fixtures/VanishedArgumentWorkflow.php
+++ b/tests/Fixtures/VanishedArgumentWorkflow.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use RuntimeException;
+
+/**
+ * Two compensatable steps, then a wait. The second step's argument is read from
+ * something outside the run — the stand-in for a record the workflow looks up while
+ * building its steps. Clearing it makes a later replay throw where the original pass
+ * did not, which is what a rollback started after the world moved on actually meets.
+ */
+final class VanishedArgumentWorkflow extends Workflow
+{
+    public static ?string $label = 'b';
+
+    public static function reset(): void
+    {
+        self::$label = 'b';
+    }
+
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(UndoAction::class, 'a')
+            ->run();
+
+        $this->action(MakeValueAction::class, $this->label())
+            ->compensateWith(UndoAction::class, 'b')
+            ->run();
+
+        $this->awaitSignal('go');
+    }
+
+    private function label(): string
+    {
+        return self::$label ?? throw new RuntimeException('the order this run was built from is gone');
+    }
+}


### PR DESCRIPTION
Closes #35.

`collectCompensations()` is the read half of a rollback: it replays `handle()` only to learn what has
to be undone. Two things broke that, and a third turned up while reviewing the fix.

## What it did

**It settled a step.** An optional step carrying a spent `retryOnSignal()` budget was moved `failed`
→ `optional_failed`, with an `action.optional_failed` event and the `OptionalActionFailed` Laravel
event, by the pass that was only supposed to look at it. Reproduced from the issue body on `main`:

```
status failed -> optional_failed;  events 6 -> 7
```

**It decided by catching.** `catch (Throwable)` treated every throw as the frontier. Measured with a
plain `RuntimeException` raised mid-`handle()` during collection:

```
stack = 1 entry (2 without the throw)
compensate() -> cancelled          <- reported a complete unwind
undo:b never ran
```

**It scheduled and dispatched work.** Found by the review, measured on `main`: a parallel block the
replay had only reached to read wrote a row per step and dispatched a Bus batch.

```
before collectCompensations():  action_runs 1, jobs 1, job_batches 0
after:                          action_runs 3, jobs 3, job_batches 1
```

## What it does now

**`giveUpAfterRetry()` resolves without writing.** Both recorder calls are gated; `resolveFailed()`
and `resolveOptionalFailed()` run unchanged, so the replay still resolves the step and walks *past*
it. Suspending at the top of the `Failed` branch — the obvious guard — would stop the replay there
and lose every compensation after it, which is what collecting exists to gather. The latent required
branch is guarded too.

**The catch classifies.** `InternalFlowControl|ActionFailedException|FlowExpiredException|AwaitSignalTimeoutException`
means a seam ended the replay; everything else propagates, so `compensate()` fails *before* its
`Cancelling` transition and before `SagaRunner::rollback()`, leaving the run exactly as found and the
rollback retriable. `endCollecting()`/`clear()` moved into a `finally` — without it an escaping throw
would leave the singleton runtime collecting and park the next ordinary drive of any run.

**`ParallelRunner` stops at an unscheduled block**, the same shape as the four guards in
`ActionBuilder`. `join()` writes nothing, so the guard belongs only in the first-encounter fork.

## How the allow-list was derived

Instrumenting the old catch and running the whole suite logged **23 hits, all `FlowSuspended`** —
the original comment named two throws and the suite exercised one. The rest came from targeted
probes: a required `Failed` step → `ActionFailedException`; a required `Expired` step →
`FlowExpiredException`; a timed-out wait-signal after a real `FlowMonitor::sweep()` →
`AwaitSignalTimeoutException`. All four are live on the real `compensate()` path on a non-terminal
run. `RetryPolicyReentryException` is unreachable while collecting — the predicate never runs.

## Tests

Four, no skips, each verified by mutation:

| mutation | goes red |
|---|---|
| remove the `$collecting` gate | `'status' => 'failed'` vs `'optional_failed'` |
| restore `catch (Throwable)` | `Exception "RuntimeException" not thrown.` |
| cleanup after `return` instead of `finally` | `Failed asserting that true is false.` |
| remove the `ParallelRunner` guard | `Failed asserting that 3 is identical to 1.` |

`VanishedArgumentWorkflow` throws from the second step's **argument expression** — the surface the
issue names — reading a static the test clears between the run and the rollback, standing in for a
record deleted since.

## Filed rather than fixed here

Three defects the review surfaced, each measured and each reproducing on `main`:

- **#48** — a terminal child under `continueParentOnFailure()` is read as a live frontier, so
  compensations after it are lost silently. Milestone 1.2.0.
- **#49** — a host-thrown `ActionFailedException` lands in the allow-list. The residual of narrowing
  the catch; needs provenance on the instances the engine raises. Milestone 1.3.0.
- **#50** — a collecting replay rewrites the run's tags. The obvious guard was written, measured to
  truncate a rollback for a workflow that branches on a tag, and reverted; the issue records both
  measurements so it is not written again. Milestone 1.3.0.

## Runs

| | |
|---|---|
| SQLite | 399 passed, 3 skipped |
| MySQL | 399 passed, 3 skipped |
| PostgreSQL | 402 passed, 0 skipped |

Pint clean over 353 files, PHPStan level 5 clean, `docs` builds.
