### PR TITLE
Step a run the sweep cannot expire aside instead of holding the page

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -506,6 +506,14 @@ does not rethrow. Nothing is stored and nothing about the run changes. A listene
 journalled as `rejection_undelivered` rather than failing the job, since this path must stay quiet.
 See [Events](https://sagalaraflow.dev/events#refused-outcome).
 
+### 24. A run the sweep cannot expire now steps aside instead of holding the page
+
+The monitor reads one page of overdue runs, oldest first, and a run whose rollback it cannot plan
+kept its place in it — enough of them at the head and the runs behind were never inspected. Such a
+run is now held off for a widening window (`monitor.expiration.backoff`, 60s doubling to an hour)
+and counted in two new `flow_runs` columns, so the page moves on and the journal stops repeating
+itself. There is no attempt cap: the cause can be temporary. Run `php artisan migrate`.
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/config/saga-lara-flow.php
+++ b/config/saga-lara-flow.php
@@ -111,6 +111,12 @@ return [
             'enabled' => true,
             'batch_size' => 100,
 
+            // A run whose rollback the sweep cannot plan steps aside for this long
+            // (exponential, per run) instead of holding its place in the page. There
+            // is no attempt cap: the cause can be temporary, and the ceiling is what
+            // keeps a permanent one cheap.
+            'backoff' => ['base_seconds' => 60, 'max_seconds' => 3600],
+
             // Default deadlines (in seconds) applied at write time when none is set
             // explicitly: 'run' on create, 'action' on schedule, 'signal' on await.
             // null = off (no implicit deadline). There is no per-entity opt-out flag;

--- a/database/migrations/2026_08_31_000000_add_expiry_backoff_to_flow_runs.php
+++ b/database/migrations/2026_08_31_000000_add_expiry_backoff_to_flow_runs.php
@@ -1,0 +1,37 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'flow_runs', function (Blueprint $table): void {
+            $table->unsignedInteger('expiry_attempts')->default(0)->after('repair_available_at');
+            $table->timestamp('expiry_available_at')->nullable()->after('expiry_attempts');
+        });
+    }
+
+    public function down(): void
+    {
+        $schema = Schema::connection($this->connection());
+
+        $schema->table($this->prefix().'flow_runs', function (Blueprint $table): void {
+            $table->dropColumn(['expiry_attempts', 'expiry_available_at']);
+        });
+    }
+
+    private function connection(): ?string
+    {
+        return config('saga-lara-flow.database.connection');
+    }
+
+    private function prefix(): string
+    {
+        return (string) config('saga-lara-flow.database.table_prefix', '');
+    }
+};

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -75,6 +75,28 @@ A sweep only ever looks at work belonging to a run that is still going. A run th
 and waits as it ends (see [statuses](./statuses.md)), and the scan skips whatever was left unsettled before that, so a
 batch is always filled with candidates a sweep can actually act on.
 
+## A run the sweep cannot expire
+
+Expiring a run means replaying it to find what to undo, and that replay can throw — a workflow reading something that
+has since gone, or a deploy that edited a workflow with runs still in flight. The sweep journals `expiry_failed`,
+leaves the run exactly where it found it, and holds it off for a while so the page of candidates moves on to the runs
+behind it:
+
+```php
+'monitor' => [
+    'expiration' => [
+        'batch_size' => 100,
+        'backoff' => ['base_seconds' => 60, 'max_seconds' => 3600],
+    ],
+],
+```
+
+The window doubles with each failure up to `max_seconds`, and `flow_runs.expiry_attempts` counts them for you to
+query. A held-off run rejoins the queue on the time its window opens rather than on its original deadline, so however
+many of them there are they cannot queue ahead of a run that has been overdue longer than they have waited. There is **no attempt cap**: the cause is often temporary, so a run that becomes plannable again is expired on
+the next open window. Nothing resets the count, so a run that has been failing since Tuesday says so. Fixing the
+workflow is still the actual remedy — see [Reclaim & recovery](./reclaim-and-recovery.md).
+
 ## Repair (the doctor)
 
 Separate from expiration: the **doctor** recovers a run whose progress was lost to a *dropped job* — an action that

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -234,7 +234,8 @@ is about a run rather than a row, and carries the run id, its workflow class and
 - **`claim_not_committed`** — a claim was written and was gone once its transaction closed. The line carries both
   attempt counts, the claimed one and the one the row actually holds.
 - **`expiry_failed`** — the sweep could not plan an overdue run's rollback, so it left the run alone and moved on to
