### PR TITLE
Document the transaction the engine cannot write inside

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -94,8 +94,7 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
   the event out of the transaction is not the same fix: a model observer on a row the transaction
   writes runs there whatever the event does, which is what `TransactionIntegrityTest`'s observer
   case pins. What such a read proves is visibility on the writing connection, which equals
-  durability only while the engine's transaction is the outermost one — a host transaction wrapped
-  around a run is out of the engine's reach on every driver, and the docs ask hosts not to open one.
+  durability only while the engine's transaction is the outermost one — see the boundary below.
 - **A read that decides something must use `useWritePdo()`.** A lagging replica will answer with the
   very state the fence was guarding against.
 - **Do not `refresh()` a model the caller still holds.** It discards their unsaved attributes;
@@ -106,6 +105,28 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
 `FlowStatus::terminal()` and `FlowStatus::signalable()` are different sets and are not
 interchangeable. `Cancelling` is **not** terminal — it is a run mid-rollback. Swapping one boundary
 for the other changes public behaviour and needs its own exception and its own documentation.
+
+### A host transaction around an engine call is out of scope
+
+The engine's entry points must be called with no transaction of the caller's open. This is a
+**documented boundary, not an open defect** — do not file it as one, and do not add code that tries
+to detect or survive it.
+
+Measured identically on all three drivers: with a host transaction rolled back around them,
+`runSync()` leaves no row of the run at all, `compensate()` performs the rollback and records
+nothing (leaving the run compensatable a second time — `["undo:a", "undo:a"]` against one
+`compensation_runs` row), and `signal()` and `cancel()` are discarded while the caller is handed a
+`FlowRun` saying otherwise. Only the queued `run()` is safe, and only while `queue.after_commit` is
+on.
+
+The engine cannot get out from under it. Inside a host transaction its own `transaction()` is a
+savepoint (nesting level 2), so it commits nothing and every read-back proves visibility rather than
+durability; a second connection would escape the scope but could not then see the host's uncommitted
+rows at all. Nor can a `transactionLevel() > 0` check sit at the writes: the engine's own writers
+legitimately run above zero — `FlowStateMachine::finish()` settles every open step inside its
+transaction, and `park()` writes the step and its signal inside one. And detection would come too
+late for what the boundary actually costs, which is work already performed. So it is documented in
+`docs/docs/queues-locks-idempotency.md` and enforced nowhere.
 
 ### Side effects
 

--- a/README.md
+++ b/README.md
@@ -630,6 +630,12 @@ $run->result;   // the value handle() returned
 
 The queued and synchronous paths are guaranteed to reach the **same** final database state.
 
