### PR TITLE
Read a terminal child as history instead of a frontier

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -478,7 +478,7 @@ See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
 Planning a manual rollback replays `handle()` to find the compensations. That replay no longer
 settles a spent optional step (`action.optional_failed`, with its `OptionalActionFailed` event) and
 no longer schedules a parallel block it had only reached to read. Nor is every throw the end of the
-stack now: four classes end it, and an unexpected throw surfaces out of `compensate()`, run
+stack now: six classes end it, and an unexpected throw surfaces out of `compensate()`, run
 untouched, rather than rolling back a truncated plan and reporting it complete.
 
 Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. The expiry
@@ -513,6 +513,16 @@ kept its place in it — enough of them at the head and the runs behind were nev
 run is now held off for a widening window (`monitor.expiration.backoff`, 60s doubling to an hour)
 and counted in two new `flow_runs` columns, so the page moves on and the journal stops repeating
 itself. There is no attempt cap: the cause can be temporary. Run `php artisan migrate`.
+
+### 25. A rollback no longer stops at a child that already finished
+
+Planning a rollback treated any awaited child that was not `Completed` as the live frontier, so a
+parent that carried on past a failed one under `->continueParentOnFailure()` rolled back only the
+steps before it — and `compensate()` reported that partial unwind as complete. A terminal child is
+now read the way an ordinary replay reads it, and the two throws that follow from it end the plan
+like a recorded step failure does. Rollbacks that were silently short are now whole, so a
+compensation you never saw run may start running. See
+[Child workflows](https://sagalaraflow.dev/child-workflows).
 
 ### Recommended while you are here
 

--- a/docs/docs/child-workflows.md
+++ b/docs/docs/child-workflows.md
@@ -59,3 +59,8 @@ still fails and compensates.
 
 To let the parent proceed regardless of the child's outcome, call `->continueParentOnFailure()` — the
 child's failure is then swallowed rather than thrown.
+
+A parent that carries on this way keeps collecting compensations, and a later rollback runs them: a
+child that has already finished is history the plan reads, not a frontier it stops at. A child still
+in flight is a frontier, so a rollback planned while one runs covers only the steps before it — the
+child rolls itself back through its own [close policy](#close-policies) instead.

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -94,10 +94,11 @@ SagaFlow::loadFlow($runId)->compensate(); // roll back completed steps, then can
 The rollback is planned before anything is undone: the handle replays `handle()` only to learn which
 completed steps carry compensations. Every seam is guarded for that pass, so it runs no business
 logic, starts no work, and settles no step — one it has not seen is a place to stop, not a place to
-schedule. (Your own `tag()` calls still rewrite their rows, as they do on every replay.) Four
-exception classes end that pass — the frontier it stopped at, and a step failure, an expiry or a
-signal timeout already in the run's history. Anything else is a fault, not an ending: an argument
-expression reading a record that has since been deleted, say. The plan is then incomplete, so
+schedule. (Your own `tag()` calls still rewrite their rows, as they do on every replay.) Six
+exception classes end that pass — the frontier it stopped at, and a step failure, an expiry, a
+signal timeout or an awaited child's failure or cancellation already in the run's history. Anything
+else is a fault, not an ending: an argument expression reading a record that has since been deleted,
+say. The plan is then incomplete, so
 `compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
 it and reporting a finished rollback. Fix the cause and call it again.
 

--- a/src/Runtime/ChildWorkflowManager.php
+++ b/src/Runtime/ChildWorkflowManager.php
@@ -67,18 +67,16 @@ readonly class ChildWorkflowManager
 
         $link = $this->guard->expectChild($parent->id, $sequence, $workflowClass);
 
-        // Compensation-only planning: replay a completed child, otherwise stop here
-        // (an unfinished child is the live frontier).
-        if ($runtime->isCollecting()) {
-            if ($link !== null && $link->child->status === FlowStatus::Completed) {
-                return $this->serializer->deserialize($link->child->result);
-            }
-
-            $this->suspender->suspend('child', $sequence);
-        }
-
+        // A recorded child resolves the same way for both replays: what it already
+        // came to is history, and a rollback has to be planned past it.
         if ($link !== null) {
             return $this->resolve($link, $continueParentOnFailure, $sequence);
+        }
+
+        // Compensation-only planning stops at a child this run never started: that is
+        // the live frontier, and the pass must not start one to find out.
+        if ($runtime->isCollecting()) {
+            $this->suspender->suspend('child', $sequence);
         }
 
         // First encounter: create and start the child, then suspend the parent.
@@ -120,6 +118,11 @@ readonly class ChildWorkflowManager
     }
 
     /**
+     * Resolve a child already recorded against this ordinal. A terminal child has an
+     * answer either way — a result, a failure the parent may be told to survive, or a
+     * cancellation it cannot — and only one still in flight is a wait. The compensation
+     * pass runs through here too, where a suspension would end the stack short.
+     *
      * @throws FlowSuspended
      * @throws ChildWorkflowFailedException
      * @throws ChildWorkflowCancelledException

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -10,6 +10,8 @@ use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ActionFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\AwaitSignalTimeoutException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ChildWorkflowCancelledException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\ChildWorkflowFailedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ExpirationNotPlannedException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowExpiredException;
@@ -148,9 +150,10 @@ class FlowExecutor
      * so completed steps register their compensations and the replay stops at the
      * live frontier. Every seam is guarded, so the pass starts no work and settles
      * no step; a workflow's own tag() calls still rewrite their rows, as they do on
-     * every replay. Used by FlowHandle::compensate(). A throw the
-     * replay did not expect is a fault, not a frontier, and leaves rather than
-     * shortening the stack behind the caller's back.
+     * every replay. Planned from three places — compensate(), the expiration sweep and
+     * a parent closing a child — so a throw the replay did not expect is a fault, not a
+     * frontier: it leaves rather than shortening the stack behind the caller's back,
+     * and the two callers the operator did not ask for absorb it where it lands.
      *
      * @return list<CompensationEntry>
      *
@@ -189,11 +192,12 @@ class FlowExecutor
                 $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
 
                 $this->callWithDependencies($workflow, 'handle', $arguments);
-            } catch (InternalFlowControl|ActionFailedException|FlowExpiredException|AwaitSignalTimeoutException) {
-                // The four classes that end a replay: the frontier, and a step failure,
-                // an expiry or a signal timeout already recorded in this run's history.
-                // Membership is all this tests — a caller raising one of these itself
-                // is read as an ending too, which is why the set is kept small.
+            } catch (InternalFlowControl|ActionFailedException|FlowExpiredException|AwaitSignalTimeoutException|ChildWorkflowFailedException|ChildWorkflowCancelledException) {
+                // The six classes that end a replay: the frontier, and a step failure,
+                // an expiry, a signal timeout or an awaited child's terminal outcome
+                // already recorded in this run's history. Membership is all this tests —
+                // a caller raising one of these itself is read as an ending too, which
+                // is why the set only grows for a throw the engine itself replays.
                 //
                 // Nothing else ends it. A throw from a builder argument, a workflow
                 // helper or anything else the replay runs is a fault, and swallowing it

--- a/tests/Feature/TerminalChildCollectionTest.php
+++ b/tests/Feature/TerminalChildCollectionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\SignalStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FailingChildWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\WaitingChildWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A child that already reached a terminal state is history, not a frontier. The
+ * collecting replay used to stop at anything other than Completed, so every
+ * compensation a parent registered after a failed or cancelled child was absent from
+ * the rollback while compensate() reported a complete unwind.
+ *
+ * Resolving those children the way the ordinary replay does turns two of them into
+ * throws, and both are recorded history replaying — so both have to end the collection
+ * rather than escape it. Without that, a run the sweep expires fine today becomes one
+ * it can never plan, which is the failure #52 was closed for.
+ */
+beforeEach(function (): void {
+    CompensationLog::reset();
+});
+
+final class ContinuePastFailedChildWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->child(FailingChildWorkflow::class)->continueParentOnFailure()->run();
+        $this->action(MakeValueAction::class, 'b')->compensateWith(UndoAction::class, 'b')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+final class StopAtFailedChildWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->child(FailingChildWorkflow::class)->run();
+        $this->action(MakeValueAction::class, 'b')->compensateWith(UndoAction::class, 'b')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+final class AwaitCancellableChildWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->child(WaitingChildWorkflow::class)->run();
+        $this->action(MakeValueAction::class, 'b')->compensateWith(UndoAction::class, 'b')->run();
+    }
+}
+
+final class ChildAfterSignalWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->awaitSignal('go');
+        $this->child(FailingChildWorkflow::class)->continueParentOnFailure()->run();
+        $this->action(MakeValueAction::class, 'b')->compensateWith(UndoAction::class, 'b')->run();
+    }
+}
+
+/**
+ * The window a parent sits in between its child finalizing and the resume job that
+ * tells it so: the parent is still Waiting, the child is already terminal, and any
+ * plan made now has to read the child from its row rather than wait on it.
+ */
+function parentWaitingOnTerminalChild(string $workflow, FlowStatus $childLands): FlowRun
+{
+    $run = SagaFlow::create($workflow)->expiresAt(now()->addMinutes(5))->run();
+    drainQueue();
+
+    $parent = FlowRun::query()->findOrFail($run->id);
+    $child = FlowRun::query()->where('parent_id', $parent->id)->firstOrFail();
+
+    $child->newQuery()->toBase()->where('id', $child->id)->update(['status' => $childLands->value]);
+    $parent->newQuery()->toBase()->where('id', $parent->id)->update(['status' => FlowStatus::Waiting->value]);
+    DB::connection('testing')->table('jobs')->delete();
+
+    return $parent->fresh();
+}
+
+function sequencesOf(FlowRun $parent): array
+{
+    return array_map(
+        fn ($entry) => $entry->sequence,
+        app(FlowExecutor::class)->collectCompensations($parent),
+    );
+}
+
+it('plans the steps a parent took after a child it was told to survive', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(ContinuePastFailedChildWorkflow::class)->run();
+    drainQueue();
+
+    $parent = FlowRun::query()->findOrFail($run->id);
+    expect($parent->status)->toBe(FlowStatus::Waiting)
+        ->and($parent->actions()->where('status', 'completed')->pluck('sequence')->all())->toBe([0, 2]);
+
+    // The child rolled itself back on its own way out; this is the parent's rollback.
+    CompensationLog::reset();
+
+    expect(sequencesOf($parent))->toBe([0, 2]);
+
+    $rolled = SagaFlow::loadFlow($parent->id)->compensate();
+
+    expect($rolled->status)->toBe(FlowStatus::Cancelled)
+        ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
+});
+
+it('ends a plan where a strict child ended the parent, without escaping', function () {
+    useDatabaseQueue();
+
+    $parent = parentWaitingOnTerminalChild(StopAtFailedChildWorkflow::class, FlowStatus::Failed);
+
+    // The parent never ran a step after the child, so the whole of what it did is 'a'.
+    expect(sequencesOf($parent))->toBe([0]);
+});
+
+it('ends a plan where a cancelled child ended the parent, without escaping', function () {
+    useDatabaseQueue();
+
+    $parent = parentWaitingOnTerminalChild(AwaitCancellableChildWorkflow::class, FlowStatus::Cancelled);
+
+    expect(sequencesOf($parent))->toBe([0]);
+});
+
+it('keeps expiring a run whose child failed under it', function () {
+    useDatabaseQueue();
+    logToFile($log = sys_get_temp_dir().'/terminal-child-'.uniqid().'.log');
+
+    $parent = parentWaitingOnTerminalChild(StopAtFailedChildWorkflow::class, FlowStatus::Failed);
+    $this->travel(600)->seconds();
+
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1)
+        ->and($parent->fresh()->status)->toBe(FlowStatus::Cancelling)
+        // A run the sweep can plan is never held off, so nothing queues behind it.
+        ->and($parent->fresh()->expiry_attempts)->toBe(0)
+        ->and(substr_count((string) @file_get_contents($log), 'expiry_failed'))->toBe(0);
+});
+
+it('stops at a child this run never started, and starts none to find out', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(ChildAfterSignalWorkflow::class)->run();
+    drainQueue();
+
+    // The R2 shape: the wait was consumed, the resume that would have reached the
+    // child was lost. The replay now gets past the signal with no child on record.
+    SagaFlow::loadFlow($run->id)->signal('go');
+    DB::connection('testing')->table((new FlowSignal)->getTable())
+        ->update(['status' => SignalStatus::Consumed->value]);
+    DB::connection('testing')->table('jobs')->delete();
+
+    $parent = FlowRun::query()->findOrFail($run->id);
+    $runsBefore = FlowRun::query()->count();
+
+    expect(sequencesOf($parent))->toBe([0])
+        ->and(FlowRun::query()->count())->toBe($runsBefore)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(0);
+});
+
+it('resolves a terminal child without writing anything down', function () {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(ContinuePastFailedChildWorkflow::class)->run();
+    drainQueue();
+    $parent = FlowRun::query()->findOrFail($run->id);
+
+    $writes = 0;
+    DB::listen(function ($query) use (&$writes): void {
+        if (! str_starts_with(strtolower(ltrim($query->sql)), 'select')) {
+            $writes++;
+        }
+    });
+
+    expect(sequencesOf($parent))->toBe([0, 2])
+        ->and($writes)->toBe(0);
+});


### PR DESCRIPTION
Closes #48.

`collectCompensations()` treated any awaited child that was not `Completed` as the live frontier. A
parent that carried on past a failed one under `->continueParentOnFailure()` therefore rolled back
only the steps *before* it, and `compensate()` reported that partial unwind as complete.

The collecting branch did not get rewritten — it went away. `resolve()`, the same one the ordinary
replay uses, now runs above the `isCollecting()` check, so both replays read a recorded child the
same way; collection keeps one rule of its own, which is not to start a child this run never
started. The two throws that follow (`ChildWorkflowFailedException`, `ChildWorkflowCancelledException`)
join the allow-list in `collectCompensationsInner()`, four classes to six.

## Step 0 — five measurements, and two of them changed the scope

**1. Six classes is enough, but not because I guessed.** An instrumented `catch` over the whole
suite, with the shape applied and the list *not* expanded, sees 57 throws: 37 × `FlowSuspended`
(4 of them from `ChildWorkflowManager::resolve`) and 19 × `RuntimeException` from the #35 fixtures,
which correctly leave. Not one child class. The suite stays green without the list expansion — it
does not cover these classes at all, so they had to be reached with targeted probes, as in #35.

**2. The state space is eight, not three.** Every child status, one scene (parent `waiting`,
compensatable steps 0 and 2):

```
completed  -> [0,2]      failed(continue) -> [0,2]
cancelled  -> throws ChildWorkflowCancelledException
expired    -> [0]        cancelling       -> [0]
waiting / running / pending -> [0]
```

`Expired` falls into `default => suspend` and this shape does **not** cover it — but it is not
reachable through the package's API: `createChild()` bypasses `CreateWorkflowBuilder`, so a child
gets no `expires_at` from `#[FlowTimeout(seconds: 1)]` (measured: `NULL`) or from
`monitor.expiration.defaults.run = 5` (parent got one, child did not), and only the sweep and
`SagaRunner` write `Expired`, both off `expires_at`. Filed as #59 rather than widened into here.
`Cancelling` is a child in flight, so suspending is right.

Can the `Cancelled` arm hide a parent that carried on? No: `allowedFrom()` is empty for all four
terminal states (`FlowStateMachine:219-222`), so a child that was `Completed` when the parent
replayed past it can never later become `Cancelled`.

**3. Three callers, measured as a number — and it went to zero.** The window scene (parent
`Waiting`, *strict* child `Failed`, resume job not yet run), two sweeps:

| | sweep 1 | parent | `expiry_attempts` | `expiry_failed` lines |
|---|---|---|---|---|
| A `main` | `runs:1` | cancelling | 0 | **0** |
| B shape only | `runs:0` | waiting | 1 | **2** |
| C shape + list | `runs:1` | cancelling | 0 | **0** |

C restores A exactly. The list is not "nice to have alongside" — without it every sweep writes a
line and holds a healthy run off, which is the failure #52 was closed for. `compensate()` and
`CancelChildWorkflowJob::close()` pass cleanly under C; `close()` plans twice, so the new classes
reach it twice.

**4. Collection still writes nothing.** Zero non-`select` statements while planning over a terminal
child, no row count moved in any of ten tables, `flow_runs.updated_at` untouched.

**5. `expiry_attempts` makes no prose false.** A run at `attempts=3` with a shut window → `runs:0`;
once the window opens → `runs:1`, counter still 3. Both doc sentences already say precisely that.

## Tests and mutations

Six tests in `tests/Feature/TerminalChildCollectionTest.php`; six mutations — M1 revert the shape
(2 red), M2 drop `ChildWorkflowFailedException` (2), M3 drop `ChildWorkflowCancelledException` (1),
M4 drop the frontier guard (1), M5 make `Failed` always throw, ignoring `continueParentOnFailure`
(2), M6 let `resolve()` write while collecting (1).

**M4 was green at first, and that made it the tenth test of mine to pass for the wrong reason.** The
"a child this run never started" scene was built with `signal('go')` plus deleting the jobs, but the
signal stayed `Received`, so `SignalWaiter` suspended the collecting replay on the *signal* ordinal
and never reached the child at all — the test was asserting an emptiness. Rebuilt as the real R2
shape (signal moved to `Consumed`, resume lost); M4 is red now. Caught by the mutation, not by
review.

**M6 was green at first too, and there the mutation was the blind one.** `$link->touch()` on a
`FlowChild` writes nothing when `updated_at` already holds the same second — the attribute never
goes dirty and `save()` issues no `UPDATE`. Replaced with an explicit `UPDATE`, which is red. The
zero-writes assertion is live; the mutation was not.

## Adversarial review

One [high] finding, and it is real but not this change: the collecting replay reads history through
ordinary reads, so a lagging replica yields a short plan — CONTRIBUTING:98 exactly. Measured with a
`retrieved` observer modelling the replica:

| | A: replica shows the child still `Running` | B: replica shows the parent's **own** step 2 still `Running`, child fresh | C: nothing lagging |
|---|---|---|---|
| `main` | `[0]` | `[0]` | `[0]` |
| this branch | `[0]` | `[0]` | `[0,2]` |

Column **B** settles it: the child is fresh there and the plan is still short, so the exposure
belongs to every history read the collecting replay makes, not to the child seam. A and B are
identical before and after, so nothing here regresses. The review's own recommendation — route
*every* history read to the writer — is a different concern by its own wording. Filed as #60 with
both columns and two candidate fixes; patching only the child seam would make the seam look safe
while column B stayed open.

## Runs

SQLite 451 passed / 4 skipped, MySQL 451/4, PostgreSQL 455/0 (from 445/4, 445/4, 449/0). Pint and
PHPStan level 5 clean; the docs site builds.

## Text

`UPGRADING.md` item 21 "four classes" → "six", plus a new item 25; `sagas-and-compensation.md` the
same count with the child's outcome named; `child-workflows.md` a paragraph under
`continueParentOnFailure()` on a finished child being history and a child in flight being the
frontier. Width checked against each file (100). The `collectCompensations()` docblock said "Used by
FlowHandle::compensate()" and there are four call sites — corrected in the same pass, since this
change makes the new throws reachable from all of them.
