### PR TITLE
Refuse new work under a run that is rolling back

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,9 +102,17 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
 
 ### Status boundaries
 
-`FlowStatus::terminal()` and `FlowStatus::signalable()` are different sets and are not
-interchangeable. `Cancelling` is **not** terminal — it is a run mid-rollback. Swapping one boundary
-for the other changes public behaviour and needs its own exception and its own documentation.
+`FlowStatus::terminal()`, `FlowStatus::signalable()` and `FlowStatus::mayStartWork()` are different
+sets and are not interchangeable. `Cancelling` is **not** terminal — it is a run mid-rollback.
+Swapping one boundary for the other changes public behaviour and needs its own exception and its own
+documentation.
+
+The one that decides a write is `mayStartWork()` versus `live()`: ask the narrower one wherever work
+would **begin** (the action claim, the repair rules that send another job, the retry that spends a
+signal to start a fresh cycle), and `live()` wherever a row already started is settled or written
+down. A rollback plans the stack it will undo once, so a
+step that starts under `Cancelling` lands outside every plan there is; but the same rollback needs
+its compensations claimed and its bookkeeping written, and those are not new work.
 
 ### A host transaction around an engine call is out of scope
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -524,6 +524,17 @@ like a recorded step failure does. Rollbacks that were silently short are now wh
 compensation you never saw run may start running. See
 [Child workflows](https://sagalaraflow.dev/child-workflows).
 
+### 26. No step starts under a run that is rolling back
+
+A queued step could still be claimed and executed while its run was in `Cancelling` — a job already
+on the queue when the rollback began, one the doctor sent after it, or a signal-gated retry starting
+a fresh cycle. The step then completed after the stack to undo had been planned, so its compensation
+was in no plan and never ran, over a run reporting a complete unwind. Those four seams now ask
+whether the run may start new work, which `Cancelling` is not; settling a row already started is
+unchanged, so an overdue step is still expired and the rollback's own compensations still run. A
+step refused this way is left as the run's terminal settlement finds it. See
+[Statuses](https://sagalaraflow.dev/statuses).
+
 ### Recommended while you are here
 
 - **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -142,7 +142,9 @@ Every parameter:
   `monitor.queue_looping`). When `enabled`, the pass runs at most once per `throttle_seconds`.
 
 The doctor only ever re-dispatches existing jobs or re-wakes flows — replay decides the rest, so it never creates
-duplicate work or mutates a business result.
+duplicate work or mutates a business result. It also leaves a run that is rolling back (`Cancelling`) entirely alone:
+another job for a step under it would complete outside the stack that rollback already planned. See
+[statuses](./statuses.md).
 
 :::tip Turn it on in production
 Any step whose job is committed and then dispatched can lose that job to a dying process — including a step restarted

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -25,6 +25,14 @@ Every row the engine writes carries a status from a backed enum, so a host can f
 `Completed`, `Failed`, `Cancelled` and `Expired` are terminal: a run never leaves them, and it
 refuses signals and cancellation once there.
 
+`Cancelling` is not terminal, but no **step** starts under it. A rollback plans the stack it will
+undo once, so a step that began afterwards would finish outside that plan — its compensation in no
+stack, never run, under a run reporting a complete unwind. A job already queued for such a step is
+refused when it tries to claim the row, a signal-gated retry will not start another cycle, and the
+[doctor](./expiration-and-monitoring.md#repair-the-doctor) sends no replacement. Settling what
+already started is a different question and carries on as usual: a step past its own deadline is
+still expired, and the rollback's own compensations still run.
+
 ## `ActionStatus` — one step
 
 | Case | Meaning |
@@ -72,7 +80,8 @@ fully unwind — and it is recorded on the run's own `exception` as
 `CompensationUnfinishedException`. See [sagas & compensations](./sagas-and-compensation.md).
 
 A step that is `Cancelled` is inert: a late job cannot claim it, and no monitor or repair sweep
-selects it.
+selects it. A step under a run that is `Cancelling` is inert in the narrower sense above — no job
+claims it and no repair sends another — while the deadline sweeps still settle it.
 
 ## `CompensationStatus` and `ChildStatus`
 

--- a/src/Enums/FlowStatus.php
+++ b/src/Enums/FlowStatus.php
@@ -18,6 +18,11 @@ enum FlowStatus: string
         return in_array($this, self::terminal(), true);
     }
 
+    public function canStartWork(): bool
+    {
+        return in_array($this, self::mayStartWork(), true);
+    }
+
     /**
      * The statuses a run never leaves. Single source of truth for isTerminal() and
      * for the sweeps that must not pick up work belonging to a finished run.
@@ -27,6 +32,24 @@ enum FlowStatus: string
     public static function terminal(): array
     {
         return [self::Completed, self::Failed, self::Cancelled, self::Expired];
+    }
+
+    /**
+     * The statuses a run may start new work in: everything it has not finished in,
+     * minus the one it rolls back in. A rollback plans the stack it will undo once,
+     * so a step that starts under Cancelling finishes outside every plan there is —
+     * its compensation is in none of them and never runs, over a run reporting a
+     * complete unwind.
+     *
+     * The same three statuses signalable() names, and still a separate set: that one
+     * answers who may be handed a signal, this one whether the engine may start work of
+     * its own. Single source of truth for canStartWork().
+     *
+     * @return array<int, self>
+     */
+    public static function mayStartWork(): array
+    {
+        return [self::Pending, self::Running, self::Waiting];
     }
 
     /**

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -111,11 +111,12 @@ class CancelChildWorkflowJob implements ShouldQueue
 
             if ($this->withCompensation) {
                 // The plan that is acted on is made here, with the child fenced:
-                // Cancelling is a state no drive() can leave, so nothing can complete
-                // another compensatable step under it. A plan made before the fence
-                // can go stale — the transition guard reads status alone, so a child
-                // resumed and re-parked in between still matches — and unwinding it
-                // would leave that step standing under a run reported as rolled back.
+                // Cancelling is a state no drive() can leave and no step can be claimed
+                // under, so nothing can complete another compensatable step. A plan made
+                // before the fence can go stale — the transition guard reads status
+                // alone, so a child resumed and re-parked in between still matches — and
+                // unwinding it would leave that step standing under a run reported as
+                // rolled back.
                 $entries = $executor->collectCompensations($child);
 
                 // Roll back inline (Sync), inside THIS job, rather than dispatching another

--- a/src/Models/FlowRun.php
+++ b/src/Models/FlowRun.php
@@ -68,19 +68,35 @@ class FlowRun extends Model
     }
 
     /**
-     * Constrain a flow_runs query to runs that have not finished. The engine reads
-     * this in three places — the two sweeps that must not pick up work belonging to a
-     * finished run, and the fenced action writes that must not move a settled row —
-     * and they have to agree, because a run counted live by one and finished by
-     * another is exactly the gap a leftover row survives in.
+     * Constrain a flow_runs query to runs that have not finished. Three places read it —
+     * the two deadline sweeps, which must not settle work belonging to a finished run,
+     * and the fenced action writes, which must not move a settled row — and they have to
+     * agree, because a run counted live by one and finished by another is exactly the gap
+     * a leftover row survives in.
      *
-     * A run mid-rollback is still live here: Cancelling is not terminal.
+     * A run mid-rollback is still live here: Cancelling is not terminal, and settling
+     * its rows is exactly what a rollback needs. Whether work may BEGIN is the other
+     * question — mayStartWork() below.
      *
      * @param  Builder<FlowRun>  $query
      */
     public static function live(Builder $query): void
     {
         $query->whereNotIn('status', FlowStatus::terminal());
+    }
+
+    /**
+     * Constrain a flow_runs query to runs that may still start new work: live(), minus
+     * the run that is rolling back. Asked wherever work BEGINS — the action claim, the
+     * two repair scans that send another job, and the signal-gated retry that spends a
+     * delivery to start a fresh cycle — and never where a row already started is being
+     * settled or written down.
+     *
+     * @param  Builder<FlowRun>  $query
+     */
+    public static function mayStartWork(Builder $query): void
+    {
+        $query->whereIn('status', FlowStatus::mayStartWork());
     }
 
     /**

--- a/src/Repositories/EloquentActionRunRepository.php
+++ b/src/Repositories/EloquentActionRunRepository.php
@@ -30,6 +30,13 @@ class EloquentActionRunRepository implements ActionRunRepository
             ->get();
     }
 
+    /**
+     * Repair sends another job, so the run has to be one that may still start work, not
+     * merely one that has not finished. A run rolling back would have the rule refuse
+     * the row anyway — after it had taken a slot in the batch and before anything held
+     * it off, so ordered oldest-first and never changing it would sit at the head of
+     * every pass and starve the runs behind it.
+     */
     public function dueForRepair(int $limit, int $graceSeconds, int $maxAttempts): iterable
     {
         $now = Carbon::now();
@@ -44,7 +51,7 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
-            ->whereHas('flowRun', FlowRun::live(...))
+            ->whereHas('flowRun', FlowRun::mayStartWork(...))
             ->orderBy('created_at')
             ->limit($limit)
             ->get();
@@ -55,7 +62,8 @@ class EloquentActionRunRepository implements ActionRunRepository
      * so staleness is one indexed comparison — the same shape as dueForExpiration().
      * Ordering by the filtered column is what makes the limit safe: a pass can only be
      * filled with rows that are actually due, so a backlog of not-yet-stale rows can
-     * never crowd out stale ones.
+     * never crowd out stale ones. It sends a job too, so it asks dueForRepair()'s
+     * narrower question about the run.
      */
     public function dueForStaleRunningRepair(int $limit, int $maxAttempts): iterable
     {
@@ -72,7 +80,7 @@ class EloquentActionRunRepository implements ActionRunRepository
                     ->whereNull('repair_available_at')
                     ->orWhere('repair_available_at', '<=', $now);
             })
-            ->whereHas('flowRun', FlowRun::live(...))
+            ->whereHas('flowRun', FlowRun::mayStartWork(...))
             ->orderBy('reclaim_stale_at')
             ->limit($limit)
             ->get();

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -2,6 +2,7 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
+use Closure;
 use DateTimeInterface;
 use DiscoveryUkraine\SagaLaraFlow\Concerns\NormalizesExceptions;
 use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
@@ -18,6 +19,7 @@ use DiscoveryUkraine\SagaLaraFlow\Events\ActionStarted;
 use DiscoveryUkraine\SagaLaraFlow\Events\OptionalActionFailed;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\DB;
 use Throwable;
@@ -161,10 +163,12 @@ final readonly class ActionRecorder
      * stale-cycle check into this same atomic write so a cycle change landing after
      * the row was read still loses the claim. Null imposes no constraint.
      *
-     * The run's liveness is folded in the same way, and for a reason the row cannot see
+     * The run's own state is folded in the same way, and for a reason the row cannot see
      * on its own: terminal settlement leaves a Failed row — the state between two of the
      * queue's own native tries — exactly as it found it, so without this a job already on
      * the queue when the run was cancelled still claims it and runs the business logic.
+     * A run rolling back is fenced against too, and not because it has finished: it has
+     * already planned the stack it will undo, and a step starting now lands outside it.
      *
      * The claim and its two records share one transaction: a listener throwing on
      * ActionStarted would otherwise leave the row Running with nothing executing it.
@@ -186,7 +190,7 @@ final readonly class ActionRecorder
 
                 $claimed = $actionRun->newQuery()
                     ->whereKey($actionRun->getKey())
-                    ->whereHas('flowRun', FlowRun::live(...))
+                    ->whereHas('flowRun', FlowRun::mayStartWork(...))
                     ->when(
                         $expectedRetryGeneration !== null,
                         fn ($query) => $query->where('retry_signal_attempts', $expectedRetryGeneration),
@@ -458,14 +462,25 @@ final readonly class ActionRecorder
      * matching row always changes — which keeps the count off the zero MySQL reports for
      * an update that changed nothing and FlowStateMachine::write() has to disambiguate.
      *
+     * $runFence is which boundary the run is held to, because the callers do not all ask
+     * the same thing: writing down what a step already did needs a run that has not
+     * finished, while a caller that starts the step again needs one that may still start
+     * work at all.
+     *
      * @param  array<string, mixed|list<mixed>>  $expected
      * @param  array<string, mixed>  $context
+     * @param  (Closure(Builder<FlowRun>): void)|null  $runFence
      */
-    private function writeFenced(ActionRun $actionRun, array $expected, string $site, array $context = []): bool
-    {
+    private function writeFenced(
+        ActionRun $actionRun,
+        array $expected,
+        string $site,
+        array $context = [],
+        ?Closure $runFence = null,
+    ): bool {
         $query = $actionRun->newQuery()
             ->whereKey($actionRun->getKey())
-            ->whereHas('flowRun', FlowRun::live(...));
+            ->whereHas('flowRun', $runFence ?? FlowRun::live(...));
 
         foreach ($expected as $column => $value) {
             match (true) {
@@ -684,10 +699,13 @@ final readonly class ActionRecorder
      * `attempts` is deliberately untouched — it counts queue attempts within one
      * execution — and the previous exception stands until the new attempt overwrites it.
      *
-     * Fenced on the status and the cycle the caller read. Terminal settlement closes a
-     * parked step as Cancelled, and rewinding that to Pending would put a settled step
-     * back into the run's open work — and back into the doctor's reach — under a run
-     * that has already finished.
+     * Fenced on the status and the cycle the caller read, and on the run being one that
+     * may still start work. Terminal settlement closes a parked step as Cancelled, and
+     * rewinding that to Pending would put a settled step back into the run's open work —
+     * and back into the doctor's reach — under a run that has already finished. A run
+     * rolling back refuses it for the nearer reason: this spends the delivery and a unit
+     * of the budget and then sends a job, which is a cycle beginning, not a record of one
+     * that ran.
      */
     public function retryAction(
         ActionRun $actionRun,
@@ -725,7 +743,7 @@ final readonly class ActionRecorder
 
         $actionRun->expires_at = $deadline === null ? null : Carbon::instance($deadline);
 
-        if (! $this->writeFenced($actionRun, $asRead, 'retry_action')) {
+        if (! $this->writeFenced($actionRun, $asRead, 'retry_action', runFence: FlowRun::mayStartWork(...))) {
             return false;
         }
 

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -140,10 +140,8 @@ final readonly class FlowDoctor
                 return false;
             }
 
-            $flow = $lockedAction->flowRun;
-
             // Never resurrect a step whose run is finished or rolling back.
-            if ($flow->isTerminal() || $flow->status === FlowStatus::Cancelling) {
+            if (! $lockedAction->flowRun->status->canStartWork()) {
                 return false;
             }
 
@@ -188,10 +186,8 @@ final readonly class FlowDoctor
                 return false;
             }
 
-            $flow = $lockedAction->flowRun;
-
             // Never resurrect a step whose run is finished or rolling back.
-            if ($flow->isTerminal() || $flow->status === FlowStatus::Cancelling) {
+            if (! $lockedAction->flowRun->status->canStartWork()) {
                 return false;
             }
 

--- a/tests/Feature/CancellingRunWorkTest.php
+++ b/tests/Feature/CancellingRunWorkTest.php
@@ -1,0 +1,447 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Events\ActionRetried;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\FlakyPaymentAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * A run rolling back plans the stack it will undo once. Work that starts after that
+ * plan finishes outside it: its compensation is in no stack, never runs, and the run
+ * lands terminal reporting a complete unwind over a step that is still applied.
+ *
+ * Not finished is therefore the wrong question at the seams where work BEGINS, and the
+ * right one everywhere a row already started is settled or written down. The two are
+ * separate predicates because a rollback needs the second to keep working while the
+ * first is closed.
+ */
+beforeEach(function (): void {
+    CompensationLog::reset();
+    RetriedPaymentAction::$calls = 0;
+    CancelMidStepAction::$calls = 0;
+    CancelMidStepAction::$runId = null;
+    FlakyPaymentAction::reset(5);
+});
+
+/**
+ * Fails its first native attempt and succeeds on the next, so the queue owes the row
+ * another try while it sits Failed — the one status terminal settlement leaves exactly
+ * as it found it, and therefore the window that needs no race to reach.
+ */
+final class RetriedPaymentAction extends Action
+{
+    public int $tries = 3;
+
+    public static int $calls = 0;
+
+    /**
+     * @return array{charged: string}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        if (self::$calls === 1) {
+            throw new RuntimeException('insufficient balance');
+        }
+
+        return ['charged' => $orderId];
+    }
+}
+
+/**
+ * Moves its own run into Cancelling from inside handle(), so the rollback begins while
+ * this step is executing: the claim is already won, and everything written afterwards
+ * is a record of work that really ran.
+ */
+final class CancelMidStepAction extends Action
+{
+    public static int $calls = 0;
+
+    public static ?string $runId = null;
+
+    /**
+     * @return array{charged: string}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        app(StateMachine::class)->transition(
+            FlowRun::query()->findOrFail((string) self::$runId),
+            FlowStatus::Cancelling,
+        );
+
+        throw new RuntimeException('insufficient balance');
+    }
+}
+
+final class RetriedPaymentWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->action(RetriedPaymentAction::class, 'order-1')->compensateWith(UndoAction::class, 'p')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+final class CancelMidStepWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->action(CancelMidStepAction::class, 'order-1')->compensateWith(UndoAction::class, 'p')->run();
+    }
+}
+
+/**
+ * Drive the run until the payment step has failed its first native attempt and the
+ * queue still owes it another, then hand back that step.
+ */
+function stepFailedBetweenTries(string $flowRunId): ActionRun
+{
+    for ($tick = 0; $tick < 12; $tick++) {
+        $step = ActionRun::query()->where('flow_run_id', $flowRunId)->where('sequence', 1)->first();
+
+        if ($step?->status === ActionStatus::Failed || DB::connection('testing')->table('jobs')->count() === 0) {
+            break;
+        }
+
+        workOneJob();
+    }
+
+    $step = ActionRun::query()->where('flow_run_id', $flowRunId)->where('sequence', 1)->firstOrFail();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+
+    return $step;
+}
+
+/**
+ * A step written straight into the database under a run in the given status, aged so
+ * the doctor's grace period has passed. Older rows sort first — which is what puts one
+ * at the head of every batch.
+ *
+ * @param  array<string, mixed>  $attributes
+ */
+function repairCandidate(
+    FlowStatus $runStatus,
+    int $ageMinutes,
+    ActionStatus $stepStatus = ActionStatus::Pending,
+    array $attributes = [],
+): ActionRun {
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => $runStatus,
+        'arguments' => [],
+    ]);
+
+    $step = ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => $stepStatus,
+        'attempts' => 0,
+        ...$attributes,
+    ]);
+
+    ActionRun::query()->whereKey($step->id)->update(['created_at' => now()->subMinutes($ageMinutes)]);
+
+    return $step->fresh();
+}
+
+it('does not run a step whose job outlived the start of the rollback', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetriedPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+    stepFailedBetweenTries($run->id);
+
+    // The sweep expires the run, which plans the rollback and moves it to Cancelling.
+    $this->travel(60)->seconds();
+
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1)
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling);
+
+    // The native retry the queue still owed now arrives, under a run rolling back.
+    drainQueue();
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+
+    expect(RetriedPaymentAction::$calls)->toBe(1)
+        ->and($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->result)->toBeNull()
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('journals the refused claim and leaves the job nothing to retry', function (): void {
+    useDatabaseQueue();
+    logToFile($log = sys_get_temp_dir().'/cancelling-claim-'.uniqid().'.log');
+
+    $run = SagaFlow::create(RetriedPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+    stepFailedBetweenTries($run->id);
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $lines = (string) @file_get_contents($log);
+
+    // One refusal, named, and no queue failure behind it: a lost claim means somebody
+    // else owns the row, which is not this job's business to retry.
+    expect(substr_count($lines, '"reason":"claim_lost"'))->toBe(1)
+        ->and($lines)->toContain('"entity":"action"')
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(0);
+});
+
+it('settles a step it refused to start rather than leaving it open', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetriedPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    // Stop while the payment step is still Pending and its first job is queued.
+    for ($tick = 0; $tick < 12; $tick++) {
+        $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->first();
+
+        if ($step?->status === ActionStatus::Pending || DB::connection('testing')->table('jobs')->count() === 0) {
+            break;
+        }
+
+        workOneJob();
+    }
+
+    expect(ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail()->status)
+        ->toBe(ActionStatus::Pending);
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+
+    expect(RetriedPaymentAction::$calls)->toBe(0)
+        ->and($step->status)->toBe(ActionStatus::Cancelled)
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('still runs the compensations of the rollback that closed the run', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetriedPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+    stepFailedBetweenTries($run->id);
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    // The compensations run under Cancelling, which is exactly the status the claim is
+    // now fenced against: they are claimed on their own rows, never on the run's state.
+    expect(CompensationLog::all())->toBe(['undo:a'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('records that the queue is finished with a step the cancel caught mid-execution', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(CancelMidStepWorkflow::class)->run();
+    CancelMidStepAction::$runId = $run->id;
+
+    drainQueue();
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+
+    // The claim was won before the rollback began, so what follows is bookkeeping about
+    // work that really ran. Refusing it would tell the retry seam the queue still owes
+    // an attempt nobody will ever send.
+    expect(CancelMidStepAction::$calls)->toBe(1)
+        ->and($step->status)->toBe(ActionStatus::Failed)
+        ->and($step->queue_attempts_exhausted)->toBeTrue()
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling);
+});
+
+it('does not let a rolling-back run hold the head of the repair batch', function (): void {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.batch_size', 1);
+    config()->set('saga-lara-flow.repair.redispatch_lost_actions', true);
+
+    // Older, so it sorts first; its rule refuses it after it has taken the slot and
+    // before anything holds it off, so its window never moves.
+    $rollingBack = repairCandidate(FlowStatus::Cancelling, 30);
+    $stuck = repairCandidate(FlowStatus::Waiting, 10);
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(1)
+        ->and($report->skipped)->toBe(0)
+        ->and($stuck->fresh()->repair_attempts)->toBe(1)
+        ->and($rollingBack->fresh()->repair_attempts)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+});
+
+it('still expires an overdue step under a run that is rolling back', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetriedPaymentWorkflow::class)->run();
+    $step = stepFailedBetweenTries($run->id);
+
+    // A rollback long enough for the step's own deadline to pass under it. Settling
+    // that step is not starting work, and leaving it unresolved for the length of the
+    // rollback would be the sweep failing at the one thing it is for.
+    app(StateMachine::class)->transition(FlowRun::query()->findOrFail($run->id), FlowStatus::Cancelling);
+    $step->newQuery()->toBase()->where('id', $step->id)->update([
+        'status' => ActionStatus::Pending->value,
+        'expires_at' => now()->subMinute(),
+    ]);
+
+    $report = app(FlowMonitor::class)->sweep();
+
+    expect($report['actions'])->toBe(1)
+        ->and($step->fresh()->status)->toBe(ActionStatus::Expired)
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling);
+});
+
+it('refuses a repair candidate the rollback claimed after the batch was read', function (): void {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.redispatch_lost_actions', true);
+
+    $stuck = repairCandidate(FlowStatus::Waiting, 10);
+    $table = (new FlowRun)->getTable();
+
+    // The rollback starts in the gap the batch leaves open: between the scan that read
+    // this row and the lock the rule takes on it. One process, staged on the scan's own
+    // query, because the check under the lock exists for exactly this interleaving.
+    DB::listen(function ($query) use ($stuck, $table): void {
+        if (str_contains($query->sql, 'action_runs') && str_contains($query->sql, 'created_at')) {
+            DB::connection('testing')->table($table)
+                ->where('id', $stuck->flow_run_id)
+                ->update(['status' => FlowStatus::Cancelling->value]);
+        }
+    });
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(0)
+        ->and($report->skipped)->toBe(1)
+        ->and($stuck->fresh()->repair_attempts)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(0);
+});
+
+it('does not spend a retry cycle on a run the rollback claimed mid-replay', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RetryOnSignalWorkflow::class)->withArguments('order-1')->run();
+    drainQueue();
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+
+    expect($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(0);
+
+    SagaFlow::loadFlow($run->id)->signal('balance-refilled');
+
+    // The rollback commits while this replay is under way. Staged on the seam's own
+    // read of the wait-signal: that happens outside any transaction and before the one
+    // the retry writes in, so the row the fence reads really does say Cancelling.
+    $staged = false;
+    FlowSignal::retrieved(function () use ($run, &$staged): void {
+        if ($staged) {
+            return;
+        }
+
+        $staged = true;
+
+        app(StateMachine::class)->transition(
+            FlowRun::query()->findOrFail($run->id),
+            FlowStatus::Cancelling,
+        );
+    });
+
+    $announced = 0;
+    Event::listen(ActionRetried::class, function () use (&$announced): void {
+        $announced++;
+    });
+
+    drainQueue();
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+    $signal = FlowSignal::query()->where('flow_run_id', $run->id)->orderByDesc('id')->firstOrFail();
+
+    // A retry spends the delivery and a unit of the budget and then sends a job. None of
+    // that may happen once the run is rolling back: the step it would restart lands
+    // outside the stack that rollback already planned.
+    expect($staged)->toBeTrue()
+        ->and($step->status)->toBe(ActionStatus::AwaitingRetry)
+        ->and($step->retry_signal_attempts)->toBe(0)
+        ->and($signal->status->value)->toBe('received')
+        ->and($announced)->toBe(0)
+        ->and(FlakyPaymentAction::$calls)->toBe(1);
+});
+
+it('does not let a rolling-back run hold the head of the stale-running batch', function (): void {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.batch_size', 1);
+    config()->set('saga-lara-flow.repair.redispatch_stale_running_actions', true);
+
+    // R3 orders by reclaim_stale_at, so the one that went stale first leads the page.
+    $rollingBack = repairCandidate(FlowStatus::Cancelling, 30, ActionStatus::Running, [
+        'reclaim_stale_at' => now()->subMinutes(30),
+    ]);
+    $stuck = repairCandidate(FlowStatus::Running, 10, ActionStatus::Running, [
+        'reclaim_stale_at' => now()->subMinutes(10),
+    ]);
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(1)
+        ->and($report->skipped)->toBe(0)
+        ->and($stuck->fresh()->repair_attempts)->toBe(1)
+        ->and($rollingBack->fresh()->repair_attempts)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+});
+
+it('refuses a stale-running candidate the rollback claimed after the batch was read', function (): void {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+    config()->set('saga-lara-flow.repair.redispatch_stale_running_actions', true);
+
+    $stuck = repairCandidate(FlowStatus::Running, 10, ActionStatus::Running, [
+        'reclaim_stale_at' => now()->subMinutes(10),
+    ]);
+    $table = (new FlowRun)->getTable();
+
+    DB::listen(function ($query) use ($stuck, $table): void {
+        if (str_contains($query->sql, 'action_runs') && str_contains($query->sql, 'reclaim_stale_at')) {
+            DB::connection('testing')->table($table)
+                ->where('id', $stuck->flow_run_id)
+                ->update(['status' => FlowStatus::Cancelling->value]);
+        }
+    });
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(0)
+        ->and($report->skipped)->toBe(1)
+        ->and($stuck->fresh()->repair_attempts)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(0);
+});

--- a/tests/Feature/RetryOnSignalQueuedTest.php
+++ b/tests/Feature/RetryOnSignalQueuedTest.php
@@ -36,7 +36,6 @@ use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryOnSignalWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RetryPolicyWorkflow;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliablePaymentAction;
 use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnreliableRetryOnSignalWorkflow;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Event;
 
@@ -52,17 +51,6 @@ beforeEach(function () {
     RecordingRetryPolicy::reset();
     CompensationLog::reset();
 });
-
-/**
- * Process exactly one queued job, so a test can inspect the run between two steps
- * of the async path instead of after the whole queue has drained.
- */
-function workOneJob(): void
-{
-    // --sleep=0: an empty queue would otherwise cost the worker's default three
-    // seconds, and these helpers are called in loops.
-    Artisan::call('queue:work', ['--once' => true, '--sleep' => 0, '--no-interaction' => true]);
-}
 
 /**
  * Drive the queue one job at a time until the step at $sequence satisfies $ready, so

--- a/tests/Helpers.php
+++ b/tests/Helpers.php
@@ -82,6 +82,23 @@ if (! function_exists('useDatabaseQueue')) {
     }
 
     /**
+     * Process exactly one queued job, so a test can inspect the run between two steps
+     * of the async path instead of after the whole queue has drained.
+     */
+    function workOneJob(): void
+    {
+        // The flags carry the same weight as in drainQueue(): --sleep=0 so an empty
+        // queue costs nothing, --memory so the suite's own footprint cannot stop the
+        // worker silently.
+        Artisan::call('queue:work', [
+            '--once' => true,
+            '--sleep' => 0,
+            '--memory' => 4096,
+            '--no-interaction' => true,
+        ]);
+    }
+
+    /**
      * Snapshot of the durable state a run leaves behind, for cross-mode comparison.
      *
      * @return array<string, mixed>


### PR DESCRIPTION
Closes #53.

A run in `Cancelling` — the state a rollback holds it in — still let new work start. A rollback
plans the stack it will undo exactly once, so anything that begins after that plan finishes outside
it: its compensation is in no stack, never runs, and the run lands terminal reporting a complete
unwind over a step that is still applied.

## Reproduction, and the engine reaches it on its own

No hand-written statuses. A step with `$tries` fails its first native attempt (the row sits `Failed`,
the queue still owes it another), the expiration sweep expires the run and queues its rollback, and
the leftover job then claims the row under `Cancelling`:

```
tick 4:      run=waiting  step1=failed  calls=1  jobs=1
sweep:       {"runs":1}   run=cancelling  jobs=2
after drain: run=expired  step1=completed  calls=2  log=["undo:a"]
```

`undo:p` never ran. `Failed` is what makes this reachable with no race at all: `settleOpenSteps()`
covers `Pending`/`Running`/`AwaitingRetry` and leaves `Failed` — the state between two of the queue's
own native tries — exactly as it found it.

## The shape

Option 1 from the issue: a separate named predicate beside `live()`, not replacing it.

- `FlowStatus::mayStartWork()` (the set) and `canStartWork()` (the predicate), mirroring the existing
  `terminal()`/`isTerminal()` pair; `FlowRun::mayStartWork()` mirroring `FlowRun::live()`.
- Asked at the four seams where work **begins**: the action claim, the doctor's two repair scans, and
  the signal-gated retry that spends a delivery to start a fresh cycle.
- `writeFenced()` gained a `runFence` parameter, defaulting to `live()`, because its five callers do
  not ask the same thing: four write down what a step already did, and only `retryAction()` starts a
  cycle.
- The predicate already existed twice in `FlowDoctor`, hand-written and unnamed
  (`isTerminal() || Cancelling`); both now read the named one.
- `live()`'s docblock claimed three call sites; grep found six. Both docblocks now carry counts
  checked by grep.

## Measured, not reasoned

- **The suite never saw this window.** Instrumenting all six `live()` sites across the whole suite:
  720 hits, and `cancelling` appears **zero** times at any of them. A green suite proves nothing
  about this change by itself, which is why every predicate below carries its own mutation.
- **The repair scans are not tidiness.** With `batch_size=1`, one `Cancelling` candidate holds the
  head of the repair page for five passes running — `{"redispatchedActions":0,"skipped":1}`,
  `jobs=0`, and the healthy run behind it is never repaired, because the rule refuses the row
  *before* `bumpThrottle()`. After narrowing: pass 1 gives `{"redispatchedActions":1,"skipped":0}`.
  That is the defect `TerminalBatchExclusionTest` was written for, in the one status its predicate
  did not cover.
- **A refused claim leaves nothing open.** A `Failed` row stays `Failed` (its real history); a
  `Pending` row is closed `Cancelled` by terminal settlement. One `claim_lost` line, no
  `write_refused`, no job left to retry.
- **The rollback is untouched, structurally.** `CompensationRecorder::startCompensation()` has no
  run-state fence at all — it fences its own row's status. Mutation M5 (fencing it the same way)
  reds two tests, so the claim is not empty.

## Deliberately left on `live()`

- The other four `writeFenced()` callers. A run moved to `Cancelling` *mid-execution* reaches
  `writeFenced:queue_attempts_exhausted` with the run already `cancelling`, and that write must land:
  `exhausted=1` is the only record that the queue is finished with the job. Under the narrower
  predicate it would be refused and the retry seam would wait for an attempt nobody will send.
- The two deadline sweeps. Settling under `Cancelling` is correct — an overdue step is still expired
  (`actions:1`) and `wake()` already declines to resume a run mid-rollback. Narrowing them would
  leave an overdue step unresolved for the length of a long rollback.

## Tests and mutations

Eleven tests in `tests/Feature/CancellingRunWorkTest.php`, eleven mutations, each reddening its own:
M1 claim fence → `live()` (3 red), M2a/M2b the two repair scans (1 each), M3a/M3b the two under-lock
re-checks (1 each), M4 the default `writeFenced` fence narrowed (1), M5 the compensation claim fenced
(2), M6 `Cancelling` back in the set (8), M7 the action-expiry scan narrowed (1), M8 `canStartWork()`
widened to not-terminal (2), M9 the `retryAction` fence removed (1).

The two staged interleavings use the project's own single-process techniques — a `DB::listen()`
listener between the candidate scan and the lock, and an Eloquent `retrieved` observer that commits
the rollback mid-replay.

`workOneJob()` moved from `RetryOnSignalQueuedTest` into `tests/Helpers.php`: two files declaring it
is a fatal redeclaration in PHP, and the shared copy also carries the `--memory` flag the private one
lacked.

## Not closed here, each measured identical before and after

- **#62** — a step that completes between the plan and the transition. The fence correctly allows
  that claim: the run is still `Waiting`.
- **#63** — a signal delivered to a rolling-back run is accepted and can never be consumed.
  `SignalDispatcher` gates on `isTerminal()` alone and is not touched here.
- **#64** — a stale resume re-runs the whole rollback; every compensation executes twice
  (`comps=2`, `log=["undo:a","undo:a"]`). A different mechanism entirely: the rollback restarting,
  not a step starting.
- **#65** — a replay that outlived the rollback still creates children and runs `sideEffect()`
  factories. Two seams, neither closable with one predicate.

## Verification

SQLite 462/4, MySQL 462/4, PostgreSQL 466/0 (`main`: 451/4, 451/4, 455/0). Pint and PHPStan level 5
clean, docs site builds.
