### PR TITLE
Refuse an action write whose row moved on since it was read

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -484,6 +484,18 @@ Nothing to do unless a listener expected `OptionalActionFailed` during `compensa
 sweep absorbs such a throw instead, journalling `expiry_failed` and stepping over the run. See
 [Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation).
 
+### 22. Writes to a step check the row is still the one they read
+
+Five recorder transitions — a give-up, a park, a rewind, settling a parked step, and the queue's
+exhausted-attempts flag — now state the row they expect and the run's liveness in one `UPDATE`. One
+that loses writes nothing, journals `write_refused` with a `site`, and returns `false` where it used
+to return `void`. The claim is fenced on the run too, and still reports `claim_lost` as before.
+
+The other thing to check: those five no longer call `save()`, so they raise no Eloquent model events
+— an observer on your `ActionRun` model stops seeing them. Three publish a package event instead,
+and settling a parked step and recording the queue's exhausted attempts publish none, by design. See
+[Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -107,8 +107,9 @@ package keeps a second journal for them:
 ],
 ```
 
-Grep for `claim_lost`, `outcome_rejected` and `batch_finished_early`; each line carries the run id,
-row id, sequence and class. `claim_not_committed` joins them when a claim did not survive its own
+Grep for `claim_lost`, `outcome_rejected`, `batch_finished_early` and `write_refused`; each line
+carries the run id, row id, sequence and class, and `write_refused` adds the `site` of the write that
+was refused. `claim_not_committed` joins them when a claim did not survive its own
 transaction, which is a defect in listener or observer code rather than a race, and `expiry_failed`
 when the sweep could not plan an overdue run's rollback and stepped over it. A refused run
 transition is journalled here too, as `transition_lost`,

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -220,7 +220,7 @@ journal for them — `AnomalyLog`, alongside the `flow_events` business history:
 ],
 ```
 
-Five reason codes to grep for. The first four carry the run id, row id, sequence and class; the fifth
+Six reason codes to grep for. All but one carry the run id, row id, sequence and class; `expiry_failed`
 is about a run rather than a row, and carries the run id, its workflow class and the throw:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
@@ -230,12 +230,19 @@ is about a run rather than a row, and carries the run id, its workflow class and
   attempt counts, the claimed one and the one the row actually holds.
 - **`expiry_failed`** — the sweep could not plan an overdue run's rollback, so it left the run alone and moved on to
   the next. The line carries the throw. The run stays overdue and is tried again on the next sweep.
+- **`write_refused`** — a write to a step was refused because the row had moved on since it was read, or the run under
+  it had finished. The line carries a `site` naming which write it was.
 
 Raise the level to `warning` to surface them in your alerting. A steady stream of the first three points to a queue
 timeout tuned shorter than the work takes, or to locks being off.
 
-The last two are not races and do not come from tuning. `expiry_failed` means the run's own `handle()` threw while the
-sweep was replaying it to find the compensations — a workflow reading something that has since gone, most often. Until
+`write_refused` is a race like the first three, and the ordinary one: terminal settlement runs once, so anything
+written to a step afterwards would stand for ever with nothing left to notice it. A steady stream of it on runs nobody
+cancelled points the same way as `claim_lost` — a queue timeout tuned shorter than the work takes.
+
+The remaining two are not races and do not come from tuning. `expiry_failed` means the run's own `handle()` threw
+while the sweep was replaying it to find the compensations — a workflow reading something that has since gone, most
+often. Until
 that is fixed the run cannot be expired, but nothing else in the sweep is held up by it.
 
 `claim_not_committed` is the other one: something ran inside the engine's own transaction and left it

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -640,9 +640,9 @@ class ActionBuilder
     }
 
     /**
-     * Park a failed step on its retry signal and suspend the flow. Never returns:
-     * either the retry starts immediately (a signal was already delivered) or the
-     * flow goes Waiting until one is.
+     * Park a failed step on its retry signal and suspend the flow. Never returns: either
+     * the retry starts immediately (a signal was already delivered) or the flow goes
+     * Waiting until one is.
      *
      * @throws FlowSuspended
      * @throws Throwable
@@ -699,23 +699,41 @@ class ActionBuilder
      *
      * $record is false when an open signal from an earlier pass was adopted.
      *
+     * A parking that loses its fence — the row moved on, or the run finished — writes
+     * neither row, fires no ActionAwaitingRetry, and suspends like a won one. Whatever
+     * moved the row wrote where the step really is, and a run that ended has nothing
+     * left to resolve; either way this pass has no state left to decide from, and the
+     * suspension leaves no wait behind because none was recorded.
+     *
      * @throws FlowSuspended
      * @throws Throwable
      */
     private function park(ActionRun $step, string $signal, int $sequence, bool $record = true): never
     {
-        $this->connection()->transaction(function () use ($step, $signal, $sequence, $record): void {
-            if ($record) {
-                app(SignalRecorder::class)->recordSignalWaiting(
-                    $this->runtime->run(),
-                    $signal,
-                    $sequence,
-                    $this->retryWaitSeconds === null ? null : now()->addSeconds($this->retryWaitSeconds),
-                );
-            }
+        try {
+            $this->connection()->transaction(function () use ($step, $signal, $sequence, $record): void {
+                if ($record) {
+                    app(SignalRecorder::class)->recordSignalWaiting(
+                        $this->runtime->run(),
+                        $signal,
+                        $sequence,
+                        $this->retryWaitSeconds === null ? null : now()->addSeconds($this->retryWaitSeconds),
+                    );
+                }
 
-            app(ActionRecorder::class)->awaitRetry($step, $signal, $this->budgetFor($step));
-        });
+                if (! app(ActionRecorder::class)->awaitRetry($step, $signal, $this->budgetFor($step))) {
+                    // The wait-signal must go back with the transition it was recorded
+                    // for: left standing, it is the newest open wait for its name, so a
+                    // delivery would be swallowed by a park that never happened.
+                    throw new FencedWriteLost;
+                }
+            });
+        } catch (FencedWriteLost) {
+            // Nothing was written, and there is nothing left to resolve from: whatever
+            // moved the row recorded where the step really is, and a run that ended has
+            // no next step to take. Wait, and read it on the following replay.
+            app(FlowSuspender::class)->suspend('action', $sequence);
+        }
 
         app(FlowSuspender::class)->suspend('action', $sequence);
     }

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -922,7 +922,13 @@ class ActionBuilder
         }
 
         if (! $collecting && $step->status !== ActionStatus::OptionalFailed) {
-            app(ActionRecorder::class)->optionalFail($step);
+            if (! app(ActionRecorder::class)->optionalFail($step)) {
+                // The give-up did not happen, so the fallback that stands for it is not
+                // this pass's to hand back: returning it would carry the replay past a
+                // step nothing resolved and — when what refused the write was the run
+                // ending — into work no settlement will ever close.
+                app(FlowSuspender::class)->suspend('action', $sequence);
+            }
         }
 
         return $this->resolveOptionalFailed($step, $sequence);

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -636,6 +636,8 @@ class ActionBuilder
         if ($delivered !== null
             && $this->handOverAndRetry($signal, $delivered, $step, $sequence)
             && $this->retrySurvivedCommit($step)) {
+            app(ActionRecorder::class)->publishRetried($step);
+
             $this->startRetriedStep($step, $sequence);
         }
 
@@ -768,7 +770,11 @@ class ActionBuilder
 
                     $recorder->consumeSignal($flowRun, $delivered, $sequence);
 
-                    if (! app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt())) {
+                    if (! app(ActionRecorder::class)->retryAction(
+                        $step,
+                        $this->resolvedExpiresAt(),
+                        publish: false,
+                    )) {
                         throw new FencedWriteLost;
                     }
 
@@ -812,7 +818,11 @@ class ActionBuilder
             $this->connection()->transaction(function () use ($signal, $step, $sequence): void {
                 app(SignalRecorder::class)->consumeSignal($this->runtime->run(), $signal, $sequence);
 
-                if (! app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt())) {
+                if (! app(ActionRecorder::class)->retryAction(
+                    $step,
+                    $this->resolvedExpiresAt(),
+                    publish: false,
+                )) {
                     // The row moved on under this pass. Rolling back is what keeps the
                     // delivery: a consumed signal with no cycle behind it would pay for
                     // a retry nobody ran, and no later pass looks for it again.
@@ -828,6 +838,8 @@ class ActionBuilder
         if (! $this->retrySurvivedCommit($step)) {
             app(FlowSuspender::class)->suspend('action', $sequence);
         }
+
+        app(ActionRecorder::class)->publishRetried($step);
 
         $this->startRetriedStep($step, $sequence);
     }

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -629,11 +629,14 @@ class ActionBuilder
         $delivered = app(SignalRepository::class)
             ->earliestPendingSince($this->runtime->run()->id, $signal->name, $step->finished_at);
 
-        // Close the spent wait-signal and bind the floating row to this ordinal, so no
-        // later await consumes the same signal twice. A lost claim means a delivery
-        // landed in the wait-signal itself, which the next replay resolves.
-        if ($delivered !== null && $this->handOverDelivery($signal, $delivered, $sequence)) {
-            $this->retryNow($step, $sequence);
+        // Close the spent wait-signal, bind the floating row to this ordinal so no later
+        // await consumes the same signal twice, and spend the cycle it pays for — all
+        // three together. A lost claim means a delivery landed in the wait-signal itself,
+        // which the next replay resolves.
+        if ($delivered !== null
+            && $this->handOverAndRetry($signal, $delivered, $step, $sequence)
+            && $this->retrySurvivedCommit($step)) {
+            $this->startRetriedStep($step, $sequence);
         }
 
         $suspender->suspend('action', $sequence);
@@ -739,27 +742,41 @@ class ActionBuilder
     }
 
     /**
-     * Close a spent wait-signal and claim the floating delivery that ended its wait,
-     * atomically. Returns false when the signal is no longer Waiting: it received a
-     * delivery of its own, which the next replay resolves.
+     * Close a spent wait-signal, claim the floating delivery that ended its wait, and
+     * spend the cycle it pays for — one transition, so a delivery is never consumed
+     * without the retry it bought. Returns false when nothing was written: the wait
+     * received a delivery of its own, or the step moved on under this pass; either way
+     * the next replay resolves it from the row as it stands.
      *
      * @throws Throwable
      */
-    private function handOverDelivery(FlowSignal $signal, FlowSignal $delivered, int $sequence): bool
-    {
+    private function handOverAndRetry(
+        FlowSignal $signal,
+        FlowSignal $delivered,
+        ActionRun $step,
+        int $sequence
+    ): bool {
         $recorder = app(SignalRecorder::class);
         $flowRun = $this->runtime->run();
 
-        return (bool) $this->connection()
-            ->transaction(function () use ($recorder, $flowRun, $signal, $delivered, $sequence): bool {
-                if (! $recorder->consumeWhileWaiting($flowRun, $signal, $sequence)) {
-                    return false;
-                }
+        try {
+            return (bool) $this->connection()
+                ->transaction(function () use ($recorder, $flowRun, $signal, $delivered, $step, $sequence): bool {
+                    if (! $recorder->consumeWhileWaiting($flowRun, $signal, $sequence)) {
+                        return false;
+                    }
 
-                $recorder->consumeSignal($flowRun, $delivered, $sequence);
+                    $recorder->consumeSignal($flowRun, $delivered, $sequence);
 
-                return true;
-            });
+                    if (! app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt())) {
+                        throw new FencedWriteLost;
+                    }
+
+                    return true;
+                });
+        } catch (FencedWriteLost) {
+            return false;
+        }
     }
 
     /**

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -18,6 +18,7 @@ use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionClaimFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\HistoryContractMismatchException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FencedWriteLost;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\InternalFlowControl;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
@@ -744,20 +745,54 @@ class ActionBuilder
     }
 
     /**
+     * Whether the cycle this pass spent is on record now its transaction has closed. A
+     * commit reporting success is not proof: the rewind records a flow_events row inside
+     * that transaction, so a host observer on it runs there too, and on PostgreSQL a
+     * failing statement it swallows turns the commit into a rollback while still
+     * reporting success — the trap ActionRecorder::claimSurvivedCommit() exists for.
+     * Starting the step on a rewind that was undone claims a row still parked, and that
+     * failure reaches the drive loop as a business one.
+     */
+    private function retrySurvivedCommit(ActionRun $step): bool
+    {
+        $generation = $step->newQuery()
+            ->useWritePdo()
+            ->whereKey($step->getKey())
+            ->value('retry_signal_attempts');
+
+        return (int) $generation === $step->retry_signal_attempts;
+    }
+
+    /**
      * @throws FlowSuspended
      * @throws Throwable
      */
     private function consumeAndRetry(FlowSignal $signal, ActionRun $step, int $sequence): never
     {
-        // Spending the signal and spending the cycle it pays for are one transition:
-        // a crash between them would leave the signal Consumed and the step Failed,
-        // and the next replay — which only looks for an unconsumed signal — would park
-        // again for a delivery nobody owes. Starting the step stays outside.
-        $this->connection()->transaction(function () use ($signal, $step, $sequence): void {
-            app(SignalRecorder::class)->consumeSignal($this->runtime->run(), $signal, $sequence);
+        try {
+            // Spending the signal and spending the cycle it pays for are one transition:
+            // a crash between them would leave the signal Consumed and the step Failed,
+            // and the next replay — which only looks for an unconsumed signal — would park
+            // again for a delivery nobody owes. Starting the step stays outside.
+            $this->connection()->transaction(function () use ($signal, $step, $sequence): void {
+                app(SignalRecorder::class)->consumeSignal($this->runtime->run(), $signal, $sequence);
 
-            app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt());
-        });
+                if (! app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt())) {
+                    // The row moved on under this pass. Rolling back is what keeps the
+                    // delivery: a consumed signal with no cycle behind it would pay for
+                    // a retry nobody ran, and no later pass looks for it again.
+                    throw new FencedWriteLost;
+                }
+            });
+        } catch (FencedWriteLost) {
+            // Nothing was written, so the row still says what it says. Wait for the pass
+            // that did move it, and resolve from the row as it stands next time.
+            app(FlowSuspender::class)->suspend('action', $sequence);
+        }
+
+        if (! $this->retrySurvivedCommit($step)) {
+            app(FlowSuspender::class)->suspend('action', $sequence);
+        }
 
         $this->startRetriedStep($step, $sequence);
     }
@@ -780,7 +815,10 @@ class ActionBuilder
      */
     private function retryNow(ActionRun $step, int $sequence): never
     {
-        app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt());
+        if (! app(ActionRecorder::class)->retryAction($step, $this->resolvedExpiresAt())) {
+            // Dispatching now would send a job for a row this pass did not rewind.
+            app(FlowSuspender::class)->suspend('action', $sequence);
+        }
 
         $this->startRetriedStep($step, $sequence);
     }

--- a/src/Exceptions/Internal/FencedWriteLost.php
+++ b/src/Exceptions/Internal/FencedWriteLost.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal;
+
+use Exception;
+
+/**
+ * Thrown inside a transaction whose action_runs write was refused, purely to roll the
+ * rest of that transaction back — the flow_signals row written beside it must not stand
+ * for a step transition that did not happen.
+ *
+ * It is caught by the seam that opened the transaction and never leaves it — three of
+ * them park, consume-and-retry, and hand a floating delivery over. It is not an
+ * InternalFlowControl: the drive loop must not read it as a suspension, and the seam
+ * decides what the losing pass does instead.
+ */
+final class FencedWriteLost extends Exception {}

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -5,6 +5,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Models;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\Concerns\UsesSagaFlowConnection;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Concerns\HasUlids;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -60,6 +61,22 @@ class FlowRun extends Model
             'repair_attempts' => 'integer',
             'repair_available_at' => 'datetime',
         ];
+    }
+
+    /**
+     * Constrain a flow_runs query to runs that have not finished. The engine reads
+     * this in three places — the two sweeps that must not pick up work belonging to a
+     * finished run, and the fenced action writes that must not move a settled row —
+     * and they have to agree, because a run counted live by one and finished by
+     * another is exactly the gap a leftover row survives in.
+     *
+     * A run mid-rollback is still live here: Cancelling is not terminal.
+     *
+     * @param  Builder<FlowRun>  $query
+     */
+    public static function live(Builder $query): void
+    {
+        $query->whereNotIn('status', FlowStatus::terminal());
     }
 
     /**

--- a/src/Repositories/EloquentActionRunRepository.php
+++ b/src/Repositories/EloquentActionRunRepository.php
@@ -4,10 +4,8 @@ namespace DiscoveryUkraine\SagaLaraFlow\Repositories;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
-use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class EloquentActionRunRepository implements ActionRunRepository
@@ -26,7 +24,7 @@ class EloquentActionRunRepository implements ActionRunRepository
             ->whereIn('status', [ActionStatus::Pending, ActionStatus::Running])
             ->whereNotNull('expires_at')
             ->where('expires_at', '<=', Carbon::now())
-            ->whereHas('flowRun', $this->liveRun(...))
+            ->whereHas('flowRun', FlowRun::live(...))
             ->orderBy('expires_at')
             ->limit($limit)
             ->get();
@@ -46,7 +44,7 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
-            ->whereHas('flowRun', $this->liveRun(...))
+            ->whereHas('flowRun', FlowRun::live(...))
             ->orderBy('created_at')
             ->limit($limit)
             ->get();
@@ -74,23 +72,10 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
-            ->whereHas('flowRun', $this->liveRun(...))
+            ->whereHas('flowRun', FlowRun::live(...))
             ->orderBy('reclaim_stale_at')
             ->limit($limit)
             ->get();
-    }
-
-    /**
-     * Never hand a sweep a step whose run has already finished. Terminal settlement
-     * leaves only rows written before it existed, but they are enough to starve a sweep:
-     * every guard that rejects them returns before any throttle is bumped, so the same
-     * rows come back at the head of every batch, oldest-first, for ever.
-     *
-     * @param  Builder<FlowRun>  $query
-     */
-    private function liveRun(Builder $query): void
-    {
-        $query->whereNotIn('status', FlowStatus::terminal());
     }
 
     /**

--- a/src/Repositories/EloquentSignalRepository.php
+++ b/src/Repositories/EloquentSignalRepository.php
@@ -4,11 +4,9 @@ namespace DiscoveryUkraine\SagaLaraFlow\Repositories;
 
 use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
-use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 
 class EloquentSignalRepository implements SignalRepository
@@ -70,22 +68,10 @@ class EloquentSignalRepository implements SignalRepository
             ->where('status', SignalStatus::Waiting)
             ->whereNotNull('timeout_at')
             ->where('timeout_at', '<=', Carbon::now())
-            ->whereHas('flowRun', $this->liveRun(...))
+            ->whereHas('flowRun', FlowRun::live(...))
             ->orderBy('timeout_at')
             ->limit($limit)
             ->get();
-    }
-
-    /**
-     * Never hand the sweep a wait whose run has already finished. Terminal settlement
-     * leaves only rows written before it existed, but timeoutSignal() rejects them with
-     * no counter to hold them off, so one would sit at the head of every batch for ever.
-     *
-     * @param  Builder<FlowRun>  $query
-     */
-    private function liveRun(Builder $query): void
-    {
-        $query->whereNotIn('status', FlowStatus::terminal());
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -505,15 +505,29 @@ final readonly class ActionRecorder
      * instead of comparing the attempts counter with the action's $tries, which lives
      * in code and can change under a job already in flight. No event is appended —
      * this is queue bookkeeping, not a step in the flow's history.
+     *
+     * Fenced on the cycle the caller read, because the flag is read back as "the queue
+     * has finished with this row": a hook reporting for a spent cycle would tell the
+     * seam that a cycle rewound in the meantime is over before its job has run, and the
+     * seam would spend a retry on a step still in flight.
      */
-    public function markQueueAttemptsExhausted(ActionRun $actionRun): void
+    public function markQueueAttemptsExhausted(ActionRun $actionRun): bool
     {
         if ($actionRun->queue_attempts_exhausted) {
-            return;
+            return false;
         }
 
         $actionRun->queue_attempts_exhausted = true;
-        $actionRun->save();
+
+        return $this->writeFenced($actionRun, [
+            'queue_attempts_exhausted' => false,
+            // The status too. A claim does not move the cycle — it moves the row to
+            // Running and raises `attempts` — so without this the hook's spent view of a
+            // Failed row still matches the live attempt running under it, and tells the
+            // seam the queue is finished with a job that has only just started.
+            'status' => $actionRun->getOriginal('status'),
+            'retry_signal_attempts' => $actionRun->getOriginal('retry_signal_attempts'),
+        ], 'queue_attempts_exhausted');
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -392,16 +392,99 @@ final readonly class ActionRecorder
     }
 
     /**
+     * Persist the pending attribute changes only if the row is still the one the caller
+     * read and the run under it has not finished. The values come from getDirty(), so
+     * the model's own casts encode them exactly as save() would; $expected names the
+     * stored values the caller's decision rested on, and the run's liveness rides in the
+     * same statement rather than a read before it, so no row this pass already saw can
+     * move between the check and the write.
+     *
+     * It fences against what is committed, which is what terminal settlement leaves
+     * behind, and not against a transition still in flight — that one is invisible to a
+     * snapshot until it commits. The values are dirty attributes, so a caller with
+     * nothing to write would report a refusal it never made; every site reaches this
+     * with a change.
+     *
+     * Every $expected key that the write also sets names the value being REPLACED, so a
+     * matching row always changes — which keeps the count off the zero MySQL reports for
+     * an update that changed nothing and FlowStateMachine::write() has to disambiguate.
+     *
+     * @param  array<string, mixed|list<mixed>>  $expected
+     * @param  array<string, mixed>  $context
+     */
+    private function writeFenced(ActionRun $actionRun, array $expected, string $site, array $context = []): bool
+    {
+        $query = $actionRun->newQuery()
+            ->whereKey($actionRun->getKey())
+            ->whereHas('flowRun', FlowRun::live(...));
+
+        foreach ($expected as $column => $value) {
+            match (true) {
+                is_array($value) => $query->whereIn($column, $value),
+                // `= NULL` matches nothing in SQL, so a caller expecting an empty column
+                // would silently never write rather than be fenced on what it read.
+                $value === null => $query->whereNull($column),
+                default => $query->where($column, $value),
+            };
+        }
+
+        $written = $query->update($actionRun->getDirty()) === 1;
+
+        if (! $written) {
+            $this->anomalies->log(AnomalyLog::REASON_WRITE_REFUSED, [
+                'entity' => 'action',
+                'site' => $site,
+                'flow_run_id' => $actionRun->flow_run_id,
+                'action_run_id' => $actionRun->id,
+                'sequence' => $actionRun->sequence,
+                'action_class' => $actionRun->action_class,
+                ...$context,
+            ]);
+
+            // Leave the model saying what the database says. The caller carries on with
+            // this instance — the seam resolves the step from it — and an attribute the
+            // write did not land would otherwise be read back as though it had, and be
+            // carried into the next write's getDirty() under a fence that never named it.
+            $actionRun->discardChanges();
+
+            return false;
+        }
+
+        $actionRun->syncOriginal();
+
+        return true;
+    }
+
+    /**
      * Mark a failed optional (continueOnFailure) step as OptionalFailed once its
      * retries are exhausted. The flow is not failed; the recorded exception is
      * preserved and an optional_failed event/Laravel event is appended so the
      * give-up is visible in history.
+     *
+     * Refused, with nothing written and no event appended, when the row has moved on
+     * since it was read or the run under it has finished: a give-up recorded onto a
+     * settled run says a fallback was taken that no replay will ever reach.
      */
-    public function optionalFail(ActionRun $actionRun): void
+    public function optionalFail(ActionRun $actionRun): bool
     {
+        // The row as read, not a named status: a give-up arrives on Failed when the
+        // attempt ended it and on AwaitingRetry when a timed-out wait did, and naming
+        // both would let this write take a row another pass had just parked.
+        //
+        // The cycle too, not the status alone. A row can leave Failed for a retry and
+        // come back to it, so status by itself cannot tell this generation from the next
+        // one, and a hook holding the spent cycle would end a live one with a fallback.
+        $asRead = [
+            'status' => $actionRun->getOriginal('status'),
+            'retry_signal_attempts' => $actionRun->getOriginal('retry_signal_attempts'),
+        ];
+
         $actionRun->status = ActionStatus::OptionalFailed;
         $actionRun->finished_at = Carbon::now();
-        $actionRun->save();
+
+        if (! $this->writeFenced($actionRun, $asRead, 'optional_fail')) {
+            return false;
+        }
 
         $this->events->record(
             $actionRun->flowRun,
@@ -412,6 +495,8 @@ final readonly class ActionRecorder
         );
 
         event(new OptionalActionFailed($actionRun));
+
+        return true;
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -160,6 +160,11 @@ final readonly class ActionRecorder
      * stale-cycle check into this same atomic write so a cycle change landing after
      * the row was read still loses the claim. Null imposes no constraint.
      *
+     * The run's liveness is folded in the same way, and for a reason the row cannot see
+     * on its own: terminal settlement leaves a Failed row — the state between two of the
+     * queue's own native tries — exactly as it found it, so without this a job already on
+     * the queue when the run was cancelled still claims it and runs the business logic.
+     *
      * The claim and its two records share one transaction: a listener throwing on
      * ActionStarted would otherwise leave the row Running with nothing executing it.
      * A commit is not proof the claim survived one, so the row is read back afterwards
@@ -180,6 +185,7 @@ final readonly class ActionRecorder
 
                 $claimed = $actionRun->newQuery()
                     ->whereKey($actionRun->getKey())
+                    ->whereHas('flowRun', FlowRun::live(...))
                     ->when(
                         $expectedRetryGeneration !== null,
                         fn ($query) => $query->where('retry_signal_attempts', $expectedRetryGeneration),

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -646,8 +646,11 @@ final readonly class ActionRecorder
      * back into the run's open work — and back into the doctor's reach — under a run
      * that has already finished.
      */
-    public function retryAction(ActionRun $actionRun, ?DateTimeInterface $expiresAt = null): bool
-    {
+    public function retryAction(
+        ActionRun $actionRun,
+        ?DateTimeInterface $expiresAt = null,
+        bool $publish = true
+    ): bool {
         $asRead = [
             'status' => $actionRun->getOriginal('status'),
             'retry_signal_attempts' => $actionRun->getOriginal('retry_signal_attempts'),
@@ -683,6 +686,23 @@ final readonly class ActionRecorder
             return false;
         }
 
+        if ($publish) {
+            $this->publishRetried($actionRun);
+        }
+
+        return true;
+    }
+
+    /**
+     * Append the retry to the run's history and tell the host about it. Separate from the
+     * write because a caller that rewinds inside a transaction of its own must publish
+     * after it closes: ActionRetried is dispatched after commit, and Laravel drains those
+     * callbacks inside transaction(), so on PostgreSQL — where a swallowed failure turns
+     * the commit into a rollback while still reporting success — a listener would run for
+     * a rewind the database threw away. Nothing can take that back afterwards.
+     */
+    public function publishRetried(ActionRun $actionRun): void
+    {
         $this->events->record(
             $actionRun->flowRun,
             FlowEventType::ActionRetried,
@@ -696,8 +716,6 @@ final readonly class ActionRecorder
         );
 
         event(new ActionRetried($actionRun));
-
-        return true;
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -587,9 +587,19 @@ final readonly class ActionRecorder
      * action.awaiting_retry event. The step is NOT terminal — the recorded exception
      * and finished_at of the last attempt are kept so the seam can decide again once
      * the signal arrives (or the wait-signal times out).
+     *
+     * Fenced on the failure being parked and the cycle it belongs to. A park that lands
+     * after terminal settlement would give a finished run a step claiming to be waiting
+     * and a wait nothing will ever resolve: settlement runs once, and every sweep that
+     * could reach them skips a finished run on purpose.
      */
-    public function awaitRetry(ActionRun $actionRun, string $signal, ?int $maxAttempts = null): void
+    public function awaitRetry(ActionRun $actionRun, string $signal, ?int $maxAttempts = null): bool
     {
+        $asRead = [
+            'status' => $actionRun->getOriginal('status'),
+            'retry_signal_attempts' => $actionRun->getOriginal('retry_signal_attempts'),
+        ];
+
         $actionRun->status = ActionStatus::AwaitingRetry;
         $actionRun->retry_signal = $signal;
 
@@ -598,7 +608,9 @@ final readonly class ActionRecorder
         // row, so an empty column would silently mean unbounded.
         $actionRun->retry_signal_max_attempts ??= $maxAttempts;
 
-        $actionRun->save();
+        if (! $this->writeFenced($actionRun, $asRead, 'await_retry')) {
+            return false;
+        }
 
         $this->events->record(
             $actionRun->flowRun,
@@ -613,6 +625,8 @@ final readonly class ActionRecorder
         );
 
         event(new ActionAwaitingRetry($actionRun, $signal));
+
+        return true;
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -620,9 +620,19 @@ final readonly class ActionRecorder
      * the row to Pending so the very same (flow_run_id, sequence) ordinal runs again.
      * `attempts` is deliberately untouched — it counts queue attempts within one
      * execution — and the previous exception stands until the new attempt overwrites it.
+     *
+     * Fenced on the status and the cycle the caller read. Terminal settlement closes a
+     * parked step as Cancelled, and rewinding that to Pending would put a settled step
+     * back into the run's open work — and back into the doctor's reach — under a run
+     * that has already finished.
      */
-    public function retryAction(ActionRun $actionRun, ?DateTimeInterface $expiresAt = null): void
+    public function retryAction(ActionRun $actionRun, ?DateTimeInterface $expiresAt = null): bool
     {
+        $asRead = [
+            'status' => $actionRun->getOriginal('status'),
+            'retry_signal_attempts' => $actionRun->getOriginal('retry_signal_attempts'),
+        ];
+
         $actionRun->retry_signal_attempts = $actionRun->retry_signal_attempts + 1;
         $actionRun->status = ActionStatus::Pending;
         $actionRun->started_at = null;
@@ -648,7 +658,10 @@ final readonly class ActionRecorder
         $deadline = $expiresAt ?? $this->defaultExpiry();
 
         $actionRun->expires_at = $deadline === null ? null : Carbon::instance($deadline);
-        $actionRun->save();
+
+        if (! $this->writeFenced($actionRun, $asRead, 'retry_action')) {
+            return false;
+        }
 
         $this->events->record(
             $actionRun->flowRun,
@@ -663,6 +676,8 @@ final readonly class ActionRecorder
         );
 
         event(new ActionRetried($actionRun));
+
+        return true;
     }
 
     /**

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -521,15 +521,25 @@ final readonly class ActionRecorder
      * retry policy deferred, keeping the exception and finished_at of the attempt that
      * failed. No event is appended — action.failed was recorded back then, and the
      * give-up is visible from the flow's own failure and the timed-out wait-signal.
+     *
+     * Returns whether this call settled the row. The early return covers a row this
+     * caller can already see is not parked; the fence covers the row that stopped being
+     * parked after it was read — terminal settlement leaves Cancelled behind, and
+     * writing Failed over it would put a settled step back into the run's open work.
      */
-    public function settleAwaitingRetry(ActionRun $actionRun): void
+    public function settleAwaitingRetry(ActionRun $actionRun): bool
     {
         if ($actionRun->status !== ActionStatus::AwaitingRetry) {
-            return;
+            return false;
         }
 
         $actionRun->status = ActionStatus::Failed;
-        $actionRun->save();
+
+        return $this->writeFenced(
+            $actionRun,
+            ['status' => ActionStatus::AwaitingRetry],
+            'settle_awaiting_retry',
+        );
     }
 
     /**

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -11,9 +11,10 @@ use Throwable;
  * EventLog records what happened to a run in business terms. This records the moments
  * where the world turned out not to be what the engine assumed — a claim lost to
  * whoever already owned the row, a claim the transaction that made it did not keep, an
- * outcome write refused because the row had changed hands, a batch already closed by a
- * duplicate before its own job reported, a run transition refused because the row had
- * moved on, a retry policy that threw, an overdue run whose rollback could not be
+ * outcome write refused because the row had changed hands, a step write refused because
+ * the row had moved on since it was read, a batch already closed by a duplicate before
+ * its own job reported, a run transition refused because the row had moved on, a retry
+ * policy that threw, an overdue run whose rollback could not be
  * planned. Most are ordinary consequences of at-least-once delivery and of nothing
  * serialising an operator against a worker; the claim that did not commit and the last
  * two are defects in the caller's own code, journalled here for the same reason as the
@@ -43,6 +44,8 @@ final readonly class AnomalyLog
     public const string REASON_RETRY_POLICY_THREW = 'retry_policy_threw';
 
     public const string REASON_EXPIRY_FAILED = 'expiry_failed';
+
+    public const string REASON_WRITE_REFUSED = 'write_refused';
 
     /**
      * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -581,3 +581,31 @@ it('claims a step normally while the run is still live', function () {
         ->and(FlakyPaymentAction::$calls)->toBe(1)
         ->and($step->fresh()->status)->toBe(ActionStatus::Completed);
 });
+
+/**
+ * MySQL counts the rows an UPDATE changed, not the rows it matched, so a write whose
+ * every value already equals what is stored reports zero there and one on SQLite and
+ * PostgreSQL — the ambiguity FlowStateMachine::write() has to read the row back to
+ * resolve. These writes carry no such branch, because every fence names the value it is
+ * replacing: a row that matches always changes, so zero always means the fence lost.
+ *
+ * The flag write is the only one whose target could already be stored, which makes it
+ * the one that proves the invariant.
+ */
+it('gives the same answer on every driver when the stored value is already the target', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'retry_signal' => 'balance-refilled',
+        'queue_attempts_exhausted' => false,
+    ]);
+
+    $asRead = ActionRun::query()->findOrFail($step->id);
+
+    // Another delivery of the same hook got there first.
+    ActionRun::query()->whereKey($step->id)->update(['queue_attempts_exhausted' => true]);
+
+    // The fence names queue_attempts_exhausted = false, so this cannot be an update
+    // that changes nothing: it is a fence that does not match, on every driver alike.
+    expect(app(ActionRecorder::class)->markQueueAttemptsExhausted($asRead))->toBeFalse()
+        ->and($step->fresh()->queue_attempts_exhausted)->toBeTrue();
+});

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -4,11 +4,17 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SelfCancellingBeforeParkWorkflow;
+use Illuminate\Support\Facades\Event;
 
 /**
  * Every write to an action_runs row now states the row it expects to find, and the
@@ -23,6 +29,7 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
  */
 beforeEach(function () {
     FlakyPaymentAction::reset();
+    SelfCancellingBeforeParkWorkflow::reset();
 
     config()->set('saga-lara-flow.queue.after_commit', false);
 });
@@ -240,4 +247,90 @@ it('refuses a give-up from a cycle the row has already left and returned from', 
     expect($recorder->optionalFail($spentCycle))->toBeFalse()
         ->and($step->fresh()->status)->toBe(ActionStatus::Failed)
         ->and($step->fresh()->retry_signal_attempts)->toBe(1);
+});
+
+it('writes no retry state when a cancellation lands before the park', function () {
+    FlakyPaymentAction::reset(failures: 5);
+
+    // The cancellation the issue describes: a separate request landing between the
+    // failure being recorded and the park committing. A listener puts it exactly there.
+    $cancelled = null;
+
+    Event::listen(ActionFailed::class, function (ActionFailed $event) use (&$cancelled): void {
+        $cancelled = $event->actionRun->flow_run_id;
+
+        SagaFlow::findRun($cancelled)->markCancelled();
+    });
+
+    try {
+        SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-probe')->runSync();
+    } catch (Throwable) {
+        // The cancellation is the setup; the rows it leaves behind are the assertion.
+    }
+
+    $run = FlowRun::query()->findOrFail($cancelled);
+
+    expect($run->status)->toBe(FlowStatus::Cancelled)
+        ->and($run->actions()->pluck('status')->all())->not->toContain(ActionStatus::AwaitingRetry)
+        ->and($run->signals()->pluck('status')->all())->not->toContain(SignalStatus::Waiting)
+        ->and($run->events()->pluck('type')->all())->not->toContain('action.awaiting_retry');
+});
+
+it('writes no retry state when the run ends during the replay that parks, on the queue', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 5);
+    SelfCancellingBeforeParkWorkflow::$armed = true;
+
+    // A cancellation arriving before this replay could not reach the park at all: the
+    // drive loop transitions to Running first, which no terminal status allows. So the
+    // run is ended from inside the pass that is about to park — the window the queued
+    // path really has, staged in one process.
+    $handle = SagaFlow::create(SelfCancellingBeforeParkWorkflow::class)
+        ->withArguments('order-probe')
+        ->run();
+
+    try {
+        drainQueue();
+    } catch (Throwable) {
+        // The cancellation is the setup; the rows it leaves behind are the assertion.
+    }
+
+    $run = FlowRun::query()->findOrFail($handle->id);
+
+    expect($run->status)->toBe(FlowStatus::Cancelled)
+        ->and($run->actions()->pluck('status')->all())->not->toContain(ActionStatus::AwaitingRetry)
+        ->and($run->signals()->pluck('status')->all())->not->toContain(SignalStatus::Waiting)
+        ->and($run->events()->pluck('type')->all())->not->toContain('action.awaiting_retry');
+});
+
+/**
+ * Two replays reading the same failed generation both try to park it. Only one can
+ * win, and the one that loses must not carry the state it failed to write into the
+ * next decision it makes — it holds a model saying AwaitingRetry over a row the winner
+ * parked, and the give-up that follows would take that row and orphan the winner's wait.
+ */
+it('does not let a losing park take the row the winning park wrote', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'continue_on_failure' => true,
+        'retry_signal' => 'balance-refilled',
+    ]);
+
+    $winner = ActionRun::query()->findOrFail($step->id);
+    $loser = ActionRun::query()->findOrFail($step->id);
+
+    $recorder = app(ActionRecorder::class);
+
+    expect($recorder->awaitRetry($winner, 'balance-refilled', null))->toBeTrue()
+        ->and($recorder->awaitRetry($loser, 'balance-refilled', null))->toBeFalse();
+
+    // A refused write leaves the model saying what the database says, so nothing it
+    // failed to write is carried into the next one.
+    expect($loser->status)->toBe(ActionStatus::Failed)
+        ->and($loser->getDirty())->toBe([]);
+
+    // The give-up the losing replay would go on to record must find the row it read,
+    // not the row the winner parked.
+    expect($recorder->optionalFail($loser))->toBeFalse()
+        ->and($step->fresh()->status)->toBe(ActionStatus::AwaitingRetry);
 });

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -98,3 +98,29 @@ it('records a give-up for a step whose wait timed out on an awaiting_retry row',
     expect(app(ActionRecorder::class)->optionalFail($step))->toBeTrue()
         ->and($step->fresh()->status)->toBe(ActionStatus::OptionalFailed);
 });
+
+it('refuses to settle a parked step that terminal settlement has already closed', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::AwaitingRetry, ['retry_signal' => 'balance-refilled']);
+
+    // The seam is holding the row it read before the cancellation landed.
+    $asRead = ActionRun::query()->findOrFail($step->id);
+
+    $run->markCancelled();
+
+    // Settlement closed it; the in-memory copy the seam holds still says otherwise, so
+    // the early return does not fire and only the fence stands between the two.
+    expect($step->fresh()->status)->toBe(ActionStatus::Cancelled)
+        ->and($asRead->status)->toBe(ActionStatus::AwaitingRetry);
+
+    expect(app(ActionRecorder::class)->settleAwaitingRetry($asRead))->toBeFalse()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Cancelled);
+});
+
+it('settles a parked step normally while the run is still live', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::AwaitingRetry, ['retry_signal' => 'balance-refilled']);
+
+    expect(app(ActionRecorder::class)->settleAwaitingRetry($step))->toBeTrue()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Failed);
+});

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -9,6 +9,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
@@ -436,13 +437,15 @@ it('spends a floating delivery on the retry cycle it pays for', function () {
 
 /**
  * The handover writes the wait's closure, the delivery's consumption and the rewind in
- * one transaction, so the rewind's own flow_events row is written inside it — and a host
- * observer on that row is caller code running there. On PostgreSQL a failing statement it
- * swallows aborts the whole transaction and turns the eventual commit into a rollback
- * while still reporting success. Starting the step on that would claim a row the database
- * still has parked, and the drive loop reads that failure as a business one.
+ * one transaction, so an observer on the retry's own history row is caller code running
+ * inside it. On PostgreSQL a failing statement it swallows aborts the whole transaction
+ * and turns the eventual commit into a rollback while still reporting success — and
+ * ActionRetried is dispatched after commit, which Laravel drains inside transaction().
+ * A listener would then run for a rewind the database threw away, and nothing can take
+ * that back. Published after the read-back instead, the observer runs outside the
+ * transaction, where it can harm nothing.
  */
-it('verifies the handover committed before starting the retry it bought', function () {
+it('tells the host about a retry only when the database has one', function () {
     if (DB::connection('testing')->getDriverName() !== 'pgsql') {
         $this->markTestSkipped('Only PostgreSQL turns a commit into a rollback after a swallowed failure.');
     }
@@ -458,8 +461,7 @@ it('verifies the handover committed before starting the retry it bought', functi
     $run = FlowRun::query()->where('workflow_class', RetryOnSignalWorkflow::class)->latest('id')->firstOrFail();
     $step = $run->actions()->where('sequence', 1)->firstOrFail();
 
-    // A delivery that never matched the wait-signal, which is what the handover exists to
-    // take. The step stays AwaitingRetry: only a parked step reaches that branch.
+    // A delivery that never matched the wait-signal, which is what the handover takes.
     FlowSignal::create([
         'flow_run_id' => $run->id,
         'name' => 'balance-refilled',
@@ -479,17 +481,22 @@ it('verifies the handover committed before starting the retry it bought', functi
         }
     });
 
+    $retried = 0;
+
+    Event::listen(ActionRetried::class, function () use (&$retried): void {
+        $retried++;
+    });
+
     try {
         app(FlowExecutor::class)->drive($run->fresh(), RunMode::Sync);
     } catch (Throwable) {
-        // The poisoned transaction is the setup.
+        // The step runs again and fails again; the cycle is what matters here.
     }
 
-    // The run is untouched, not failed over a cycle the database threw away.
-    expect($run->fresh()->status)->toBe(FlowStatus::Waiting)
-        ->and($step->fresh()->status)->toBe(ActionStatus::AwaitingRetry)
-        ->and($step->fresh()->retry_signal_attempts)->toBe(0)
-        ->and($run->compensations()->count())->toBe(0);
+    // What the host was told and what the row holds have to agree. Published from inside,
+    // the event goes out while the cycle behind it is rolled back.
+    expect($retried)->toBe(1)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(1);
 });
 
 /**

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+
+/**
+ * Every write to an action_runs row now states the row it expects to find, and the
+ * run's liveness rides in the same UPDATE. Without that a worker, a queue hook or a
+ * replay holding a row it read a moment ago writes over whatever happened since —
+ * most visibly over terminal settlement, which runs once and never again, so anything
+ * written after it stands for ever with nothing left to notice it.
+ *
+ * The window needs no race to open. Terminal settlement closes Pending, Running and
+ * AwaitingRetry rows; a Failed row — the state between two of the queue's own native
+ * tries — it leaves alone, and every one of these writers accepts a Failed row.
+ */
+beforeEach(function () {
+    FlakyPaymentAction::reset();
+
+    config()->set('saga-lara-flow.queue.after_commit', false);
+});
+
+function fencedFlowRun(FlowStatus $status = FlowStatus::Waiting): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => $status,
+        'arguments' => [],
+    ]);
+}
+
+/**
+ * @param  array<string, mixed>  $extra
+ */
+function fencedStep(FlowRun $run, ActionStatus $status, array $extra = []): ActionRun
+{
+    $step = ActionRun::create(array_merge([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => FlakyPaymentAction::class,
+        'arguments' => app(Serializer::class)->serialize(['order-1']),
+        'status' => $status,
+        'reclaim_stale_after_seconds' => 900,
+        'attempts' => 1,
+    ], $extra));
+
+    // Read back, so the model carries every column the schema defaulted — which is what
+    // a row reaching any of these writers in production always has.
+    return $step->refresh();
+}
+
+it('refuses to record a give-up on a step whose run has already finished', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, ['continue_on_failure' => true]);
+
+    $run->markCancelled();
+
+    // Settlement leaves a Failed row exactly as it found it, which is what makes this
+    // reachable without a race at all.
+    expect($step->fresh()->status)->toBe(ActionStatus::Failed);
+
+    $written = app(ActionRecorder::class)->optionalFail($step->fresh());
+
+    expect($written)->toBeFalse()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Failed)
+        ->and($step->fresh()->finished_at)->toBeNull()
+        ->and($run->events()->pluck('type')->all())->not->toContain('action.optional_failed');
+});
+
+it('records a give-up normally while the run is still live', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, ['continue_on_failure' => true]);
+
+    $written = app(ActionRecorder::class)->optionalFail($step);
+
+    expect($written)->toBeTrue()
+        ->and($step->fresh()->status)->toBe(ActionStatus::OptionalFailed)
+        ->and($step->fresh()->finished_at)->not->toBeNull();
+});
+
+it('records a give-up for a step whose wait timed out on an awaiting_retry row', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::AwaitingRetry, [
+        'continue_on_failure' => true,
+        'retry_signal' => 'balance-refilled',
+    ]);
+
+    // The optional branch of a timed-out wait never runs settleAwaitingRetry(), so the
+    // row is still AwaitingRetry here. Measured on the suite: this arrives alongside
+    // Failed, and a fence naming only Failed would refuse a legitimate give-up.
+    expect(app(ActionRecorder::class)->optionalFail($step))->toBeTrue()
+        ->and($step->fresh()->status)->toBe(ActionStatus::OptionalFailed);
+});

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -186,3 +186,58 @@ it('does not mark a generation exhausted while an attempt is running under it', 
         // spend a retry cycle on a step still in flight.
         ->and($step->fresh()->queue_attempts_exhausted)->toBeFalse();
 });
+
+it('refuses to rewind a step that terminal settlement has already closed', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::AwaitingRetry, ['retry_signal' => 'balance-refilled']);
+
+    $asRead = ActionRun::query()->findOrFail($step->id);
+
+    $run->markCancelled();
+
+    expect($step->fresh()->status)->toBe(ActionStatus::Cancelled);
+
+    expect(app(ActionRecorder::class)->retryAction($asRead))->toBeFalse()
+        // Rewound, this row would re-enter dueForRepair() looking live again, under a
+        // run that finished before the cycle was ever spent.
+        ->and($step->fresh()->status)->toBe(ActionStatus::Cancelled)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(0)
+        ->and($run->events()->pluck('type')->all())->not->toContain('action.retried');
+});
+
+it('rewinds a step normally while the run is still live', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::AwaitingRetry, ['retry_signal' => 'balance-refilled']);
+
+    expect(app(ActionRecorder::class)->retryAction($step))->toBeTrue()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Pending)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(1);
+});
+
+/**
+ * A row can leave Failed for a retry and come back to it, so a status-only fence cannot
+ * tell one generation from the next. A queue hook holding the spent cycle would end the
+ * live one with a fallback nobody asked for.
+ */
+it('refuses a give-up from a cycle the row has already left and returned from', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'continue_on_failure' => true,
+        'retry_signal' => 'balance-refilled',
+        'retry_signal_attempts' => 0,
+    ]);
+
+    // The old failed() hook resolved the row on cycle 0 and has not written yet.
+    $spentCycle = ActionRun::query()->findOrFail($step->id);
+
+    $recorder = app(ActionRecorder::class);
+
+    // A signal pays for cycle 1, whose attempt then fails back to Failed — the same
+    // status the hook is holding, one generation on.
+    $recorder->retryAction(ActionRun::query()->findOrFail($step->id));
+    ActionRun::query()->whereKey($step->id)->update(['status' => ActionStatus::Failed]);
+
+    expect($recorder->optionalFail($spentCycle))->toBeFalse()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Failed)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(1);
+});

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -124,3 +124,65 @@ it('settles a parked step normally while the run is still live', function () {
     expect(app(ActionRecorder::class)->settleAwaitingRetry($step))->toBeTrue()
         ->and($step->fresh()->status)->toBe(ActionStatus::Failed);
 });
+
+it('refuses queue bookkeeping for a retry cycle the row has already left', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'retry_signal' => 'balance-refilled',
+        'retry_signal_attempts' => 0,
+        'queue_attempts_exhausted' => false,
+    ]);
+
+    // RunActionJob::failed() resolved the row and passed its generation guard on cycle
+    // 0. The seam then spends a cycle before this write lands.
+    $asRead = ActionRun::query()->findOrFail($step->id);
+
+    app(ActionRecorder::class)->retryAction(ActionRun::query()->findOrFail($step->id));
+
+    expect($step->fresh()->retry_signal_attempts)->toBe(1)
+        ->and($step->fresh()->status)->toBe(ActionStatus::Pending);
+
+    expect(app(ActionRecorder::class)->markQueueAttemptsExhausted($asRead))->toBeFalse()
+        // Cycle 1's job has not run yet. Left true, ActionBuilder's Failed branch would
+        // stop waiting for the queue and spend a retry on a step still in flight.
+        ->and($step->fresh()->queue_attempts_exhausted)->toBeFalse();
+});
+
+it('records queue bookkeeping for the cycle the row is actually on', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'retry_signal' => 'balance-refilled',
+        'retry_signal_attempts' => 0,
+        'queue_attempts_exhausted' => false,
+    ]);
+
+    expect(app(ActionRecorder::class)->markQueueAttemptsExhausted($step))->toBeTrue()
+        ->and($step->fresh()->queue_attempts_exhausted)->toBeTrue();
+});
+
+/**
+ * A claim raises `attempts` and moves the row to Running; it does not move the retry
+ * cycle. So a queue hook holding the spent view of a Failed row still matches the live
+ * attempt running under it unless the status it read is part of the fence too.
+ */
+it('does not mark a generation exhausted while an attempt is running under it', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed, [
+        'retry_signal' => 'balance-refilled',
+        'retry_signal_attempts' => 0,
+        'queue_attempts_exhausted' => false,
+    ]);
+
+    // The old hook resolved the row while it was Failed and has not written yet.
+    $asRead = ActionRun::query()->findOrFail($step->id);
+
+    // A duplicate delivery claims the same cycle and starts running it.
+    expect(app(ActionRecorder::class)->startAction(ActionRun::query()->findOrFail($step->id)))->toBeTrue()
+        ->and($step->fresh()->status)->toBe(ActionStatus::Running)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(0);
+
+    expect(app(ActionRecorder::class)->markQueueAttemptsExhausted($asRead))->toBeFalse()
+        // Flagged, the seam would stop waiting for a job that has only just started and
+        // spend a retry cycle on a step still in flight.
+        ->and($step->fresh()->queue_attempts_exhausted)->toBeFalse();
+});

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -3,13 +3,18 @@
 use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
@@ -333,4 +338,152 @@ it('does not let a losing park take the row the winning park wrote', function ()
     // not the row the winner parked.
     expect($recorder->optionalFail($loser))->toBeFalse()
         ->and($step->fresh()->status)->toBe(ActionStatus::AwaitingRetry);
+});
+
+/**
+ * The floating-delivery branch spends two signal rows to buy one retry cycle. If the
+ * rewind it pays for is refused after those rows are committed, the delivery is gone and
+ * no cycle exists to show for it — and no later pass looks for it again, because both
+ * rows read as spent.
+ */
+it('does not spend a delivery on a retry cycle the row refused', function () {
+    FlakyPaymentAction::reset(failures: 5);
+
+    $handle = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-probe');
+
+    try {
+        $handle->runSync();
+    } catch (Throwable) {
+        // Parks on the retry signal.
+    }
+
+    $run = FlowRun::query()->where('workflow_class', RetryOnSignalWorkflow::class)->latest('id')->firstOrFail();
+    $step = $run->actions()->where('sequence', 1)->firstOrFail();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry);
+
+    // The step stays AwaitingRetry: the branch under test is the one that adopts a
+    // delivery which never matched the wait-signal, and only a parked step reaches it.
+    FlowSignal::create([
+        'flow_run_id' => $run->id,
+        'name' => 'balance-refilled',
+        'status' => SignalStatus::Received,
+        'received_at' => now(),
+    ]);
+
+    // The rewind loses inside the handover's own transaction: the cycle moves under this
+    // pass while it is consuming, which an observer on the signal write can stage in one
+    // process because both writes share that transaction.
+    FlowSignal::updated(function (FlowSignal $signal): void {
+        if ($signal->status === SignalStatus::Consumed) {
+            ActionRun::query()
+                ->where('flow_run_id', $signal->flow_run_id)
+                ->where('sequence', 1)
+                ->update(['retry_signal_attempts' => 7]);
+        }
+    });
+
+    try {
+        app(FlowExecutor::class)->drive($run->fresh(), RunMode::Sync);
+    } catch (Throwable) {
+        // The refusal is the setup.
+    }
+
+    $signals = $run->signals()->get();
+
+    // Neither row may read as spent: the delivery is still owed a cycle.
+    expect($signals->where('status', SignalStatus::Consumed)->count())->toBe(0)
+        ->and($signals->where('status', SignalStatus::Waiting)->count())->toBe(1)
+        ->and($signals->where('status', SignalStatus::Received)->count())->toBe(1);
+});
+
+/**
+ * The same construction with nothing moving the row underneath, so the branch above is
+ * held to a reachable path rather than passing because the replay never arrived.
+ */
+it('spends a floating delivery on the retry cycle it pays for', function () {
+    FlakyPaymentAction::reset(failures: 5);
+
+    try {
+        SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-probe')->runSync();
+    } catch (Throwable) {
+        // Parks on the retry signal.
+    }
+
+    $run = FlowRun::query()->where('workflow_class', RetryOnSignalWorkflow::class)->latest('id')->firstOrFail();
+    $step = $run->actions()->where('sequence', 1)->firstOrFail();
+
+    FlowSignal::create([
+        'flow_run_id' => $run->id,
+        'name' => 'balance-refilled',
+        'status' => SignalStatus::Received,
+        'received_at' => now(),
+    ]);
+
+    try {
+        app(FlowExecutor::class)->drive($run->fresh(), RunMode::Sync);
+    } catch (Throwable) {
+        // The step runs again and fails again; the cycle is what matters here.
+    }
+
+    expect($run->signals()->where('status', SignalStatus::Consumed)->count())->toBe(2)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(1);
+});
+
+/**
+ * The handover writes the wait's closure, the delivery's consumption and the rewind in
+ * one transaction, so the rewind's own flow_events row is written inside it — and a host
+ * observer on that row is caller code running there. On PostgreSQL a failing statement it
+ * swallows aborts the whole transaction and turns the eventual commit into a rollback
+ * while still reporting success. Starting the step on that would claim a row the database
+ * still has parked, and the drive loop reads that failure as a business one.
+ */
+it('verifies the handover committed before starting the retry it bought', function () {
+    if (DB::connection('testing')->getDriverName() !== 'pgsql') {
+        $this->markTestSkipped('Only PostgreSQL turns a commit into a rollback after a swallowed failure.');
+    }
+
+    FlakyPaymentAction::reset(failures: 5);
+
+    try {
+        SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-probe')->runSync();
+    } catch (Throwable) {
+        // Parks on the retry signal.
+    }
+
+    $run = FlowRun::query()->where('workflow_class', RetryOnSignalWorkflow::class)->latest('id')->firstOrFail();
+    $step = $run->actions()->where('sequence', 1)->firstOrFail();
+
+    // A delivery that never matched the wait-signal, which is what the handover exists to
+    // take. The step stays AwaitingRetry: only a parked step reaches that branch.
+    FlowSignal::create([
+        'flow_run_id' => $run->id,
+        'name' => 'balance-refilled',
+        'status' => SignalStatus::Received,
+        'received_at' => now(),
+    ]);
+
+    FlowEvent::created(function (FlowEvent $event): void {
+        if ($event->type !== FlowEventType::ActionRetried) {
+            return;
+        }
+
+        try {
+            DB::connection('testing')->select('select * from a_table_that_does_not_exist');
+        } catch (Throwable) {
+            // Swallowed, exactly as the observer code this stands for would.
+        }
+    });
+
+    try {
+        app(FlowExecutor::class)->drive($run->fresh(), RunMode::Sync);
+    } catch (Throwable) {
+        // The poisoned transaction is the setup.
+    }
+
+    // The run is untouched, not failed over a cycle the database threw away.
+    expect($run->fresh()->status)->toBe(FlowStatus::Waiting)
+        ->and($step->fresh()->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->fresh()->retry_signal_attempts)->toBe(0)
+        ->and($run->compensations()->count())->toBe(0);
 });

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -19,6 +19,7 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SelfCancellingBeforeParkWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SelfCancellingOptionalRetryWorkflow;
 use Illuminate\Support\Facades\Event;
 
 /**
@@ -35,6 +36,7 @@ use Illuminate\Support\Facades\Event;
 beforeEach(function () {
     FlakyPaymentAction::reset();
     SelfCancellingBeforeParkWorkflow::reset();
+    SelfCancellingOptionalRetryWorkflow::reset();
 
     config()->set('saga-lara-flow.queue.after_commit', false);
 });
@@ -486,4 +488,67 @@ it('verifies the handover committed before starting the retry it bought', functi
         ->and($step->fresh()->status)->toBe(ActionStatus::AwaitingRetry)
         ->and($step->fresh()->retry_signal_attempts)->toBe(0)
         ->and($run->compensations()->count())->toBe(0);
+});
+
+/**
+ * A parking that loses has nothing left to resolve from, and resolving anyway is worse
+ * than stopping: an optional step would hand back its fallback and let handle() carry on
+ * into the next seam, scheduling a row under a run whose settlement has already run.
+ */
+it('stops the pass instead of scheduling more work when a park loses to the run ending', function () {
+    useDatabaseQueue();
+    FlakyPaymentAction::reset(failures: 5);
+    SelfCancellingOptionalRetryWorkflow::$armed = true;
+
+    $handle = SagaFlow::create(SelfCancellingOptionalRetryWorkflow::class)
+        ->withArguments('order-probe')
+        ->run();
+
+    try {
+        drainQueue();
+    } catch (Throwable) {
+        // The cancellation is the setup; the rows it leaves behind are the assertion.
+    }
+
+    $run = FlowRun::query()->findOrFail($handle->id);
+
+    expect($run->status)->toBe(FlowStatus::Cancelled)
+        // The second step must not exist at all: nothing schedules work under a run that
+        // has settled, and nothing would ever settle the row if it did.
+        ->and($run->actions()->count())->toBe(1)
+        ->and($run->actions()->first()->status)->toBe(ActionStatus::Failed)
+        ->and($run->signals()->count())->toBe(0);
+
+    $scheduled = $run->events()->where('type', 'action.scheduled')->count();
+
+    expect($scheduled)->toBe(1);
+});
+
+/**
+ * The same orphan through the other door: with the retry budget spent there is no park
+ * to lose, and the Failed optional step reaches the give-up directly. A refused give-up
+ * is not a give-up, so the fallback that stands for it must not be handed back either.
+ */
+it('stops the pass instead of scheduling more work when a give-up is refused', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.actions.retry_on_signal.max_retries', 0);
+    FlakyPaymentAction::reset(failures: 5);
+    SelfCancellingOptionalRetryWorkflow::$armed = true;
+
+    $handle = SagaFlow::create(SelfCancellingOptionalRetryWorkflow::class)
+        ->withArguments('order-probe')
+        ->run();
+
+    try {
+        drainQueue();
+    } catch (Throwable) {
+        // The cancellation is the setup; the rows it leaves behind are the assertion.
+    }
+
+    $run = FlowRun::query()->findOrFail($handle->id);
+
+    expect($run->status)->toBe(FlowStatus::Cancelled)
+        ->and($run->actions()->count())->toBe(1)
+        ->and($run->actions()->first()->status)->toBe(ActionStatus::Failed)
+        ->and($run->events()->where('type', 'action.scheduled')->count())->toBe(1);
 });

--- a/tests/Feature/ConditionalActionWritesTest.php
+++ b/tests/Feature/ConditionalActionWritesTest.php
@@ -7,12 +7,14 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\StepExecution;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
@@ -551,4 +553,31 @@ it('stops the pass instead of scheduling more work when a give-up is refused', f
         ->and($run->actions()->count())->toBe(1)
         ->and($run->actions()->first()->status)->toBe(ActionStatus::Failed)
         ->and($run->events()->where('type', 'action.scheduled')->count())->toBe(1);
+});
+
+it('refuses the claim on a step whose run has already finished', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed);
+
+    $run->markCancelled();
+
+    // The redelivered job finds the row exactly as its own last attempt left it.
+    expect($step->fresh()->status)->toBe(ActionStatus::Failed);
+
+    $execution = app(ActionDispatcher::class)->execute($step->fresh());
+
+    expect($execution)->toBe(StepExecution::ClaimLost)
+        // The point of the fence: the card is not charged a second time under a run
+        // whose rollback has already been planned and reported.
+        ->and(FlakyPaymentAction::$calls)->toBe(0)
+        ->and($step->fresh()->status)->toBe(ActionStatus::Failed);
+});
+
+it('claims a step normally while the run is still live', function () {
+    $run = fencedFlowRun();
+    $step = fencedStep($run, ActionStatus::Failed);
+
+    expect(app(ActionDispatcher::class)->execute($step))->toBe(StepExecution::Executed)
+        ->and(FlakyPaymentAction::$calls)->toBe(1)
+        ->and($step->fresh()->status)->toBe(ActionStatus::Completed);
 });

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -15,6 +15,7 @@ use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\RunActionJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
@@ -897,12 +898,16 @@ it('rolls the consumption back when the retry transition fails', function () {
     $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-q23')->run();
     drainQueue();
 
-    // Blowing up on the write that spends the cycle stands in for a process that
-    // dies mid-transition. Spending the signal and spending the cycle it pays for
-    // have to land together or not at all: a consumed signal with the step still
-    // Failed would park again and wait for a second delivery that nobody owes.
-    ActionRun::saved(function (ActionRun $step): void {
-        if ($step->retry_signal_attempts === 1) {
+    // Blowing up between the two writes stands in for a process that dies mid-transition.
+    // Spending the signal and spending the cycle it pays for have to land together or not
+    // at all: a consumed signal with the step still Failed would park again and wait for
+    // a second delivery that nobody owes.
+    //
+    // The hook is on the signal's own save(), which is the one write in that transaction
+    // that still goes through the model: the step is written by a conditional UPDATE,
+    // which fires no Eloquent events at all.
+    FlowSignal::updated(function (FlowSignal $signal): void {
+        if ($signal->status === SignalStatus::Consumed) {
             throw new RuntimeException('the write exploded');
         }
     });

--- a/tests/Fixtures/SelfCancellingBeforeParkWorkflow.php
+++ b/tests/Fixtures/SelfCancellingBeforeParkWorkflow.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * Cancels its own run on the replay that is about to park its failed step, staging in
+ * one process what would otherwise need two: a cancellation landing after the failure
+ * was recorded and before the parking commits.
+ *
+ * A queued cancellation arriving BEFORE the replay cannot reach the park at all — the
+ * drive loop transitions to Running first, and no terminal status allows that — so the
+ * window this fixture opens is the only one the queued path actually has.
+ *
+ * It times itself off the step's own row rather than a call counter, so it fires on the
+ * parking pass whatever order the queue delivers in.
+ */
+final class SelfCancellingBeforeParkWorkflow extends Workflow
+{
+    public static bool $armed = false;
+
+    public static function reset(): void
+    {
+        self::$armed = false;
+    }
+
+    /**
+     * @return array{created: mixed, charged: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId): array
+    {
+        $created = $this->action(MakeValueAction::class, 'created')->run();
+
+        if (self::$armed && $this->stepHasFailed()) {
+            SagaFlow::findRun($this->runId())->markCancelled();
+        }
+
+        $charged = $this->action(FlakyPaymentAction::class, $orderId)
+            ->retryOnSignal('balance-refilled')
+            ->run();
+
+        return ['created' => $created, 'charged' => $charged];
+    }
+
+    private function stepHasFailed(): bool
+    {
+        return ActionRun::query()
+            ->where('flow_run_id', $this->runId())
+            ->where('sequence', 1)
+            ->where('status', ActionStatus::Failed)
+            ->exists();
+    }
+}

--- a/tests/Fixtures/SelfCancellingOptionalRetryWorkflow.php
+++ b/tests/Fixtures/SelfCancellingOptionalRetryWorkflow.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The shape that proves a lost parking must stop the pass rather than resolve it: an
+ * OPTIONAL retrying step with another step behind it. Resolving the give-up would hand
+ * back the fallback and let handle() carry on into that second step, scheduling a row
+ * and appending action.scheduled under a run whose settlement has already run once and
+ * will never run again.
+ *
+ * It cancels its own run on the replay that is about to park, timing itself off the
+ * step's row so it fires on that pass whatever order the queue delivers in.
+ */
+final class SelfCancellingOptionalRetryWorkflow extends Workflow
+{
+    public static bool $armed = false;
+
+    public static function reset(): void
+    {
+        self::$armed = false;
+    }
+
+    /**
+     * @return array{charged: mixed, shipped: mixed}
+     *
+     * @throws Throwable
+     */
+    public function handle(string $orderId): array
+    {
+        if (self::$armed && $this->stepHasFailed()) {
+            SagaFlow::findRun($this->runId())->markCancelled();
+        }
+
+        $charged = $this->action(FlakyPaymentAction::class, $orderId)
+            ->continueOnFailure()
+            ->fallbackValueOnFail('unpaid')
+            ->retryOnSignal('balance-refilled')
+            ->run();
+
+        $shipped = $this->action(MakeValueAction::class, 'shipped')->run();
+
+        return ['charged' => $charged, 'shipped' => $shipped];
+    }
+
+    private function stepHasFailed(): bool
+    {
+        return ActionRun::query()
+            ->where('flow_run_id', $this->runId())
+            ->where('sequence', 0)
+            ->where('status', ActionStatus::Failed)
+            ->exists();
+    }
+}


### PR DESCRIPTION
Closes #30.

`action_runs` had **one** writer that checked what it was overwriting and, as measurement found
during this work, a **second** one written independently and already divergent from it. Five others
just called `save()`. This gives all of them the same shape: every write states the row it expects
and the run's liveness in one `UPDATE`, and a write that loses journals `write_refused` and returns
`false` instead of overwriting whoever got there first.

## The window needs no race

Terminal settlement runs once, in `FlowStateMachine::finish()`'s transaction. `settleOpenSteps()`
covers `Pending`, `Running` and `AwaitingRetry`. It does **not** cover `Failed` — the state a row
sits in between two of the queue's own native tries — and every one of these writers accepted a
`Failed` row. So #30's own claim that "the claim accepts it because the row is `Pending`" is wrong:
a `Pending` row is settled to `Cancelled`, and the live hole is `Failed`. Nothing has to race.

Six reproductions on `main`, all deterministic:

| | measured on `main` |
|---|---|
| `startAction()` | run `cancelled`, step `failed` → `execute()` = `Executed`, business `handle()` calls = 1, step → `completed` |
| `retryAction()` | settled `cancelled` step + a stale model → `pending`, generation 1 |
| `awaitRetry()` | run `cancelled`, steps `[0:completed, 1:awaiting_retry]`, signals `[balance-refilled:waiting]` — matches #37's body exactly |
| `optionalFail()` | a `failed` step survives settlement → `optional_failed`, **and** `action.optional_failed` appended to a cancelled run |
| `markQueueAttemptsExhausted()` | a stale hook's view of cycle 0 writes the flag onto the live cycle-1 `Pending` row |
| `settleAwaitingRetry()` | `cancelled` → `failed`: its early return reads the **in-memory** model, so it never fires |

Instrumenting the four recorder methods over the whole suite settled one design question that reading
could not: `optionalFail()` receives `awaiting_retry` as well as `failed` (10 and 1). That is why its
fence is the row **as read** rather than a named status.

## What is here

- `FlowRun::live()` — the liveness predicate gets a name, and the two private copies in the
  repositories are deleted. Three consumers now say the same thing.
- `ActionRecorder::writeFenced()` — one conditional write for five sites. `$expected` is a
  column→value map (a scalar, a list, or null); the run's liveness rides in the same statement as a
  correlated `EXISTS`; a refusal journals `write_refused` with a `site` and calls `discardChanges()`,
  so nothing it failed to write is carried into the next one.
- `startAction()` stays hand-written — it has an `OR` branch, a raw `attempts + 1`, its own
  transaction and `claimSurvivedCommit()` — and gains exactly one thing: the liveness fence.
- `handOverAndRetry()` replaces `handOverDelivery()`: the wait's closure, the floating delivery's
  consumption and the rewind are one transaction, so a delivery is never spent on a cycle that was
  refused, and the retry is verified to have committed before the step is started.
- A losing park suspends, and a pass that could not record the give-up it resolved stops rather than
  handing back a fallback and scheduling more work under a settled run.

**The MySQL trap is closed by construction, not by a read-back.** An `UPDATE` that changes nothing
reports zero rows there and one elsewhere — measured. Every `$expected` key the write also sets names
the value being *replaced*, so a row that matches always changes, and there is deliberately no
equivalent of `FlowStateMachine::write()`'s disambiguating re-read: it would be a branch no test
could reach.

## Review

Seven adversarial passes, twenty-one findings, every one verified in code before it was accepted.
Four of them changed the design rather than the code:

- A losing park was supposed to fall through to the resolution the step would have reached without a
  policy — which is what #37 asks for. Measured: for an *optional* step that hands back the fallback,
  `handle()` carries on, and the next seam schedules a row and an `action.scheduled` event under a
  run whose settlement has already run. It suspends instead.
- `optionalFail()` fenced on a fixed status set could take a row another pass had just parked,
  orphaning the winner's wait. It fences on the row as read.
- A row can leave `Failed` for a retry and come back to it, so the give-up and the queue's
  bookkeeping fence on the generation too — and the bookkeeping on the status, because a claim moves
  `Failed → Running` without touching the cycle.
- Making the handover atomic put a `flow_events` write inside a transaction that did not have one on
  `main`. On PostgreSQL a host observer that swallows a failing query there turns the commit into a
  rollback while reporting success, so the retry is verified on the write connection before the step
  is started.

**Mutation is what caught the weak tests, not review.** Four of mine passed for the wrong reason —
one threw on its first line while asserting only the initial state, one counted calls against a
method that never runs the action, one held under the very mutation it existed to catch, one could
not distinguish its branches at all. Each was rewritten until the mutation went red.

## Not here

A conditional `UPDATE` answers from a snapshot, so it fences against a **committed** cancellation and
not one still in flight. That is real, reproduced on PostgreSQL with two connections, and closing it
needs a row lock plus a contention story the package does not have, retry budgets on the driving
jobs, and atomic history. It was implemented on this branch and taken back out: the fence work
produced no findings after the third pass, while the lock produced twelve, the last four
invalidating the previous round's fixes. All of it is **#54**.

**#37 is closed for the defect its body reproduces**; the "flow-run-first lock order" its suggested
fix asks for is #54.

Two adjacent defects found while measuring and filed rather than folded in: **#53** (a step still
executes under a run that is rolling back) and **#54**.

## Verification

| | `main` | this branch |
|---|---|---|
| SQLite | 406 / 3 | **427 / 4** |
| MySQL | 406 / 3 | **427 / 4** |
| PostgreSQL | 409 / 0 | **431 / 0** |

Pint clean over 360 files, PHPStan level 5 clean, `docs` builds. Twenty-one mutations, each hitting
its own test.