-  the next. The line carries the throw. The run stays overdue and is tried again on the next sweep.
+  the next. The line carries the throw and how many times this run has failed that way. The run stays overdue and is
+  tried again once its hold-off window opens.
 - **`write_refused`** — a write to a step was refused because the row had moved on since it was read, or the run under
   it had finished. The line carries a `site` naming which write it was.
 - **`rejection_undelivered`** — the rejection event above could not be handed over: a listener threw, or a queued one
@@ -250,8 +251,11 @@ cancelled points the same way as `claim_lost` — a queue timeout tuned shorter 
 
 The remaining two are not races and do not come from tuning. `expiry_failed` means the run's own `handle()` threw
 while the sweep was replaying it to find the compensations — a workflow reading something that has since gone, most
-often. Until
-that is fixed the run cannot be expired, but nothing else in the sweep is held up by it.
+often, or a deploy that edited a workflow with runs still in flight. Until that is fixed the run cannot be expired.
+Nothing else in the sweep is held up by it: the run is held off for a window that doubles with each failure up to
+`monitor.expiration.backoff.max_seconds`, so it drops out of the candidate page and the runs behind it are reached.
+`flow_runs.expiry_attempts` counts them. There is no cap — a cause that clears is picked up on the next open
+window — and nothing resets the count, so a run that has been failing for a week says so.
 
 `claim_not_committed` is the other one: something ran inside the engine's own transaction and left it
 unusable. On PostgreSQL a single failed statement aborts a transaction and turns the eventual commit into a rollback

--- a/src/Contracts/FlowRepository.php
+++ b/src/Contracts/FlowRepository.php
@@ -28,8 +28,10 @@ interface FlowRepository
     public function findOrFail(string $id): FlowRun;
 
     /**
-     * Non-terminal runs (Running/Waiting) whose expires_at deadline has passed,
-     * oldest first, capped at $limit. Used by the monitor to expire stuck runs.
+     * Non-terminal runs (Running/Waiting) whose expires_at deadline has passed and
+     * whose hold-off window is open, capped at $limit. Ordered by the longest wait the
+     * monitor can act on: the hold-off window where a run has one, the deadline
+     * otherwise. Used by the monitor to expire stuck runs.
      *
      * @return iterable<int, FlowRun>
      */

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -33,6 +33,8 @@ use Illuminate\Support\Carbon;
  * @property ?Carbon $cancelled_at
  * @property int $repair_attempts
  * @property ?Carbon $repair_available_at
+ * @property int $expiry_attempts
+ * @property ?Carbon $expiry_available_at
  * @property ?Carbon $created_at
  * @property ?Carbon $updated_at
  */
@@ -60,6 +62,8 @@ class FlowRun extends Model
             'cancelled_at' => 'datetime',
             'repair_attempts' => 'integer',
             'repair_available_at' => 'datetime',
+            'expiry_attempts' => 'integer',
+            'expiry_available_at' => 'datetime',
         ];
     }
 

--- a/src/Repositories/EloquentFlowRepository.php
+++ b/src/Repositories/EloquentFlowRepository.php
@@ -43,11 +43,22 @@ class EloquentFlowRepository implements FlowRepository
 
     public function dueForExpiration(int $limit): iterable
     {
+        $now = Carbon::now();
+
         return $this->flowRunClass()::query()
             ->whereIn('status', [FlowStatus::Running, FlowStatus::Waiting])
             ->whereNotNull('expires_at')
-            ->where('expires_at', '<=', Carbon::now())
-            ->orderBy('expires_at')
+            ->where('expires_at', '<=', $now)
+            // A run the sweep could not expire steps aside for a while, so it stops
+            // holding its place at the head of the page.
+            ->where(function (Builder $query) use ($now): void {
+                $query->whereNull('expiry_available_at')
+                    ->orWhere('expiry_available_at', '<=', $now);
+            })
+            // Oldest first means oldest of what can be acted on now, not oldest
+            // deadline: a run held off carries its retry time instead, so retries
+            // cannot queue ahead of a run that has been waiting longer than they have.
+            ->orderByRaw('coalesce(expiry_available_at, expires_at) asc')
             ->limit($limit)
             ->get();
     }

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -13,7 +13,9 @@ use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use Illuminate\Database\Query\Builder;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Throwable;
 
