### PR TITLE
Hand a refused outcome's payload to the host

### DIFF
--- a/README.md
+++ b/README.md
@@ -710,6 +710,13 @@ Event::listen(FlowFailed::class, function (FlowFailed $event): void {
 `FlowCancelled` carries an optional `?string $reason`, populated when you call
 `$handle->cancel('reason here')`.
 
+Two events have no `flow_events` counterpart. A worker that finishes a step whose row has moved on
+has its outcome refused, and `ActionOutcomeRejected` / `CompensationOutcomeRejected` carry what it
+produced — the value the step returned, in the form the row would have stored, or the throw the
+engine deliberately does not rethrow. The work is done and nothing local records it, so the payload
+reaches somewhere you chose rather than nowhere. See
+[Events](https://sagalaraflow.dev/events#refused-outcome).
+
 ## Artisan commands
 
 | Command                                                          | Purpose                                                          |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -81,7 +81,8 @@ of Eloquent hooks.
 Enabling reclaim lets a second worker take over a row whose first worker may be slow rather than
 dead, so both can reach the end of the same step. The outcome writes are therefore fenced against
 the claim that produced them (via `attempts`, which only the claim increments): an executor that has
-been superseded updates no rows, raises no event, and its job does not fail. In practice this means
+been superseded updates no rows, records no history, and its job does not fail — it now hands what
+it produced to `ActionOutcomeRejected` instead of dropping it (item 23). In practice this means
 a **recorded success is never demoted** — a straggler that fails after the live worker succeeded can
 no longer flip the step to `Failed` and send the saga rolling back over work that actually went
 through.
@@ -495,6 +496,15 @@ The other thing to check: those five no longer call `save()`, so they raise no E
 — an observer on your `ActionRun` model stops seeing them. Three publish a package event instead,
 and settling a parked step and recording the queue's exhausted attempts publish none, by design. See
 [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
+
+### 23. New: a refused outcome hands its payload to a listener
+
+A worker that finishes a step whose row has moved on has its outcome refused, and until now what it
+produced went nowhere. `ActionOutcomeRejected` and `CompensationOutcomeRejected` now carry it: the
+value the step returned in the form the row would have stored, or the throw the engine deliberately
+does not rethrow. Nothing is stored and nothing about the run changes. A listener that throws is
+journalled as `rejection_undelivered` rather than failing the job, since this path must stay quiet.
+See [Events](https://sagalaraflow.dev/events#refused-outcome).
 
 ### Recommended while you are here
 

--- a/docs/docs/events.md
+++ b/docs/docs/events.md
@@ -7,7 +7,9 @@ sidebar_position: 21
 # Events
 
 The engine mirrors its `flow_events` log onto Laravel events you can listen to. Register listeners
-the usual way (an event subscriber, `Event::listen`, or a listener class).
+the usual way (an event subscriber, `Event::listen`, or a listener class). Two events are the
+exception and have no entry in that log — they report an outcome the engine **refused**, which never
+became part of the run's history. See [A refused outcome](#refused-outcome).
 
 ```php
 use DiscoveryUkraine\SagaLaraFlow\Events\FlowFailed;
@@ -33,9 +35,10 @@ Flow lifecycle: `FlowStarted`, `FlowCompleted`, `FlowFailed`, `FlowWaiting`, `Fl
 
 Actions: `ActionStarted`, `ActionCompleted`, `ActionFailed`, `ActionRedispatched`,
 `OptionalActionFailed`, `ActionAwaitingRetry`, `ActionRetried` (the last two cover
-[retry on signal](./retry-on-signal.md)).
+[retry on signal](./retry-on-signal.md)), `ActionOutcomeRejected`.
 
-Compensations: `CompensationStarted`, `CompensationCompleted`, `CompensationFailed`.
+Compensations: `CompensationStarted`, `CompensationCompleted`, `CompensationFailed`,
+`CompensationOutcomeRejected`.
 
 Child workflows: `ChildWorkflowStarted`, `ChildWorkflowCompleted`, `ChildWorkflowFailed`,
 `ChildWorkflowCancelled`.
@@ -45,11 +48,63 @@ Signals & side effects: `FlowSignalReceived`, `FlowSignalConsumed`, `SideEffectR
 
 (See `src/Events` for the full list.)
 
+## A refused outcome {#refused-outcome}
+
+A step finishes, and by then its row has moved on — the run was cancelled, a reclaim handed the row
+to a second worker, the monitor expired it. The engine refuses that outcome, which is the right call
+for the run, and the work stays done with nowhere to record it. `ActionOutcomeRejected` and
+`CompensationOutcomeRejected` carry what it produced:
+
+```php
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionOutcomeRejected;
+
+Event::listen(ActionOutcomeRejected::class, function (ActionOutcomeRejected $event): void {
+    match ($event->outcome) {
+        // The value the action returned. Reconcile it, or park it for a human.
+        FlowEventType::ActionCompleted => Ledger::orphanedResult(
+            $event->actionRun->id,
+            $event->result,
+        ),
+        // The throw. It is not rethrown either — a job whose work was already
+        // discarded must not fail — so this is the only place it is ever named.
+        FlowEventType::ActionFailed => report($event->exception),
+        default => null,
+    };
+});
+```
+
+`$event->result` is the value **in the form the row would have stored it** — the same shape
+`$actionRun->result` carries on a step that was recorded, so the reconciliation you write works
+either way, and a queued listener can be handed it. `$event->exception` is the throw itself.
+
+The step's own row is `$event->actionRun` (`$event->compensationRun` on the compensation event), and it
+reads as the row did **before** the refused write: the payload travels in the event and never on the
+model, so nothing here is safe to save back. Only the payload is at stake: the run's state is
+already settled by whoever won the row.
+
+The refusal is journalled as `outcome_rejected` whether or not you listen (see
+[Reclaim & recovery](./reclaim-and-recovery.md)). The log line names the loss but does not carry it:
+`AnomalyLog` writes to the application's default channel, which nobody chose for business payloads
+or gave a retention policy. That choice is the host's, which is what the event is for.
+
+An expiry the same fence refuses is journalled under that reason too, and raises no event: the
+exception it would have written is the monitor's own account of the deadline, not a value only the
+worker held.
+
+These two events are also the exception to the warning below. A listener that throws on either of
+them — or a queued one the payload cannot be serialised with — is journalled as
+`rejection_undelivered` and goes no further. The engine deliberately does not fail the job on this
+path: a job that fails here runs its `failed()` hook, which would write queue bookkeeping into a row
+the second worker now owns. The cost is that the discarded payload is then lost after all, so treat
+that reason code as a defect in your listener rather than a race.
+
 :::warning Listeners must be queued, or must not throw
 These events are dispatched from inside the engine's replay. A synchronous listener that throws
 interrupts the replay at that point, and the engine reads the exception as a business failure — it
 can fail and compensate a run that was doing fine. Mark your listeners `ShouldQueue`, or make sure
-they cannot throw.
+they cannot throw. The two [rejection events](#refused-outcome) are the exception: a throw there is
+journalled rather than propagated.
 :::
 
 ## Cancellation reason

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -166,14 +166,19 @@ package keeps a second journal for them:
 Grep for `claim_lost`, `outcome_rejected`, `batch_finished_early` and `write_refused`; each line
 carries the run id, row id, sequence and class, and `write_refused` adds the `site` of the write that
 was refused. `claim_not_committed` joins them when a claim did not survive its own
-transaction, which is a defect in listener or observer code rather than a race, and `expiry_failed`
-when the sweep could not plan an overdue run's rollback and stepped over it. A refused run
+transaction, which is a defect in listener or observer code rather than a race, `expiry_failed`
+when the sweep could not plan an overdue run's rollback and stepped over it, and
+`rejection_undelivered` when the event below could not be handed to a listener. A refused run
 transition is journalled here too, as `transition_lost`,
 carrying the status observed, the one intended and the one actually holding the row — it is the one
 entry that is not always quiet, since `FlowHandle` raises rather than absorbing it. None of them are
 written to `flow_events`, which records the run's business history — an abandoned attempt changed
 nothing in it. See [Reclaim & recovery](./reclaim-and-recovery.md) for what each one means and what
 to do about it.
+
+The middle one is the only one that discards something the work produced, so it also raises an event
+carrying it — see [A refused outcome](./events.md#refused-outcome). `rejection_undelivered` is that
+hand-over failing, and the one way the payload is lost anyway.
 
 :::tip A lock TTL is not the same as reclaim
 `action_ttl_seconds` does not answer "when can a stuck `Running` step be retried". It governs a

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -172,7 +172,8 @@ at-least-once delivery already has.
 
 Only one of them can record an outcome. Each claim increments the row's `attempts`, and every outcome write is
 conditional on two things: the `attempts` value its own claim produced, and the row still being `Running`. A superseded
-worker's write updates no rows, fires no event, and does not fail its job — it is logged and dropped.
+worker's write updates no rows, records no history, and does not fail its job — it is logged and dropped, and what it
+produced is handed to `ActionOutcomeRejected` rather than lost with it (see [Events](./events.md#refused-outcome)).
 
 The two conditions guard two different rivals:
 
@@ -210,8 +211,10 @@ The consequence differs by half of the engine:
 
 ## Finding these races in your logs
 
-A lost claim, a rejected outcome and an early-closed batch are all normal and all silent. The package keeps a second
-journal for them — `AnomalyLog`, alongside the `flow_events` business history:
+A lost claim, a rejected outcome and an early-closed batch are all normal, and none of them fails a job or reaches
+`flow_events`. The package keeps a second journal for them — `AnomalyLog`, alongside the `flow_events` business
+history. A rejected outcome is the one that is not otherwise silent: it also dispatches the event carrying what was
+discarded (see [Events](./events.md#refused-outcome)):
 
 ```php
 'logging' => [
@@ -220,11 +223,13 @@ journal for them — `AnomalyLog`, alongside the `flow_events` business history:
 ],
 ```
 
-Six reason codes to grep for. All but one carry the run id, row id, sequence and class; `expiry_failed`
+Seven reason codes to grep for. All but one carry the run id, row id, sequence and class; `expiry_failed`
 is about a run rather than a row, and carries the run id, its workflow class and the throw:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
-- **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped.
+- **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped. Listen for
+  `ActionOutcomeRejected` / `CompensationOutcomeRejected` to receive the payload this line cannot carry (see
+  [Events](./events.md#refused-outcome)).
 - **`batch_finished_early`** — a parallel step completed after a duplicate delivery had closed its batch.
 - **`claim_not_committed`** — a claim was written and was gone once its transaction closed. The line carries both
   attempt counts, the claimed one and the one the row actually holds.
@@ -232,6 +237,9 @@ is about a run rather than a row, and carries the run id, its workflow class and
   the next. The line carries the throw. The run stays overdue and is tried again on the next sweep.
 - **`write_refused`** — a write to a step was refused because the row had moved on since it was read, or the run under
   it had finished. The line carries a `site` naming which write it was.
+- **`rejection_undelivered`** — the rejection event above could not be handed over: a listener threw, or a queued one
+  could not be serialised with the payload. The line carries the throw's class and message. The refusal itself stands;
+  what is gone is the last copy of the discarded result, so this one is a defect in listener code to fix.
 
 Raise the level to `warning` to surface them in your alerting. A steady stream of the first three points to a queue
 timeout tuned shorter than the work takes, or to locks being off.

--- a/src/Events/ActionOutcomeRejected.php
+++ b/src/Events/ActionOutcomeRejected.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Events;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use Throwable;
+
+/**
+ * Dispatched when a step finished but its row had moved on, so the outcome was
+ * refused and nothing was stored. The work happened; this carries the only copy of
+ * what it produced. `$outcome` names which outcome it was: ActionCompleted fills
+ * `$result` in the form the row would have stored, so a queued listener can carry
+ * it; ActionFailed fills `$exception`, which is not rethrown either, making this
+ * its only notice. The model reads as the row did before the refused write, so
+ * nothing here is safe to save back.
+ */
+final readonly class ActionOutcomeRejected
+{
+    public function __construct(
+        public ActionRun $actionRun,
+        public FlowEventType $outcome,
+        public mixed $result = null,
+        public ?Throwable $exception = null,
+    ) {}
+}

--- a/src/Events/CompensationOutcomeRejected.php
+++ b/src/Events/CompensationOutcomeRejected.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Events;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use Throwable;
+
+/**
+ * The compensation counterpart of ActionOutcomeRejected: the undo ran, its row had
+ * moved on, and what it produced was refused. `$outcome` names which outcome it was
+ * — CompensationCompleted fills `$result` in the form the row would have stored,
+ * CompensationFailed fills `$exception`. The model reads as the row did before the
+ * refused write.
+ */
+final readonly class CompensationOutcomeRejected
+{
+    public function __construct(
+        public CompensationRun $compensationRun,
+        public FlowEventType $outcome,
+        public mixed $result = null,
+        public ?Throwable $exception = null,
+    ) {}
+}

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -11,6 +11,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionAwaitingRetry;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionCompleted;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionFailed;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionOutcomeRejected;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionRedispatched;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
 use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
@@ -310,7 +311,7 @@ final readonly class ActionRecorder
         $actionRun->result = $this->serializer->serialize($result);
         $actionRun->finished_at = Carbon::now();
 
-        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionCompleted)) {
+        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionCompleted, result: $actionRun->result)) {
             return false;
         }
 
@@ -338,7 +339,7 @@ final readonly class ActionRecorder
         $actionRun->exception = $exceptionArray;
         $actionRun->finished_at = Carbon::now();
 
-        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionFailed)) {
+        if (! $this->writeOutcome($actionRun, $claimedAttempts, FlowEventType::ActionFailed, exception: $exception)) {
             return false;
         }
 
@@ -370,8 +371,13 @@ final readonly class ActionRecorder
      * late worker would overwrite that Expired and leave the run carrying both
      * action.expired and action.completed.
      */
-    private function writeOutcome(ActionRun $actionRun, int $claimedAttempts, FlowEventType $outcome): bool
-    {
+    private function writeOutcome(
+        ActionRun $actionRun,
+        int $claimedAttempts,
+        FlowEventType $outcome,
+        mixed $result = null,
+        ?Throwable $exception = null,
+    ): bool {
         $written = $actionRun->newQuery()
             ->whereKey($actionRun->getKey())
             ->where('attempts', $claimedAttempts)
@@ -389,12 +395,49 @@ final readonly class ActionRecorder
                 'claimed_attempts' => $claimedAttempts,
             ]);
 
+            // The anomaly line names the loss without carrying what was lost: it goes
+            // to the application's default channel, which nobody chose for business
+            // payloads. The event hands them to the host instead, once the model reads
+            // as the row does rather than as the refused outcome.
+            $actionRun->discardChanges();
+
+            $this->announceRejection(
+                new ActionOutcomeRejected($actionRun, $outcome, $result, $exception),
+                $actionRun,
+            );
+
             return false;
         }
 
         $actionRun->syncOriginal();
 
         return true;
+    }
+
+    /**
+     * Dispatch a rejection notice without letting it fail the job. This branch is
+     * deliberately quiet — ActionDispatcher reports Superseded rather than rethrowing,
+     * because a job that fails here runs failed(), and that writes queue bookkeeping
+     * into a row this worker no longer owns. A listener that throws, or a queued one
+     * the payload cannot be serialised into, must not reopen that path; it is
+     * journalled the way a retry policy that throws already is.
+     */
+    private function announceRejection(ActionOutcomeRejected $rejection, ActionRun $actionRun): void
+    {
+        try {
+            event($rejection);
+        } catch (Throwable $undelivered) {
+            $this->anomalies->log(AnomalyLog::REASON_REJECTION_UNDELIVERED, [
+                'entity' => 'action',
+                'flow_run_id' => $actionRun->flow_run_id,
+                'action_run_id' => $actionRun->id,
+                'sequence' => $actionRun->sequence,
+                'action_class' => $actionRun->action_class,
+                'outcome' => $rejection->outcome->value,
+                'exception' => $undelivered::class,
+                'message' => $undelivered->getMessage(),
+            ]);
+        }
     }
 
     /**

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -14,8 +14,8 @@ use Throwable;
  * outcome write refused because the row had changed hands, a step write refused because
  * the row had moved on since it was read, a batch already closed by a duplicate before
  * its own job reported, a run transition refused because the row had moved on, a retry
- * policy that threw, an overdue run whose rollback could not be
- * planned. Most are ordinary consequences of at-least-once delivery and of nothing
+ * policy that threw, a rejection notice no listener could be given, an overdue run
+ * whose rollback could not be planned. Most are ordinary consequences of at-least-once delivery and of nothing
  * serialising an operator against a worker; the claim that did not commit and the last
  * two are defects in the caller's own code, journalled here for the same reason as the
  * rest — the engine carried on, so nothing else records it.
@@ -46,6 +46,8 @@ final readonly class AnomalyLog
     public const string REASON_EXPIRY_FAILED = 'expiry_failed';
 
     public const string REASON_WRITE_REFUSED = 'write_refused';
+
+    public const string REASON_REJECTION_UNDELIVERED = 'rejection_undelivered';
 
     /**
      * PSR-3's eight, the only strings a PSR logger accepts. A value outside this set

--- a/src/Runtime/CompensationRecorder.php
+++ b/src/Runtime/CompensationRecorder.php
@@ -9,6 +9,7 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationCompleted;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationFailed;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationOutcomeRejected;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStarted;
 use DiscoveryUkraine\SagaLaraFlow\Events\CompensationStepStarted;
 use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
@@ -217,7 +218,14 @@ final readonly class CompensationRecorder
         $compensation->result = $this->serializer->serialize($result);
         $compensation->finished_at = Carbon::now();
 
-        if (! $this->writeOutcome($compensation, $claimedAttempts, FlowEventType::CompensationCompleted)) {
+        $written = $this->writeOutcome(
+            $compensation,
+            $claimedAttempts,
+            FlowEventType::CompensationCompleted,
+            result: $compensation->result,
+        );
+
+        if (! $written) {
             return false;
         }
 
@@ -242,7 +250,14 @@ final readonly class CompensationRecorder
         $compensation->exception = $exceptionArray;
         $compensation->finished_at = Carbon::now();
 
-        if (! $this->writeOutcome($compensation, $claimedAttempts, FlowEventType::CompensationFailed)) {
+        $written = $this->writeOutcome(
+            $compensation,
+            $claimedAttempts,
+            FlowEventType::CompensationFailed,
+            exception: $exception,
+        );
+
+        if (! $written) {
             return false;
         }
 
@@ -269,7 +284,9 @@ final readonly class CompensationRecorder
     private function writeOutcome(
         CompensationRun $compensation,
         int $claimedAttempts,
-        FlowEventType $outcome
+        FlowEventType $outcome,
+        mixed $result = null,
+        ?Throwable $exception = null,
     ): bool {
         $written = $compensation->newQuery()
             ->whereKey($compensation->getKey())
@@ -288,12 +305,42 @@ final readonly class CompensationRecorder
                 'claimed_attempts' => $claimedAttempts,
             ]);
 
+            $compensation->discardChanges();
+
+            $this->announceRejection(
+                new CompensationOutcomeRejected($compensation, $outcome, $result, $exception),
+                $compensation,
+            );
+
             return false;
         }
 
         $compensation->syncOriginal();
 
         return true;
+    }
+
+    /**
+     * @see ActionRecorder::announceRejection()
+     */
+    private function announceRejection(
+        CompensationOutcomeRejected $rejection,
+        CompensationRun $compensation
+    ): void {
+        try {
+            event($rejection);
+        } catch (Throwable $undelivered) {
+            $this->anomalies->log(AnomalyLog::REASON_REJECTION_UNDELIVERED, [
+                'entity' => 'compensation',
+                'flow_run_id' => $compensation->flow_run_id,
+                'compensation_run_id' => $compensation->id,
+                'sequence' => $compensation->sequence,
+                'compensation_class' => $compensation->compensation_class,
+                'outcome' => $rejection->outcome->value,
+                'exception' => $undelivered::class,
+                'message' => $undelivered->getMessage(),
+            ]);
+        }
     }
 
     private function nextSequence(FlowRun $flowRun): int

--- a/tests/Feature/RejectedOutcomeEventTest.php
+++ b/tests/Feature/RejectedOutcomeEventTest.php
@@ -1,0 +1,301 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\CompensationStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowEventType;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionOutcomeRejected;
+use DiscoveryUkraine\SagaLaraFlow\Events\CompensationOutcomeRejected;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\CompensationRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ClosureBackedResult;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\QueuedRejectionListener;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ThrowingRejectionListener;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * A refused outcome is the one case where the engine holds work that happened and
+ * has nowhere to put it: the fence is right about the row, and the value the step
+ * produced exists only in the worker's memory. The anomaly line names the loss but
+ * cannot carry the payload — it goes to the application's default channel, chosen
+ * for neither business data nor its retention. These events hand it to the host
+ * instead, which is the only party that can decide where it belongs.
+ */
+function rejectedOutcomeRun(): FlowRun
+{
+    return app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => [],
+    ]);
+}
+
+/**
+ * The row as reclaim leaves it: claimed by a first worker, then claimed again by a
+ * second once the deadline passed. The first worker is still alive and about to
+ * finish — the state the outcome fence exists for.
+ */
+function supersededAction(FlowRun $run): ActionRun
+{
+    $recorder = app(ActionRecorder::class);
+
+    $workerA = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'reclaim_stale_after_seconds' => 900,
+        'attempts' => 0,
+    ]);
+
+    expect($recorder->startAction($workerA))->toBeTrue();
+
+    ActionRun::query()->whereKey($workerA->id)->update(['reclaim_stale_at' => now()->subMinute()]);
+
+    $workerB = ActionRun::query()->findOrFail($workerA->id);
+
+    expect($recorder->startAction($workerB))->toBeTrue()
+        ->and($workerB->attempts)->toBe(2);
+
+    return $workerA;
+}
+
+/**
+ * The compensation mirror of supersededAction(): reclaim has handed the row to a
+ * second worker while the first is still running.
+ */
+function supersededCompensation(FlowRun $run): CompensationRun
+{
+    $recorder = app(CompensationRecorder::class);
+
+    $workerA = CompensationRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'compensation_type' => 'class',
+        'compensation_class' => UndoAction::class,
+        'status' => CompensationStatus::Pending,
+        'reclaim_stale_after_seconds' => 900,
+        'attempts' => 0,
+    ]);
+
+    expect($recorder->startCompensation($workerA))->toBeTrue();
+
+    CompensationRun::query()->whereKey($workerA->id)->update(['reclaim_stale_at' => now()->subMinute()]);
+
+    $workerB = CompensationRun::query()->findOrFail($workerA->id);
+
+    expect($recorder->startCompensation($workerB))->toBeTrue()
+        ->and($workerB->attempts)->toBe(2);
+
+    return $workerA;
+}
+
+/**
+ * Both rejection events into one collector. It is an ArrayObject rather than an
+ * array so the caller reads what the listeners appended: an array returned from
+ * here would be a copy taken before either of them ever ran, and every assertion
+ * against it would hold no matter what the engine dispatched.
+ *
+ * @return ArrayObject<int, ActionOutcomeRejected|CompensationOutcomeRejected>
+ */
+function captureRejections(): ArrayObject
+{
+    /** @var ArrayObject<int, ActionOutcomeRejected|CompensationOutcomeRejected> $captured */
+    $captured = new ArrayObject;
+
+    Event::listen(ActionOutcomeRejected::class, function ($event) use ($captured): void {
+        $captured[] = $event;
+    });
+
+    Event::listen(CompensationOutcomeRejected::class, function ($event) use ($captured): void {
+        $captured[] = $event;
+    });
+
+    return $captured;
+}
+
+it('hands the host the result an action produced and could not record', function () {
+    $captured = [];
+    Event::listen(ActionOutcomeRejected::class, function (ActionOutcomeRejected $event) use (&$captured): void {
+        $captured[] = $event;
+    });
+
+    $workerA = supersededAction(rejectedOutcomeRun());
+
+    expect(app(ActionRecorder::class)->completeAction($workerA, ['charge_id' => 'ch_9f3']))->toBeFalse()
+        // The loss is real: the row keeps nothing of what this worker produced.
+        ->and($workerA->fresh()->result)->toBeNull();
+
+    expect($captured)->toHaveCount(1);
+
+    expect($captured[0]->outcome)->toBe(FlowEventType::ActionCompleted)
+        ->and($captured[0]->result)->toBe(['charge_id' => 'ch_9f3'])
+        ->and($captured[0]->exception)->toBeNull()
+        ->and($captured[0]->actionRun->id)->toBe($workerA->id)
+        ->and($captured[0]->actionRun->sequence)->toBe(0)
+        ->and($captured[0]->actionRun->action_class)->toBe(MakeValueAction::class);
+});
+
+it('hands the host the throw an action produced, which is not rethrown either', function () {
+    $captured = [];
+    Event::listen(ActionOutcomeRejected::class, function (ActionOutcomeRejected $event) use (&$captured): void {
+        $captured[] = $event;
+    });
+
+    $workerA = supersededAction(rejectedOutcomeRun());
+    $thrown = new RuntimeException('gateway said no');
+
+    expect(app(ActionRecorder::class)->failAction($workerA, $thrown))->toBeFalse()
+        ->and($workerA->fresh()->exception)->toBeNull();
+
+    expect($captured)->toHaveCount(1);
+
+    // ActionDispatcher deliberately swallows this throw rather than failing a job whose
+    // work was already discarded, so the event is the only place it is ever named.
+    expect($captured[0]->outcome)->toBe(FlowEventType::ActionFailed)
+        ->and($captured[0]->exception)->toBe($thrown)
+        ->and($captured[0]->result)->toBeNull();
+});
+
+it('hands the host the result a compensation produced and could not record', function () {
+    $captured = [];
+    Event::listen(CompensationOutcomeRejected::class, function (CompensationOutcomeRejected $event) use (&$captured): void {
+        $captured[] = $event;
+    });
+
+    $workerA = supersededCompensation(rejectedOutcomeRun());
+
+    expect(app(CompensationRecorder::class)->completeCompensation($workerA, ['refund_id' => 're_77']))->toBeFalse()
+        ->and($workerA->fresh()->result)->toBeNull();
+
+    expect($captured)->toHaveCount(1);
+
+    expect($captured[0]->outcome)->toBe(FlowEventType::CompensationCompleted)
+        ->and($captured[0]->result)->toBe(['refund_id' => 're_77'])
+        ->and($captured[0]->exception)->toBeNull()
+        ->and($captured[0]->compensationRun->id)->toBe($workerA->id);
+});
+
+it('hands the host the throw a compensation produced and could not record', function () {
+    $captured = [];
+    Event::listen(CompensationOutcomeRejected::class, function (CompensationOutcomeRejected $event) use (&$captured): void {
+        $captured[] = $event;
+    });
+
+    $workerA = supersededCompensation(rejectedOutcomeRun());
+    $thrown = new RuntimeException('refund gateway said no');
+
+    expect(app(CompensationRecorder::class)->failCompensation($workerA, $thrown))->toBeFalse()
+        ->and($workerA->fresh()->exception)->toBeNull();
+
+    expect($captured)->toHaveCount(1);
+
+    expect($captured[0]->outcome)->toBe(FlowEventType::CompensationFailed)
+        ->and($captured[0]->exception)->toBe($thrown)
+        ->and($captured[0]->result)->toBeNull();
+});
+
+it('hands the listener a model reading as the row, not as the refused outcome', function () {
+    $captured = [];
+    Event::listen(ActionOutcomeRejected::class, function (ActionOutcomeRejected $event) use (&$captured): void {
+        $captured[] = [
+            'status' => $event->actionRun->status,
+            'result' => $event->actionRun->result,
+            'dirty' => array_keys($event->actionRun->getDirty()),
+        ];
+    });
+
+    $workerA = supersededAction(rejectedOutcomeRun());
+
+    app(ActionRecorder::class)->completeAction($workerA, ['charge_id' => 'ch_9f3']);
+
+    // A listener that saved this model would write the refused outcome back with no
+    // fence under it. The payload travels in the event, never on the model.
+    expect($captured[0]['status'])->toBe(ActionStatus::Running)
+        ->and($captured[0]['result'])->toBeNull()
+        ->and($captured[0]['dirty'])->toBe([]);
+});
+
+it('says nothing when the outcome is recorded', function () {
+    $captured = captureRejections();
+
+    $run = rejectedOutcomeRun();
+    $recorder = app(ActionRecorder::class);
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Pending,
+        'attempts' => 0,
+    ]);
+
+    expect($recorder->startAction($action))->toBeTrue()
+        ->and($recorder->completeAction($action, ['charge_id' => 'ch_9f3']))->toBeTrue()
+        ->and($action->fresh()->result)->toBe(['charge_id' => 'ch_9f3'])
+        ->and($captured->getArrayCopy())->toBe([]);
+});
+
+it('says nothing for a refused expiry, which discards nothing a worker produced', function () {
+    $captured = captureRejections();
+
+    $run = rejectedOutcomeRun();
+
+    $action = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Completed,
+        'attempts' => 1,
+    ]);
+
+    // expireAction shares the anomaly reason but not the loss: the exception it writes
+    // is the monitor's own account of the deadline, not a value only this worker holds.
+    expect(app(ActionRecorder::class)->expireAction($action, ['class' => 'X', 'message' => 'overdue']))
+        ->toBeFalse()
+        ->and($captured->getArrayCopy())->toBe([]);
+});
+
+it('carries a payload the recommended queued listener can actually be given', function () {
+    useDatabaseQueue();
+
+    Event::listen(ActionOutcomeRejected::class, QueuedRejectionListener::class);
+
+    $captured = [];
+    Event::listen(ActionOutcomeRejected::class, function (ActionOutcomeRejected $event) use (&$captured): void {
+        $captured[] = $event->result;
+    });
+
+    $workerA = supersededAction(rejectedOutcomeRun());
+
+    // Laravel serialises the listener job with the event inside it. Handing over the
+    // value the action returned would put a closure under PHP's serialize() and throw
+    // out of a branch whose whole point is not to; the recorded form cannot.
+    expect(app(ActionRecorder::class)->completeAction($workerA, new ClosureBackedResult))->toBeFalse()
+        ->and(DB::table('jobs')->count())->toBe(1)
+        ->and($captured)->toBe([['charge_id' => 'ch_9f3']]);
+});
+
+it('journals a listener that throws instead of failing the job over it', function () {
+    $path = sys_get_temp_dir().'/saga-rejection-'.uniqid().'.log';
+    logToFile($path);
+
+    Event::listen(ActionOutcomeRejected::class, ThrowingRejectionListener::class);
+
+    $workerA = supersededAction(rejectedOutcomeRun());
+
+    // Letting this throw would fail the job, and RunActionJob::failed() then writes
+    // queue bookkeeping into the row the second worker now owns — measured: the
+    // exhausted-attempts fence passes, because both claims read Running.
+    expect(app(ActionRecorder::class)->completeAction($workerA, ['charge_id' => 'ch_9f3']))->toBeFalse()
+        ->and(file_get_contents($path))->toContain('rejection_undelivered')
+        ->and(file_get_contents($path))->toContain('listener blew up');
+});

--- a/tests/Fixtures/ClosureBackedResult.php
+++ b/tests/Fixtures/ClosureBackedResult.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use Closure;
+use JsonSerializable;
+
+/**
+ * An action result the package's serializer accepts and PHP's `serialize()` refuses:
+ * it presents clean data through JsonSerializable while holding a closure. Handing
+ * one of these to a listener verbatim is what breaks a queued listener, so it stands
+ * in for every result carrying a connection, a container binding, or a callback.
+ */
+final class ClosureBackedResult implements JsonSerializable
+{
+    private Closure $unserializable;
+
+    public function __construct()
+    {
+        $this->unserializable = fn (): int => 1;
+    }
+
+    public function jsonSerialize(): mixed
+    {
+        return ['charge_id' => 'ch_9f3'];
+    }
+}

--- a/tests/Fixtures/QueuedRejectionListener.php
+++ b/tests/Fixtures/QueuedRejectionListener.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionOutcomeRejected;
+use Illuminate\Contracts\Queue\ShouldQueue;
+
+/**
+ * The listener the documentation recommends: queued, so it cannot interrupt the
+ * engine. Laravel serialises the whole listener job, event included, which is what
+ * puts the event's payload under PHP's `serialize()`.
+ */
+final class QueuedRejectionListener implements ShouldQueue
+{
+    public function handle(ActionOutcomeRejected $event): void {}
+}

--- a/tests/Fixtures/ThrowingRejectionListener.php
+++ b/tests/Fixtures/ThrowingRejectionListener.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionOutcomeRejected;
+use RuntimeException;
+
+/**
+ * A synchronous listener that throws — the contract the documentation asks hosts not
+ * to break, and which on this one path must not be allowed to fail the job.
+ */
+final class ThrowingRejectionListener
+{
+    public function handle(ActionOutcomeRejected $event): void
+    {
+        throw new RuntimeException('listener blew up');
+    }
+}


### PR DESCRIPTION
Closes #31.

A worker that finishes a step whose row has moved on has its outcome refused — the right call for
the run — and until now the value it produced went nowhere. One `outcome_rejected` log line named the
loss without carrying it. Two new events hand it to the host, which is the only party that can decide
where a business payload belongs.

## What the measurement changed

**Step 0 was instrumented across the whole suite before anything was written.** 27 refusals, 11
shapes. Three things came out of it that the issue and the plan did not say:

**`writeOutcome()` exists in two classes.** `CompensationRecorder::writeOutcome()` discards a
compensation's result identically, and it is a live path — `ClaimFencingTest` already exercises it,
throwing away the payload `'stale'`. So there are two events, not one.

**Four call paths need voicing, not eight conditional writers.** Only `writeOutcome` loses work that
was produced:

| site | refusals in the suite | what dies |
| --- | --- | --- |
| `writeOutcome` / `action.completed` | 9 | the value the action returned |
| `writeOutcome` / `action.failed` | 2 | the throw — `ActionDispatcher` deliberately does not rethrow it |
| `writeOutcome` / `compensation.completed` | 1 | the value the compensation returned |
| `expireAction` | 1 | nothing produced: the exception is the monitor's own account of the deadline |
| `writeFenced` ×5 | 14 | nothing: statuses, counters, timestamps |

`expireAction` shares the anomaly reason and deliberately raises no event; a test pins that boundary.

**No `ShouldDispatchAfterCommit`.** All 12 payload-losing refusals fire at `DB::transactionLevel()
=== 0` across the suite, so the interface would be a no-op — and its only effect would be to withhold
the notice under a host transaction, the one case where the payload is certainly lost.

## Shape

`ActionOutcomeRejected` and `CompensationOutcomeRejected` carry the step's row, a `FlowEventType`
naming which outcome was refused, the result and the throw. `$result` is the value **in the form the
row would have stored it**, so a host's reconciliation reads the same whether the outcome landed or
not — and a queued listener can be handed it.

The model is passed through `discardChanges()` first, as `writeFenced()` already does: a listener
that saved a model still holding the refused outcome would write it back with no fence under it. The
payload travels in the event, never on the model.

Neither event is written to `flow_events`. An abandoned attempt changed nothing in the run's history.

## The path this must not reopen

`ActionDispatcher::execute()` says in its own comment why a refused outcome is not rethrown:
`RunActionJob::failed()` would then write queue bookkeeping into a row this worker no longer owns. A
synchronous event in the refusal branch reopened exactly that. Measured in three links:

- a queued listener plus a result the package's serializer accepts and PHP's `serialize()` refuses (a
  `JsonSerializable` holding a closure) → `Serialization of 'Closure' is not allowed` escapes
  `completeAction()`;
- any synchronous listener that throws escapes it the same way;
- `markQueueAttemptsExhausted()` on the reclaimed row **passes its fence and writes `true`** — the
  fence names `queue_attempts_exhausted`, `status` and `retry_signal_attempts`, and both claims read
  `Running`.

So the loser's job would have corrupted the winner's row. Closed two ways: the recorded form of the
result is queue-safe by construction, and `announceRejection()` catches the throw and journals a new
reason, `rejection_undelivered`, following the existing `retry_policy_threw` precedent. That reason
code is a defect in listener code, not a race, and it is documented as such.

## Tests

Nine, each verified by a mutation that is a true revert — eleven mutations, each reddening exactly
its own test:

| mutation | goes red |
| --- | --- |
| remove the action event | 5 |
| remove the compensation event | 2 |
| remove `discardChanges()` | 1 |
| also fire from `expireAction` | 1 |
| also fire on a successful write | 1 |
| drop the action payload | 1 |
| drop the compensation payload | 1 |
| pass the throw into the `result` slot | 1 |
| pass the raw result instead of the recorded form | 1 |
| remove the catch around `event()` | 1 |
| drop the compensation's exception | 1 |

Two tests were passing for the wrong reason and the mutations caught both. The collector helper
returned an array **by value** — a copy taken before any listener had appended to it — so both
"says nothing" tests could never fail; it is an `ArrayObject` now. And the refused `failCompensation()`
had no test at all, so dropping its `exception:` argument left everything green.

## Documentation

New `{#refused-outcome}` section in `docs/docs/events.md`, linked from README, UPGRADING (item 23),
`reclaim-and-recovery.md` and `queues-locks-idempotency.md`. Four sentences this change falsified are
corrected: "the engine mirrors its `flow_events` log onto Laravel events" now has its exception,
"a superseded worker's write ... fires no event" and UPGRADING item 4's "raises no event" no longer
say that, and "a lost claim, a rejected outcome and an early-closed batch are all normal and all
silent" is now accurate. The journal's reason codes go from six to seven.

These two events are also the documented exception to "listeners must be queued, or must not throw":
a throw on this path is journalled rather than propagated, because failing the job here is what
reaches the other worker's row.

## Runs

SQLite 436 passed / 4 skipped, MySQL 436 / 4, PostgreSQL 440 / 0. Pint and PHPStan (level 5) clean.
The docs site builds.