+> **Never call it inside a `DB::transaction()` of your own.** The steps run while your transaction
+> is open, so a rollback afterwards discards every row of the run while the work those rows describe
+> is already done. The same holds for `signal()`, `cancel()` and `compensate()`; only the queued
+> `run()` is safe. See
+> [Queues, locks & idempotency](https://sagalaraflow.dev/queues-locks-idempotency#host-transactions).
+
 ## Versioning long-running workflows
 
 A workflow may be suspended for days while its code keeps shipping. To change a running workflow's

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -37,6 +37,62 @@ So end-to-end idempotency depends on **your action code**. Make each action safe
 The `(flow_run_id, sequence)` pair is a natural, stable idempotency key to hand to downstream systems.
 :::
 
+## Never wrap an engine call in a transaction of your own {#host-transactions}
+
+The guarantee above is read from the run's **recorded history**. A `DB::transaction()` of your own
+around an engine call puts that history inside your rollback scope, so a rollback erases the record
+while the work it describes has already happened. Measured identically on SQLite, MySQL and
+PostgreSQL — this is the shape of the thing, not a driver quirk:
+
+| the call inside your transaction | after your transaction rolls back |
+| --- | --- |
+| `runSync()` | the steps ran; **every row of the run is gone** |
+| `compensate()` | the compensations ran; no `compensation_runs` row, the run left non-terminal |
+| `signal()` | the delivery is gone; the wait is still open and nothing will wake the run |
+| `cancel()` | the transition is gone; the run is where it was and keeps going |
+| `run()` (queued) | nothing recorded and nothing dispatched — consistent, see below |
+
+Only the queued `run()` is safe, and only while `saga-lara-flow.queue.after_commit` is on, as it is
+by default: the job is held until your transaction commits, so a run either starts on committed data
+or never starts at all. With it off the job goes out immediately, and whether it survives your
+rollback is the queue driver's business rather than the engine's — leaving a job that may name a run
+which was never committed.
+
+Nothing raises. Every one of those calls returns normally and hands you a `FlowRun` describing a
+state your own rollback then discarded.
+
+### Why this is worse than losing the work
+
+The rows are not bookkeeping — they are what stops the work happening twice. `compensate()` under a
+rolled-back transaction leaves the run exactly where it was, so compensating it again runs every
+compensation a second time:
+
+```
+compensate() inside a host transaction that rolls back  → undo:a executed
+compensate() again, normally                            → undo:a executed
+CompensationLog                                         → ["undo:a", "undo:a"]
+compensation_runs rows                                  → 1
+```
+
+Two rollbacks of one step, and one record saying it happened once. The row that would have said
+`undo:a` already ran is the row your rollback deleted.
+
+### Why the engine cannot defend itself
+
+Inside your transaction the engine's own `transaction()` is a **savepoint**, not a transaction
+(measured: nesting level 2). It commits nothing, so durability is yours to decide, and the read-back
+the engine uses to verify its own writes proves visibility on the connection rather than durability
+— those are the same thing only while the engine's transaction is the outermost one. Getting out
+would take a second connection, which then cannot see your uncommitted rows at all and would fence
+against a run that, to it, does not exist. So this is a boundary the package documents rather than a
+defect it is holding open.
+
+### What to do instead
+
+Commit your own work first, then call the engine — or use the queued `run()`, which does that
+ordering for you. Where a step needs data you are about to write, pass it in as an argument or read
+it inside the action, which runs after your transaction has closed.
+
 ## Locks
 
 Concurrent drives of the *same* run are serialized by Laravel's `WithoutOverlapping` middleware:

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -343,7 +343,8 @@ The counters are two different things: `attempts` keeps counting *every* executi
 
 - **Don't wrap a step in your own `DB::transaction()`.** The engine suspends by throwing, so an
   application transaction around `->run()` would roll the suspension's bookkeeping back. This is true
-  of every suspending seam in the package, not only this one.
+  of every seam and every entry point in the package, not only this one — see
+  [what a host transaction leaves behind](./queues-locks-idempotency.md#host-transactions).
 - **Package event listeners must be queued (`ShouldQueue`) or must not throw.** A throwing listener
   on `ActionRetried` or `FlowSignalConsumed` interrupts the replay mid-way, and the engine reads that
   as a business failure.

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -101,6 +101,12 @@ expression reading a record that has since been deleted, say. The plan is then i
 `compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
 it and reporting a finished rollback. Fix the cause and call it again.
 
+:::warning Not inside a transaction of your own
+The compensations execute before your transaction closes, so a rollback afterwards discards the
+record while the undo work is already done — and leaves the run compensatable a second time. See
+[what a host transaction leaves behind](./queues-locks-idempotency.md#host-transactions).
+:::
+
 ## Postponing a rollback
 
 Not every failure deserves a rollback. When a step failed only because the world was not ready — a

--- a/docs/docs/signals.md
+++ b/docs/docs/signals.md
@@ -74,6 +74,10 @@ $delivered = SagaFlow::loadFlow($runId)->signalIfRunning('approval', ['approved'
 `signalIfRunning()` means *"unless the run has already finished"* — it delivers to **any
 non-terminal run**, not only a `Running` one.
 
+Neither may be called inside a `DB::transaction()` of your own: a rollback afterwards takes the
+delivery with it, the wait stays open, and nothing tells you. See
+[what a host transaction leaves behind](./queues-locks-idempotency.md#host-transactions).
+
 ### Finding the run to signal
 
 Often you do not have the `$runId` on hand — you know the workflow and a tag. Query for it:

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -27,7 +27,8 @@ failed statement forced on you — discards every row the run recorded while the
 describe is already done. A charge stays charged with nothing left to attribute it to, on every
 driver. The queued path is clear of this while `saga-lara-flow.queue.after_commit` is on, as it is
 by default: it holds the jobs until your transaction commits, and turning it off gives them the
-same problem.
+same problem. The same applies to `signal()`, `cancel()` and `compensate()` — see
+[what a host transaction leaves behind](./queues-locks-idempotency.md#host-transactions).
 :::
 
 ## When to use which


### PR DESCRIPTION
A host that wraps an engine call in its own `DB::transaction()` puts the run's recorded history inside its rollback scope. Nothing in the package can defend against it, and no open issue covers it — so this documents the boundary rather than leaving it to be rediscovered and filed as a defect.

## Checked first: nothing to close

All thirteen open issues were read, not grepped by title. Every "rollback" in #48, #49, #50, #52 and #53 is a **saga** rollback. #54 is contention between two engine writers — its two mentions of the host are a foreign exception carrying `40001` and an observer on `flow_events`, neither a transaction. #36 is `runSync()` inside `handle()`, a re-entered `FlowRuntime`. The rest say nothing about transactions.

## Measured, identically on SQLite, MySQL and PostgreSQL

With a host transaction rolled back around the call:

| call | after the rollback |
| --- | --- |
| `runSync()` | the steps ran; not one row of the run remains |
| `compensate()` | the compensations ran; no `compensation_runs` row, the run left non-terminal |
| `signal()` | the delivery is gone; the wait is still open and nothing will wake the run |
| `cancel()` | the transition is gone; the run keeps going |
| `run()` (queued) | nothing recorded, nothing dispatched — consistent |

None of them raises. The caller is handed a `FlowRun` describing a state their own rollback discarded.

The sharpest consequence is that `compensate()` becomes repeatable: the run is left exactly where it was, so compensating again runs every compensation a second time — `["undo:a", "undo:a"]` against a single `compensation_runs` row. The row that would have said `undo:a` already ran is the one the rollback deleted.

## Why the engine cannot defend itself

Inside a host transaction the engine's own `transaction()` is a savepoint — measured nesting level 2. It commits nothing, so every read-back proves visibility on the connection rather than durability. A second connection would escape the scope but could not then see the host's uncommitted rows at all. A `transactionLevel() > 0` check cannot sit at the writes either: the engine's own writers legitimately run above zero (`FlowStateMachine::finish()` settles every open step inside its transaction, `park()` writes the step and its signal inside one). And detection arrives too late for what the boundary actually costs, which is work already performed.

## Changes

- `docs/docs/queues-locks-idempotency.md` — the canonical section, anchored `{#host-transactions}`, placed directly after **Idempotency** because the recorded history that guarantee reads is exactly what the rollback erases.
- Cross-references from `synchronous-execution.md`, `sagas-and-compensation.md`, `signals.md` and `retry-on-signal.md`, whose existing bullet widens from "a step" to every entry point.
- README — a warning beside `runSync()`.
- `CONTRIBUTING.md` — a named section saying this is a documented boundary, not an open defect: do not file it, do not add code to detect or survive it. The now-redundant parenthetical in the transaction rule above it is dropped.

Documentation only. Suite unchanged at 427 passed / 4 skipped, docs site builds clean, the anchor and its four inbound links resolve in the built output.