@@ -107,11 +109,11 @@ final readonly class FlowMonitor
      * back queued, finalize as Expired) lives on FlowExecutor — the owner of every
      * run-terminal transition — and is shared with the lazy drive() deadline check.
      *
-     * A run whose rollback the sweep could not plan is journalled and stepped over.
-     * Letting that throw out would cost far more than the run it came from: the batch
-     * is read oldest first and the run is still overdue, so the same one would come
-     * back every sweep and the signal and action passes below would never run at all.
-     * The lazy check inside drive() has one run to answer for and still surfaces it.
+     * A run whose rollback the sweep could not plan is journalled, held off, and
+     * stepped over. Letting that throw out would cost far more than the run it came
+     * from: the same run would come back every sweep and the signal and action passes
+     * below would never run at all. The lazy check inside drive() has one run to answer
+     * for and still surfaces it.
      *
      * Only that failure, and it says so by its type. Everything else happened after
      * the run had already been moved — by this pass or by whoever else was holding it
@@ -124,16 +126,67 @@ final readonly class FlowMonitor
 
             return true;
         } catch (ExpirationNotPlannedException $failure) {
+            $this->holdOff($run);
+
             app(AnomalyLog::class)->log(AnomalyLog::REASON_EXPIRY_FAILED, [
                 'entity' => 'flow',
                 'flow_run_id' => $run->id,
                 'workflow_class' => $run->workflow_class,
                 'status' => $run->status->value,
+                'expiry_attempts' => $run->expiry_attempts,
                 'exception' => $this->exceptionToArray($failure->getPrevious() ?? $failure),
             ]);
 
             return false;
         }
+    }
+
+    /**
+     * Step a run that could not be planned aside for a while, so the page moves on to
+     * the ones behind it and the journal stops repeating itself every pass. Unlike the
+     * doctor's throttle it never gives up: a planning failure can be temporary, and the
+     * growing window is what bounds one that is not.
+     *
+     * Written as a plain statement rather than through the model, for three reasons a
+     * save() got wrong: it raises no Eloquent events, so a host observer can neither
+     * cancel the hold-off nor throw out of a branch that must not throw; it leaves
+     * updated_at alone, which is the doctor's staleness clock; and it reads the count
+     * from the writer, so a stale replica read cannot roll an hour's window back to a
+     * minute. The write states back that the window is still open, so a second sweep on
+     * the same run cannot stack a hold-off on top of one that just happened — and since
+     * this is the only writer of either column, the count moves with the window and
+     * needs no separate check. Losing it means that sweep already did this.
+     */
+    private function holdOff(FlowRun $run): void
+    {
+        $now = Carbon::now();
+
+        $recorded = (int) $run->newQuery()->toBase()->useWritePdo()
+            ->where($run->getKeyName(), $run->getKey())
+            ->value('expiry_attempts');
+
+        $attempts = $recorded + 1;
+
+        $written = $run->newQuery()->toBase()
+            ->where($run->getKeyName(), $run->getKey())
+            ->where(function (Builder $query) use ($now): void {
+                $query->whereNull('expiry_available_at')
+                    ->orWhere('expiry_available_at', '<=', $now);
+            })
+            ->update([
+                'expiry_attempts' => $attempts,
+                'expiry_available_at' => $now->copy()->addSeconds($this->backoff($attempts)),
+            ]);
+
+        $run->expiry_attempts = $written === 1 ? $attempts : $recorded;
+    }
+
+    private function backoff(int $attempts): int
+    {
+        $base = (int) config('saga-lara-flow.monitor.expiration.backoff.base_seconds', 60);
+        $max = (int) config('saga-lara-flow.monitor.expiration.backoff.max_seconds', 3600);
+
+        return min($max, $base * (2 ** max(0, $attempts - 1)));
     }
 
     private function timeoutSignals(int $limit): int

--- a/src/Runtime/FlowMonitor.php
+++ b/src/Runtime/FlowMonitor.php
@@ -161,11 +161,7 @@ final readonly class FlowMonitor
     {
         $now = Carbon::now();
 
-        $recorded = (int) $run->newQuery()->toBase()->useWritePdo()
-            ->where($run->getKeyName(), $run->getKey())
-            ->value('expiry_attempts');
-
-        $attempts = $recorded + 1;
+        $attempts = $this->recordedAttempts($run) + 1;
 
         $written = $run->newQuery()->toBase()
             ->where($run->getKeyName(), $run->getKey())
@@ -178,7 +174,16 @@ final readonly class FlowMonitor
                 'expiry_available_at' => $now->copy()->addSeconds($this->backoff($attempts)),
             ]);
 
-        $run->expiry_attempts = $written === 1 ? $attempts : $recorded;
+        // Refused: the sweep that got there first holds the count this run is now on,
+        // and the journal line below has to name that one rather than the stale read.
+        $run->expiry_attempts = $written === 1 ? $attempts : $this->recordedAttempts($run);
+    }
+
+    private function recordedAttempts(FlowRun $run): int
+    {
+        return (int) $run->newQuery()->toBase()->useWritePdo()
+            ->where($run->getKeyName(), $run->getKey())
+            ->value('expiry_attempts');
     }
 
     private function backoff(int $attempts): int

--- a/src/SagaLaraFlowServiceProvider.php
+++ b/src/SagaLaraFlowServiceProvider.php
@@ -49,6 +49,7 @@ class SagaLaraFlowServiceProvider extends PackageServiceProvider
             ->hasMigration('2026_08_25_000000_add_reclaim_stale_running_columns')
             ->hasMigration('2026_08_26_000000_index_signal_waits')
             ->hasMigration('2026_08_26_000001_unique_flow_tag_keys')
+            ->hasMigration('2026_08_31_000000_add_expiry_backoff_to_flow_runs')
             ->runsMigrations()
             ->hasCommands([
                 MakeWorkflowCommand::class,

--- a/tests/Feature/MonitorExpiryBackoffTest.php
+++ b/tests/Feature/MonitorExpiryBackoffTest.php
@@ -1,0 +1,308 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\AnomalyLog;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SignalOnlyWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\VanishedArgumentWorkflow;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Support\Facades\DB;
+
+beforeEach(fn () => VanishedArgumentWorkflow::reset());
+
+/**
+ * An overdue run whose replay will throw once its argument is taken away.
+ */
+function overdueUnplannableRun(int $minutesOverdue): string
+{
+    $run = SagaFlow::create(VanishedArgumentWorkflow::class)->run();
+    drainQueue();
+
+    $run = SagaFlow::findRun($run->id);
+    $run->expires_at = now()->subMinutes($minutesOverdue);
+    $run->save();
+
+    return $run->id;
+}
+
+it('lets the run behind an unplannable one expire on the next pass', function () {
+    useDatabaseQueue();
+
+    // One row wide, so the stuck run IS the page — the same holds for any size once
+    // that many runs at the head fail.
+    config()->set('saga-lara-flow.monitor.expiration.batch_size', 1);
+
+    $stuck = overdueUnplannableRun(120);
+
+    $healthy = SagaFlow::create(SignalOnlyWorkflow::class)->run();
+    drainQueue();
+    $healthy = SagaFlow::findRun($healthy->id);
+    $healthy->expires_at = now()->subMinute();
+    $healthy->save();
+
+    VanishedArgumentWorkflow::$label = null;
+
+    // The first pass spends the page on the stuck run and steps it aside.
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(0)
+        ->and(SagaFlow::findRun($healthy->id)->status)->toBe(FlowStatus::Waiting);
+
+    // The second reaches the run behind it, which is what never happened before.
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1)
+        ->and(SagaFlow::findRun($healthy->id)->status)->toBe(FlowStatus::Expired)
+        ->and(SagaFlow::findRun($stuck)->status)->toBe(FlowStatus::Waiting);
+});
+
+it('counts the failure and stops re-reading the run every pass', function () {
+    useDatabaseQueue();
+    logToFile($path = sys_get_temp_dir().'/saga-backoff-'.bin2hex(random_bytes(6)).'.log');
+
+    $stuck = overdueUnplannableRun(120);
+    VanishedArgumentWorkflow::$label = null;
+
+    app(FlowMonitor::class)->sweep();
+
+    $run = SagaFlow::findRun($stuck);
+
+    expect($run->expiry_attempts)->toBe(1)
+        ->and($run->expiry_available_at)->not->toBeNull()
+        ->and($run->expiry_available_at->isFuture())->toBeTrue();
+
+    // Held off, so the next passes do not plan it again and the journal stops
+    // repeating the same line for as long as the window is open.
+    app(FlowMonitor::class)->sweep();
+    app(FlowMonitor::class)->sweep();
+
+    $log = is_file($path) ? (string) file_get_contents($path) : '';
+
+    expect(substr_count($log, AnomalyLog::REASON_EXPIRY_FAILED.'"'))->toBe(1)
+        ->and(SagaFlow::findRun($stuck)->expiry_attempts)->toBe(1)
+        // The count travels with the journal line too, so an operator reading the log
+        // can tell a first failure from the five hundredth.
+        ->and($log)->toContain('"expiry_attempts":1');
+});
+
+it('widens the window with each failure and stops at the ceiling', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.monitor.expiration.backoff.base_seconds', 60);
+    config()->set('saga-lara-flow.monitor.expiration.backoff.max_seconds', 200);
+
+    $stuck = overdueUnplannableRun(120);
+    VanishedArgumentWorkflow::$label = null;
+
+    $windows = [];
+
+    foreach (range(1, 3) as $attempt) {
+        app(FlowMonitor::class)->sweep();
+
+        $run = SagaFlow::findRun($stuck);
+        $windows[] = (int) now()->diffInSeconds($run->expiry_available_at, absolute: false);
+
+        // Reopen it by hand: the point here is the shape of the window, not the wait.
+        $run->expiry_available_at = null;
+        $run->save();
+    }
+
+    // 60, then 120, then 240 clipped to the 200 ceiling — never a give-up.
+    expect($windows[0])->toBeGreaterThan(50)->toBeLessThan(70)
+        ->and($windows[1])->toBeGreaterThan(110)->toBeLessThan(130)
+        ->and($windows[2])->toBeGreaterThan(190)->toBeLessThan(210)
+        ->and(SagaFlow::findRun($stuck)->expiry_attempts)->toBe(3);
+});
+
+it('reaches a run that has waited longer than the retries queued in front of it', function () {
+    useDatabaseQueue();
+
+    // Scaled to the shape that starves: once a page's worth of held-off runs comes
+    // back every period, retries can fill every pass for ever on deadline order alone.
+    config()->set('saga-lara-flow.monitor.expiration.batch_size', 1);
+    config()->set('saga-lara-flow.monitor.expiration.backoff.base_seconds', 60);
+    config()->set('saga-lara-flow.monitor.expiration.backoff.max_seconds', 120);
+
+    foreach ([600, 500, 400] as $minutesOverdue) {
+        overdueUnplannableRun($minutesOverdue);
+    }
+
+    $healthy = SagaFlow::create(SignalOnlyWorkflow::class)->run();
+    drainQueue();
+    $healthy = SagaFlow::findRun($healthy->id);
+    $healthy->expires_at = now()->subMinute();
+    $healthy->save();
+
+    VanishedArgumentWorkflow::$label = null;
+
+    $reached = null;
+
+    foreach (range(1, 40) as $sweep) {
+        app(FlowMonitor::class)->sweep();
+
+        if (SagaFlow::findRun($healthy->id)->status === FlowStatus::Expired) {
+            $reached = $sweep;
+
+            break;
+        }
+
+        $this->travel(60)->seconds();
+    }
+
+    // The three broken runs are much older, so on deadline order alone they hold every
+    // pass between them and this one is never looked at.
+    expect($reached)->not->toBeNull()->toBeLessThanOrEqual(10);
+});
+
+it('keeps host model events out of the pass that must not throw', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.monitor.expiration.batch_size', 1);
+
+    $stuck = overdueUnplannableRun(120);
+
+    $healthy = SagaFlow::create(SignalOnlyWorkflow::class)->run();
+    drainQueue();
+    $healthy = SagaFlow::findRun($healthy->id);
+    $healthy->expires_at = now()->subMinute();
+    $healthy->save();
+
+    VanishedArgumentWorkflow::$label = null;
+
+    FlowRun::updating(function (FlowRun $run): void {
+        throw new RuntimeException('a host observer on the run model');
+    });
+
+    // A save() here would hand the sweep to host code: a throw would escape the branch
+    // that exists not to throw, and a refusal would leave the run holding the page
+    // while the journal reported it stepped aside.
+    app(FlowMonitor::class)->sweep();
+    $this->travel(2)->minutes();
+    app(FlowMonitor::class)->sweep();
+
+    expect(SagaFlow::findRun($stuck)->expiry_attempts)->toBe(1)
+        ->and(SagaFlow::findRun($healthy->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('counts from the row the writer holds, not from a stale read', function () {
+    useDatabaseQueue();
+
+    $stuck = overdueUnplannableRun(120);
+    VanishedArgumentWorkflow::$label = null;
+
+    $table = (new FlowRun)->getTable();
+
+    DB::connection('testing')->table($table)->where('id', $stuck)->update([
+        'expiry_attempts' => 6,
+        'expiry_available_at' => now()->subMinute(),
+    ]);
+
+    // What a lagging replica hands the page: the row as it stood before those six.
+    FlowRun::retrieved(function (FlowRun $run) use ($stuck): void {
+        if ($run->id === $stuck) {
+            $run->expiry_attempts = 0;
+            $run->syncOriginal();
+        }
+    });
+
+    app(FlowMonitor::class)->sweep();
+
+    $row = DB::connection('testing')->table($table)->where('id', $stuck)->first();
+
+    // Six failures are on the row; the page was read before them. Counting from the
+    // model would write a seventh failure as a first one and shrink the window with it.
+    expect((int) $row->expiry_attempts)->toBe(7)
+        ->and((int) now()->diffInSeconds($row->expiry_available_at, absolute: false))
+        ->toBeGreaterThan(3500);
+});
+
+/**
+ * Stage the one interleaving that matters in a single process: run $competitor the
+ * moment the hold-off has read the count and before it writes.
+ */
+function betweenTheReadAndTheWrite(callable $competitor): void
+{
+    $fired = false;
+
+    DB::listen(function (QueryExecuted $query) use ($competitor, &$fired): void {
+        if ($fired || ! str_contains($query->sql, 'expiry_attempts') || ! str_starts_with($query->sql, 'select')) {
+            return;
+        }
+
+        $fired = true;
+
+        $competitor();
+    });
+}
+
+it('refuses a hold-off the row moved under', function () {
+    useDatabaseQueue();
+
+    $stuck = overdueUnplannableRun(120);
+    VanishedArgumentWorkflow::$label = null;
+
+    $table = (new FlowRun)->getTable();
+
+    // A second sweep on the same run gets there first: it counts a failure and takes
+    // the window. Stacking a hold-off on top of that would double the wait.
+    betweenTheReadAndTheWrite(fn () => DB::connection('testing')->table($table)
+        ->where('id', $stuck)
+        ->update(['expiry_attempts' => 4, 'expiry_available_at' => now()->addHour()]));
+
+    app(FlowMonitor::class)->sweep();
+
+    $row = DB::connection('testing')->table($table)->where('id', $stuck)->first();
+
+    expect((int) $row->expiry_attempts)->toBe(4)
+        ->and((int) now()->diffInSeconds($row->expiry_available_at, absolute: false))->toBeGreaterThan(3500);
+});
+
+it('refuses a hold-off when only the window was taken', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.monitor.expiration.backoff.max_seconds', 120);
+
+    $stuck = overdueUnplannableRun(120);
+    VanishedArgumentWorkflow::$label = null;
+
+    $table = (new FlowRun)->getTable();
+
+    // The count still reads as it did, so a fence on the count alone would let this
+    // write through and push the window a second time.
+    betweenTheReadAndTheWrite(fn () => DB::connection('testing')->table($table)
+        ->where('id', $stuck)
+        ->update(['expiry_available_at' => now()->addHour()]));
+
+    app(FlowMonitor::class)->sweep();
+
+    $row = DB::connection('testing')->table($table)->where('id', $stuck)->first();
+
+    expect((int) $row->expiry_attempts)->toBe(0)
+        ->and((int) now()->diffInSeconds($row->expiry_available_at, absolute: false))->toBeGreaterThan(3500);
+});
+
+it('holds a run off without resetting the clock the doctor reads', function () {
+    useDatabaseQueue();
+
+    $stuck = overdueUnplannableRun(120);
+
+    // The R2 shape: the wait was consumed, the resume that should have followed was
+    // lost, so the run sits Waiting with nothing in flight — a doctor candidate and an
+    // expiry candidate at the same time.
+    SagaFlow::loadFlow($stuck)->signal('go');
+    DB::connection('testing')->table('jobs')->delete();
+
+    $run = SagaFlow::findRun($stuck);
+    $run->updated_at = now()->subHour();
+    $run->save();
+
+    VanishedArgumentWorkflow::$label = null;
+
+    $repository = app(FlowRepository::class);
+    $grace = (int) config('saga-lara-flow.repair.grace_seconds');
+
+    expect(collect($repository->dueForRepair(100, $grace, 10))->pluck('id')->all())->toContain($stuck);
+
+    app(FlowMonitor::class)->sweep();
+
+    // updated_at is the staleness clock: a sweep that bumped it would keep this run
+    // permanently too fresh for the doctor, every minute, for ever.
+    expect(SagaFlow::findRun($stuck)->expiry_attempts)->toBe(1)
+        ->and(collect($repository->dueForRepair(100, $grace, 10))->pluck('id')->all())->toContain($stuck);
+});

--- a/tests/Feature/MonitorExpiryBackoffTest.php
+++ b/tests/Feature/MonitorExpiryBackoffTest.php
@@ -234,6 +234,7 @@ function betweenTheReadAndTheWrite(callable $competitor): void
 
 it('refuses a hold-off the row moved under', function () {
     useDatabaseQueue();
+    logToFile($path = sys_get_temp_dir().'/saga-loser-'.bin2hex(random_bytes(6)).'.log');
 
     $stuck = overdueUnplannableRun(120);
     VanishedArgumentWorkflow::$label = null;
@@ -251,7 +252,10 @@ it('refuses a hold-off the row moved under', function () {
     $row = DB::connection('testing')->table($table)->where('id', $stuck)->first();
 
     expect((int) $row->expiry_attempts)->toBe(4)
-        ->and((int) now()->diffInSeconds($row->expiry_available_at, absolute: false))->toBeGreaterThan(3500);
+        ->and((int) now()->diffInSeconds($row->expiry_available_at, absolute: false))->toBeGreaterThan(3500)
+        // The line has to name the count the run is actually on, not the one this
+        // pass read before losing.
+        ->and(is_file($path) ? (string) file_get_contents($path) : '')->toContain('"expiry_attempts":4');
 });
 
 it('refuses a hold-off when only the window was taken', function () {


### PR DESCRIPTION
Closes #52.

`FlowMonitor::expireRuns()` reads one page of overdue runs and has no loop. A run whose rollback it
cannot plan is journalled and stepped over — but keeps its place in the page. Enough of them at the
head and the page never advances: healthy overdue runs behind them are never inspected, on any sweep.

## The direction, chosen by measurement

The issue offers two: page past the failures (no migration) or back the candidate off (columns, a
migration). Five measurements on `main` chose the second.

1. **Unplannable is not always a temporary host fault.** Instrumenting `expireRunInner()` over the
   whole suite finds 3 failures, both fixtures throwing from `handle()`. But a targeted probe found
   the engine's own path: a workflow **edited by a deploy** throws `HistoryContractMismatchException`
   out of the collecting replay — `expiry_failed`, three sweeps, still `waiting`. One deploy makes
   every in-flight run of that workflow unplannable, in bulk, and permanently. A give-up cap would
   therefore be wrong: the temporary kind exists too.
2. **There is no loop** (`FlowMonitor::expireRuns()`), and `dueForExpiration()` called twice returns
   the identical page.
3. **The doctor's shape fits, its columns do not.** A run in the R2 shape (Waiting, signal consumed,
   resume lost) is *simultaneously* a doctor candidate and an expiry candidate, and pushing
   `repair_available_at` out removes it from the doctor's set. `flow_runs.repair_attempts` is never
   reset anywhere in `src/`. Hence its own columns.
4. **The migration is marginal.** v1.1.1 shipped two migrations; `main` carries five — 1.2.0 already
   adds three unreleased ones under a banner that already says to migrate.
5. **Paging past does not close the other two consequences, and makes one worse.** Cost per sweep,
   constant and never falling: k=1 → 4 queries / 1 journal line; k=10 → 13 / 10; k=40 → 43 / 40 —
   exactly one query and one line per broken run per sweep, for ever. Today the pass stops at
   `batch_size`, so the journal takes `min(k, limit)` lines; paging past every failure raises that to
   `k`. Wall time is small (≈0.2 ms per broken run), so the cost is journal volume. And paging can
   give an operator no count: there is nowhere to keep one.

## The change

- New migration: `flow_runs.expiry_attempts` and `flow_runs.expiry_available_at`. No new index — the
  existing `[status, expires_at]` drives the selection, and the window is a residual filter.
- `dueForExpiration()` skips a run whose window is still closed and orders by
  `coalesce(expiry_available_at, expires_at)`: oldest of what can be acted on *now*, so retries
  cannot queue ahead of a run that has been overdue longer than they have waited.
- `FlowMonitor::holdOff()` counts the failure and takes the window, written as a plain statement:
  no Eloquent events, `updated_at` untouched, the count read from the writer, and the write fenced on
  the window still being open.
- Config `monitor.expiration.backoff` = 60s doubling to 3600s. **No attempt cap**, unlike the doctor:
  the cause can be temporary, and the ceiling is what bounds one that is not. Nothing resets the
  count, so a run that has been failing for a week says so.

## Two constraints the issue does not name

- **Own columns, not the doctor's** — see measurement 3.
- **The hold-off must not touch `updated_at`**, which is the doctor's staleness clock with a 60s
  grace (CONTRIBUTING). A per-minute sweep bumping it would keep an R2-shaped run permanently too
  fresh to repair, and measurement 3 proves such a run exists. Covered by its own test.

## Runs

SQLite 445 passed / 4 skipped, MySQL 445 / 4, PostgreSQL 449 / 0. Pint and PHPStan (level 5) clean;
the docs site builds.

Thirteen mutations, nine tests, no predicate left uncovered: revert the window filter (2 red), revert
`holdOff()` (4), let the hold-off touch the timestamps (1), a flat window (1), no ceiling (1), no
count in the journal (1), revert the ordering (2), go back to `save()` (1), drop the open-window
fence (2), count from the model rather than the writer (1).

## From adversarial review, two rounds, five findings — four accepted

- **Starvation remained.** Ordering by `expires_at` does not move when a run is held off, so retries
  queue ahead of healthy runs for ever once `k ≥ batch_size × ceiling / period`. Measured in a scaled
  model: the healthy run did not expire within 40 sweeps. Fixed by the `coalesce` ordering — sweep 4.
- **A `save()` let host code into a branch that must not throw.** Measured: an observer on `FlowRun`
  that throws escapes `expireRun()` and aborts the whole sweep — the failure mode #35 closed; one
  returning `false` cancels the hold-off silently while the journal reports it happened. Fixed by
  writing through a plain statement.
- **An unfenced snapshot rolled the counter backwards.** With a lagging replica, six recorded attempts
  were overwritten as one and an hour's window shrank to 59s. Fixed by reading the count from the
  writer.
- **The fence did not check the window was still open**, so a second sweep could stack a hold-off on
  a run the first had just held off. Fixed; and the review's own suggestion — a query listener that
  writes between the read and the write — is how both interleavings are now staged in one process.
- **Rejected with a measured basis:** "ordering by an expression makes the sweep unbounded". At
  200,000 rows / 20,000 candidates: SQLite 0.26 → 8.58 ms, MySQL 65.08 → 65.64 ms, PostgreSQL
  8.5 → 8.92 ms. `status IN (…)` on the leading column means MySQL and PostgreSQL sorted *before*
  this change too — the plans say `filesort` and `Sort` either way.
