### PR TITLE
Tighten the upgrade guide and the longest docblocks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,8 +16,11 @@ before opening an issue or pull request.
 - **One feature/fix per PR.** Keep the diff focused.
 - **Do not edit `CHANGELOG.md`.** It is written by maintainers at release time and has no
   `Unreleased` section. A PR that adds one will be asked to remove it.
-- **`UPGRADING.md`** is where a breaking change is described. Add to the section for the version in
-  progress; do not open a section of your own.
+- **`UPGRADING.md`** is where a breaking change is described, under the section for the version in
+  progress; do not open a section of your own. It has three parts — *Action required* for anything
+  a host must change or decide, *Behaviour changed* for a line or two plus a link to the docs page
+  that covers it, *Additions* for what needs nothing done. Mechanism belongs on that docs page, and
+  rationale in the issue and the PR; neither belongs here.
 
 ## Development setup
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,550 +2,221 @@
 
 ## From 1.1.x to 1.2.0
 
-> ### ⚠️ Run `php artisan migrate` immediately after upgrading
+> ### ⚠️ Run `php artisan migrate` after upgrading
 >
-> Every action and compensation the engine schedules writes the columns added by this release. Deploy
-> the migration together with the code, the same as every other release.
+> Four migrations ship with this release — `add_reclaim_stale_running_columns`,
+> `index_signal_waits`, `unique_flow_tag_keys` and `add_expiry_backoff_to_flow_runs` — and the
+> engine writes their columns from the moment it starts. Deploy them together with the code. They
+> run from the package — do **not** `vendor:publish` them, or `migrate` would try both copies.
+> `unique_flow_tag_keys` deletes rows; read its item below before you run it.
 
-### What's new
+### Action required
 
-`ActionRecorder::startAction()` and `CompensationRecorder::startCompensation()` now claim their row
-atomically instead of writing to it unconditionally, closing a check-then-act race where a stale
-job (a superseded retry cycle, a row the monitor just expired, or a job the doctor sent on top of a
-live one) could execute a step a second time. See [Queues, locks & idempotency](https://sagalaraflow.dev/queues-locks-idempotency)
-for the full picture, and the new **reclaim** section below for the opt-in half.
+#### Decide how a killed worker's step is recovered
 
-A companion mechanism, `actions.reclaim.stale_running` / `sagas.reclaim.stale_running`, lets a
-`Running` row be claimed again once its reclaim window has passed — recognising a worker that died
-mid-execution. Off by default; enable it globally or per action/compensation
-(`reclaimStaleAfter()`, `enableStaleReclaim()`, and their `...Compensation...` mirrors on
-`ActionBuilder`/`SagaStepBuilder`).
+**Likelihood of impact: high.** A row that is already `Running` is no longer picked up by a redelivered job, so a worker
+killed mid-execution leaves a step nothing brings back — replay parks the run, and so does `saga-flow:kick`. Turn on one
+of the two recoveries, or accept that such a run waits for a human:
 
-### 1. A `Running` row is no longer picked up by a redelivered job
-
-This is the one change to be deliberate about, and it applies **whether or not you enable reclaim**.
-
-The claim accepts a row that is `Pending` or `Failed`. A row that is already `Running` is accepted
-only once its reclaim window has passed — and with reclaim off, the default, there is no window, so
-it is never accepted. Previously any redelivered job would simply execute such a row again.
-
-What that buys you: the engine's own machinery can no longer produce a duplicate execution. A job
-left over from a superseded retry cycle, a job racing a row the monitor just expired, and a job the
-doctor dispatched on top of one still running are all now refused. (What no engine can prevent is
-the queue driver's own at-least-once delivery — SQS visibility timeouts, `retry_after` on
-Redis/database — redelivering a job while the first attempt is still alive. That is the documented
-baseline your action code already has to tolerate.)
-
-What it costs you: if a worker is killed mid-execution — an evicted pod, the OOM killer, a `SIGKILL`
-deploy — its row stays `Running`, and with everything at its default nothing brings it back. Replay
-treats a `Running` step as still in flight and parks the run, and `saga-flow:kick` does the same, so
-the run waits indefinitely. Choose one of the two recoveries if that matters to you:
-
-- **`reclaim`** — the row becomes claimable again after its window, and the step **runs again**.
-  Recovery of the work itself. See the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery).
+- **`reclaim`** — the row becomes claimable again after its window and the step **runs again**. Off by default; read
+  the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery) first.
 - **The monitor** — set `monitor.expiration.defaults.action` (or `->expiresAt()`) and schedule
-  `saga-flow:monitor`. The step is marked `Expired` and the run **fails as a business error**
-  instead of hanging. Recovery of the run, not of the work.
+  `saga-flow:monitor`. The step is marked `Expired`; a required step then fails the run as a business error, while an
+  optional one resolves through its fallback.
 
-They are complementary: reclaim retries, the monitor gives up. Neither runs unless you turn it on.
+If you already run the doctor, its new R3 rule (`repair.redispatch_stale_running_actions`, default
+`true`) redispatches **sequential actions only** — a parallel action or a compensation is bound to its batch and is
+recovered only by that job being redelivered. It reaches such a row whatever set its reclaim window,
+`reclaimStaleAfter()` included while the global switch is off, but not one whose run may no longer start work, one still
+inside its `repair_available_at` backoff, or one that has spent `repair.max_attempts`. A row past the cap stays as it is
+until a retry cycle reschedules it.
 
-### 2. The new migration
+#### `unique_flow_tag_keys` deletes duplicate rows
 
-`add_reclaim_stale_running_columns` adds `reclaim_stale_after_seconds` (the configured window) and
-`reclaim_stale_at` (the absolute deadline the claim derives from it) to both `action_runs` and
-`compensation_runs`, plus an `attempts` counter on `compensation_runs` mirroring the one
-`action_runs` already had. It runs from the package like every other migration — do not
-`vendor:publish` it.
-
-### 3. Status transitions no longer raise Eloquent model events
-
-Every status write the engine makes is now a conditional `UPDATE` — the same shape (and for the same
-reason: the only form every supported driver enforces atomically) as the signal transitions changed
-in 1.1.0. That covers `startAction()` / `startCompensation()`, the four outcome writes
-(`completeAction()`, `failAction()`, `completeCompensation()`, `failCompensation()`), and — see item
-15 — every transition of a `flow_runs` row.
-
-The consequence, exactly as documented in 1.1.0: an **observer** registered on a swapped-in
-`models.flow_run`, `models.action_run` or `models.compensation_run` no longer sees
-`updating`/`updated` for these transitions. Nothing is lost, though — each still records its own
-package event and `flow_events` entry whenever it actually writes: the flow lifecycle events
-(`FlowStarted`, `FlowWaiting`, `FlowResumed`, `FlowCompleted`, `FlowFailed`, `FlowCancelled`,
-`FlowExpired`), `ActionStarted` (`action.started`, unchanged), `ActionCompleted`, `ActionFailed`,
-`CompensationCompleted`, `CompensationFailed`, and the new `CompensationStepStarted`
-(`compensation.step_started` — distinct from `CompensationStarted`, which marks the whole rollback
-beginning once per run, not once per compensation). Listen to those, or read `flow_events`, instead
-of Eloquent hooks.
-
-### 4. A recorded outcome can no longer be overwritten by a superseded worker
-
-Enabling reclaim lets a second worker take over a row whose first worker may be slow rather than
-dead, so both can reach the end of the same step. The outcome writes are therefore fenced against
-the claim that produced them (via `attempts`, which only the claim increments): an executor that has
-been superseded updates no rows, records no history, and its job does not fail — it now hands what
-it produced to `ActionOutcomeRejected` instead of dropping it (item 23). In practice this means
-a **recorded success is never demoted** — a straggler that fails after the live worker succeeded can
-no longer flip the step to `Failed` and send the saga rolling back over work that actually went
-through.
-
-The fence has a second condition alongside `attempts`: the row must still be `Running`. That guards
-against a settlement that never claimed the row at all — the monitor expiring an overdue step does
-not touch `attempts`. `ActionRecorder::expireAction()` is conditional for the same reason, from the
-other side: a step that completes just before the sweep reaches it is not demoted to `Expired`. It
-now returns `bool`, and the monitor counts and wakes only for an expiry it actually won.
-
-Every one of these paths — a lost claim, a rejected outcome, a batch closed early, and now a refused
-run transition (item 15) — is logged, since nothing else records them. The first three are also
-quiet: they never fail a job. The fourth is the exception, and only on one surface — the engine
-absorbs it, but `FlowHandle` lets it reach the caller, because an operator whose cancellation did not
-happen has to be told. See `logging.anomaly_level` in item 7.
-
-### 5. `ActionRunRepository` gained one method
-
-If you bound your own implementation of `DiscoveryUkraine\SagaLaraFlow\Contracts\ActionRunRepository`, it must now also
-implement:
-
-```php
-public function dueForStaleRunningRepair(int $limit, int $maxAttempts): iterable;
-```
-
-As with the 1.1.0 note on `SignalRepository`, the simplest fix is to extend
-`Repositories\EloquentActionRunRepository` rather than implement the interface from scratch — it
-remains `@internal` and not a public extension point.
-
-### 6. `RunCompensationJob` now takes its own queue lock
-
-Compensations previously had no `WithoutOverlapping` protection at all (actions and parallel steps
-always did). A new `locks.compensation_ttl_seconds` (default 900, independent of
-`locks.action_ttl_seconds`) governs it; set `locks.enabled = false` to keep locking off entirely, as
-before.
-
-**If you published the config file before this release**, add the key to your `locks` array —
-package config is merged only at the top level, so your own `locks` array is taken as it stands and
-the new key is not filled in for you. Nothing breaks if you forget: a missing value inherits
-`action_ttl_seconds`, and a zero or missing TTL can never produce a lock without an expiry.
-
-### 7. New: `logging`
-
-```php
-'logging' => [
-    'anomaly_level' => env('SAGA_LARA_FLOW_ANOMALY_LOG_LEVEL', 'info'),
-    'channel' => env('SAGA_LARA_FLOW_LOG_CHANNEL'),
-],
-```
-
-The first logging the package has ever done. `Runtime\AnomalyLog` is a second journal beside the
-`flow_events` business history, and it covers exactly the things that are otherwise untraceable:
-
-- `claim_lost` — a claim lost to whoever already owned the row.
-- `outcome_rejected` — an outcome write refused because the row had changed hands.
-- `batch_finished_early` — a parallel step completed after a duplicate delivery had already closed
-  its batch.
-
-All three are normal under at-least-once delivery and none of them fails a job, so without this
-there would be nothing to investigate afterwards. Each line carries the run id, row id, sequence and
-class. Set `anomaly_level` to `null` to silence it, or to `warning` if you want these surfaced by
-your alerting. Writing the line is best-effort: an unusable level is treated as off, and a logger
-that throws is swallowed rather than allowed to fail a job that was deliberately giving up quietly.
-
-### 8. An unfinished compensation now stops a rollback
-
-A compensation left `Pending` or `Running` when its level finishes — its worker died, or its job
-never arrived — is treated the way a failed one is: under the `Stop` policy it halts the rollback,
-and either way it is recorded as the run's secondary cause under `flow_run.exception['compensation']`.
-Previously only `Failed` rows were looked for, so a rollback could finalize with a step silently
-never undone and no trace of it anywhere. A compensation registered with the `Continue` policy still
-does not stop the unwind.
-
-### 9. Three scheduling methods take an `ActionSchedule`
-
-The step's options used to be passed as a long tail of optional arguments. They are now carried by
-`Data\ActionSchedule`, a readonly object with the same names as before:
-
-```php
-use DiscoveryUkraine\SagaLaraFlow\Data\ActionSchedule;
-
-// before
-$dispatcher->dispatch($run, $sequence, ChargeCard::class, [$orderId], true, false, $expiresAt);
-
-// after
-$dispatcher->dispatch($run, $sequence, new ActionSchedule(
-    actionClass: ChargeCard::class,
-    arguments: [$orderId],
-    hasCompensation: true,
-    expiresAt: $expiresAt,
-));
-```
-
-Affected: `ActionDispatcher::dispatch()`, `ActionDispatcher::runInline()`, and
-`ActionRecorder::scheduleAction()`. Nothing in the workflow API changes — this only matters if your
-code calls those runtime classes directly.
-
-### 10. `execute()` reports how far a step got
-
-`ActionDispatcher::execute()`, `CompensationExecutor::execute()` and `ActionDispatcher::runInline()`
-return `Enums\StepExecution` instead of `void`:
-
-- **`Executed`** — the row was claimed, the step ran, and its outcome was recorded.
-- **`ClaimLost`** — the row was already owned or no longer claimable; nothing ran.
-- **`Superseded`** — the step ran, but the row changed hands before its outcome could be written.
-
-The two failing cases look the same from a queued job, which returns quietly either way; call
-`->settled()` if that is all you need. They differ where no competitor is supposed to exist: a
-freshly created row that cannot be claimed is a broken invariant and still raises
-`ActionClaimFailedException`, while being superseded afterwards is an ordinary race — the monitor and
-the doctor act on the rows a sync run creates from their own processes — and replay resolves it from
-whatever the row ended up holding.
-
-### 11. Two more migrations: wait indexes, then one row per tag key
-
-They ship as separate files because only the second one deletes anything. MySQL runs neither inside
-a transaction, so both are written to be repeatable: whatever point a run dies at, running it again
-carries on from there.
-
-**`index_signal_waits`** supports the two new `FlowQuery` filters. `flow_signals` gains
-`(status, name, flow_run_id)` and `action_runs` gains `(status, retry_signal, flow_run_id)`; the
-shipped indexes on both tables lead with `flow_run_id`, which cannot serve a lookup by signal name
-across runs.
-
-**`unique_flow_tag_keys`** narrows `flow_tags` uniqueness from `(flow_run_id, key, value)` to
-`(flow_run_id, key)`, the pair every tag writer matches on. The wider unique let two concurrent
-first writes for one key insert two rows with different values.
-
-> #### ⚠️ Rows are deleted if you have such duplicates
->
-> For each `(flow_run_id, key)` the row with the highest `updated_at` is kept, the highest `id`
-> breaking a tie, and the rest are removed. `flow_tags` timestamps are second-precision, so two
-> writes inside one second fall back to insertion order. The rollback restores the old constraint
-> but cannot bring deleted rows back.
->
-> **Pause writes to `flow_tags` while this runs.** A write landing on an already-duplicated key
-> between the winner being chosen and the losers being deleted is lost without a trace, and running
-> the migration again will not bring it back. Keys that are not already duplicated are never touched.
-
-Count the duplicates first — the table carries your configured `database.table_prefix`, `saga_` by
-default:
+**Likelihood of impact: high, if you have duplicates.** `flow_tags` uniqueness narrows from
+`(flow_run_id, key, value)` to `(flow_run_id, key)`. For each pair the row with the highest
+`updated_at` is kept — highest `id` breaking a tie — and the rest are deleted. The rollback restores the old constraint
+but cannot bring rows back. Count them first; the table carries your configured
+`database.table_prefix`, `saga_` by default:
 
 ```sql
--- MySQL
-select flow_run_id, `key`, count(*) from saga_flow_tags group by flow_run_id, `key` having count(*) > 1;
-
--- PostgreSQL, SQLite
-select flow_run_id, "key", count(*) from saga_flow_tags group by flow_run_id, "key" having count(*) > 1;
+select flow_run_id, "key", count(*)
+from saga_flow_tags
+group by flow_run_id, "key"
+having count(*) > 1; -- MySQL: backticks around `key`
 ```
 
-The narrower unique goes on before the wider one comes off, so the table is never left without one.
-A tag written for a brand-new key while the migration sits between the cleanup and the constraint
-can still make it fail; run it again.
+**Pause writes to `flow_tags` from the count until the migration finishes.** The count is only a snapshot: two
+concurrent first writes for one key can still insert a pair under the old constraint afterwards, and a write landing on
+an already-duplicated key between the winner being chosen and the losers being deleted is lost without a trace. An empty
+count means there is nothing to lose *at that moment*, not that the window is shut. This migration and
+`index_signal_waits` are both repeatable — MySQL runs neither in a transaction, so one that died part-way can simply be
+repeated.
 
-If the count comes back empty there is nothing to lose and nothing to pause for — the migration adds
-the constraint and stops.
+#### A scalar workflow result is no longer wrapped
 
-Tag writing is otherwise unchanged: one value per key per run, last write wins. The int-to-string
-normalisation now also sits on `Models\FlowTag` as a cast, so a `models.flow_tag` replacement should
-extend that model rather than reimplement it.
+**Likelihood of impact: medium.** A workflow result that *serialized* to a scalar had its value stored as
+`{"value": ...}`, and nothing reversed the wrapper. It is now written straight through the serializer, so
+`$run->result['value']` is just `$run->result` and `$this->child(...)->run()`
+resolves what the child actually returned. What serialization produces is what counts: `null`, arrays, models and
+`Arrayable` were never wrapped, while a `JsonSerializable` whose
+`jsonSerialize()` returns a scalar was, and is affected like any other scalar.
 
-### 12. A scalar workflow result is no longer wrapped
+Rows completed **before** the upgrade keep their envelope permanently — a wrapped `42` and a workflow that returned
+`['value' => 42]` are stored identically, so nothing can unwrap them safely. And because a parent replays from the top,
+one whose child completed before the upgrade reads the wrapper on *every* later replay. Code consuming a scalar has to
+accept both shapes while such rows are still read; draining the affected parents first avoids the mixed period.
 
-`flow_runs.result` is a JSON column, and a workflow returning anything other than an array had that
-value stored as `{"value": ...}`. Nothing reversed the wrapper, so a parent calling
-`$this->child(...)->run()` on a child returning an `int` got `['value' => 42]`, and a host reading
-`$run->result` got the same.
+#### Settle rows left by runs that finished before the upgrade
 
-The result is now written the way an action result already was — straight through the serializer,
-with no envelope. A JSON column stores a bare scalar fine, and `Serializer::deserialize()` passes
-non-arrays through untouched, so the child seam resolves the value the child actually returned.
-
-Two things to check:
-
-**Code that unwrapped by hand.** For a run completed on this release, `$run->result['value']` is now
-just `$run->result`. Workflows returning an array are unaffected — those were never wrapped. Runs
-completed before the upgrade are the caveat below.
-
-**Rows completed before the upgrade keep their envelope, permanently.** They are neither migrated nor
-unwrapped on read: a wrapped `42` and a workflow that legitimately returned `['value' => 42]` are
-stored identically, so nothing automatic can tell them apart without corrupting the second case.
-
-That is not a one-off. `$run->result` on a pre-upgrade run returns the wrapper for as long as the row
-exists. And because a parent replays `handle()` from the top on every resume, a parent whose child
-completed before the upgrade resolves that child to the wrapper on **every** replay, not only the
-first one after the deploy.
-
-So while pre-upgrade rows are still being read, code that consumes a scalar result has to accept both
-shapes. Draining the affected parents before upgrading avoids the mixed period entirely. Note also
-that this release does not rescue a parent already parked over such a child and written against the
-unwrapped shape — that parent was failing before the upgrade and still fails after it.
-
-### 13. A finished run no longer leaves live-looking steps and waits
-
-`ActionStatus::Cancelled` was declared but never written. Cancelling, expiring or closing a run only
-touched its `flow_runs` row, so a run that ended days ago kept steps reporting `pending`, `running`
-or `awaiting_retry`, and wait-signals reporting `waiting`.
-
-Every terminal transition now settles what the run was still holding: steps in those three statuses
-become `cancelled`, and open wait-markers become `cancelled` too. Steps that had already reached an
-outcome — `completed`, `failed`, `optional_failed`, `expired` — are untouched, so a cancelled run
-still shows what actually ran. `SignalStatus::Cancelled` is new; a `match` over `SignalStatus` that
-was exhaustive before now needs that arm.
-
-Four things to check:
-
-**Queries filtered by step or signal status.** A dashboard counting `action_runs` where
-`status = 'running'` stops counting runs that ended. That was the point — those counts were wrong —
-but a query written to compensate for it (joining `flow_runs` to exclude terminal runs) is now
-redundant rather than harmful.
-
-**`FlowQuery::whereAwaitingSignal()` and `whereAwaitingRetrySignal()`** stop matching a run once it
-finishes, because it no longer holds the row they filter on. That is true of runs that finish on this
-release; rows left behind by runs that finished earlier still carry `waiting` and `awaiting_retry`,
-and their runs still match. Keep composing with `signalable()` while any of those remain — the SQL
-below clears them if you would rather be done with it.
-
-**A worker holding a `Running` step when its run is cancelled** races the settlement, and both
-orders leave the row consistent. If the settlement lands first the step is `cancelled` and the
-worker's outcome is refused, logged as `outcome_rejected` — the same fencing the monitor's expiry
-already used. If the worker lands first the step keeps the outcome it earned and the settlement
-passes over it. Expect `outcome_rejected` lines whenever runs are cancelled while steps are
-genuinely in flight.
-
-A refused outcome is not stored: before this release the late worker's result landed in
-`action_runs.result`, and now the `outcome_rejected` line — the run, the step, its sequence and
-class, and which outcome was refused — is what records it. If the step reaches an external system,
-that log line is the pointer to reconcile from.
-
-**Rows written before the upgrade keep their old status.** They are not migrated: the package's
-migrations run automatically on `php artisan migrate`, and rewriting a host's history without being
-asked is not something a migration should do. They are harmless — no sweep selects them any more (see
-below) — but `saga-flow:show` will keep rendering them as they are. To settle them yourself:
+**Likelihood of impact: low.** Terminal runs now settle the steps and wait-markers they were holding, but existing rows
+are not migrated — rewriting a host's history is not a migration's job. They are harmless and no sweep selects them, but
+`FlowQuery::whereAwaitingSignal()` and
+`whereAwaitingRetrySignal()` keep matching their runs until you clear them:
 
 ```sql
 UPDATE saga_action_runs
-   SET status = 'cancelled'
- WHERE status IN ('pending', 'running', 'awaiting_retry')
-   AND flow_run_id IN (
-       SELECT id FROM saga_flow_runs
-        WHERE status IN ('completed', 'failed', 'cancelled', 'expired')
-   );
+SET status = 'cancelled'
+WHERE status IN ('pending', 'running', 'awaiting_retry')
+  AND flow_run_id IN (SELECT id
+                      FROM saga_flow_runs
+                      WHERE status IN ('completed', 'failed', 'cancelled', 'expired'));
 
 UPDATE saga_flow_signals
-   SET status = 'cancelled'
- WHERE status = 'waiting'
-   AND wait_sequence IS NOT NULL
-   AND flow_run_id IN (
-       SELECT id FROM saga_flow_runs
-        WHERE status IN ('completed', 'failed', 'cancelled', 'expired')
-   );
+SET status = 'cancelled'
+WHERE status = 'waiting'
+  AND wait_sequence IS NOT NULL
+  AND flow_run_id IN (SELECT id
+                      FROM saga_flow_runs
+                      WHERE status IN ('completed', 'failed', 'cancelled', 'expired'));
 ```
 
-Adjust the table names if you set `database.table_prefix`.
+Adjust the names for your `database.table_prefix`.
 
-### 14. No sweep selects work belonging to a finished run
+#### A `FlowRun` relation now reads in a defined order
 
-Four scans gained the same condition: the doctor's `dueForRepair()` and `dueForStaleRunningRepair()`,
-and the monitor's `dueForExpiration()` and `dueForTimeout()`.
-
-Each of them rejected such a row anyway, but only *after* spending a slot on it and *before* any
-counter could hold it off — the doctor returns ahead of its throttle, and the monitor has no counter
-at all. Ordered oldest-first and never changing, an unsettled row sat at the head of every batch for
-ever; enough of them and a pass filled up with dead rows and reached nothing live, while still
-reporting success.
-
-Item 13 stops new ones from appearing. This stops the ones already in your database from costing
-anything, which is why no data migration is needed.
-
-`FlowStatus::terminal()` is new, listing the four statuses a run never leaves. `isTerminal()` now
-reads from it.
-
-### 15. A run transition is refused if the row moved on
-
-Every transition of a `flow_runs` row now writes conditionally, on the status the caller read before
-deciding. If the row is no longer there, nothing is written and the transition raises
-`ConcurrentFlowTransitionException`.
-
-The hole it closes: nothing serialises an operator against a worker. The queue's per-run lock covers
-jobs; it does not cover `saga-flow:cancel`, a host calling `FlowHandle::cancel()`, or the monitor's
-sweep, which expires runs inline. Each side holds its own `FlowRun` instance, and whichever saved
-last used to win outright — up to a worker writing `running` over a run an operator had already
-cancelled, leaving a run that can never finish because its steps are settled and replay will not
-resolve them.
-
-Two things follow:
-
-**The engine absorbs it; `FlowHandle` does not.** `FlowExecutor::drive()`, `FlowExecutor::expireRun()`
-and the queued rollback's batch continuation catch it and stop: a job ends cleanly rather than
-retrying, `runSync()` returns the run in the state the winner left it, and a parent awaiting the run
-as a child reads its status and resolves accordingly. `FlowHandle::cancel()` and `compensate()`
-deliberately let it through — see item 16. A rollback an operator asked for raises from its landing
-too, for the same reason: nobody else is waiting on that answer. `CancelChildWorkflowJob` stops only
-once the child it was sent to close is genuinely closed; losing it to something that leaves the child
-live raises, so the close is retried rather than dropped.
-
-**A same-state transition is checked too.** It used to return before touching the database, which is
-precisely how a stale instance slipped past. It is now a conditional write like any other, and one
-that has genuinely lost raises rather than reporting success. `cancelled_at` and `finished_at` are
-still written once and never again, so a landing that repeats does not move the moment the run ended.
-
-What this does **not** close: two workers that both legitimately see `running` both write
-successfully, because the status does not change between them. That is ownership, not transition
-ordering, and `WithoutOverlapping` on `run:{id}` remains what covers it.
-
-Refused transitions are logged as `transition_lost`, with the status observed, the one intended, and
-the one actually holding the row. A refusal leaves the `FlowRun` instance that asked for it exactly
-as it was, so a caller that catches one can read the run's real status off its own model and act on
-it — or simply try again.
-
-### 16. `FlowHandle::cancel()` can now throw a second exception
-
-`cancel()` and `compensate()` already raised `CannotCancelTerminalFlowException` when the run they
-hold is terminal. They can now also raise `ConcurrentFlowTransitionException`, when the run was still
-live as far as the handle knew but moved underneath it.
-
-If you catch around either call, catch both. They stay distinct on purpose:
-`CannotCancelTerminalFlowException` means the handle already knew the run was finished;
-`ConcurrentFlowTransitionException` means it lost a race and the run is now in some other state,
-which the message names.
-
-Note that neither is a subclass of `InvalidTransitionException`, and `ConcurrentFlowTransitionException`
-is deliberately not one either: that exception means the state graph forbids the move, and repeating
-it cannot help, whereas a lost race is transient and re-reading the run is the sensible response.
-
-### 17. `retryOnSignal()` takes a policy object and a `when:` predicate
-
-The first parameter widens from `string` to `RetryPolicy|string`, and a fifth optional parameter,
-`when:`, is appended. Every existing call site compiles and behaves identically — nothing is
-required of you.
-
-What is new is the fourth gate. A failure that passed `only:` is now also put to `when:` (or to the
-policy's `shouldRetry()`), and a `false` there ends the policy for that failure: the step fails
-exactly as it would have without one. With neither given, nothing is asked and nothing changes.
-
-The one thing to know before writing a policy class: **nothing about it is persisted**, and only the
-ceiling's stored value is frozen. `maxRetries()` is read when the step is scheduled and held on
-`action_runs.retry_signal_max_attempts`, which is what replay enforces from then on — the same rule
-`maxRetries:` has always followed. What is *not* frozen is the calling: your `handle()` builds the
-policy again on every pass, and the builder re-reads `signal()`, `waitSeconds()` and `only()` off it
-every time — including on a pass that only replays a step already scheduled or completed. Their
-values take effect immediately. `shouldRetry()` is stored rather than called, and runs at the gate
-only for a step that has failed. A deploy therefore changes all four for runs already in flight —
-including which signal a parked step will next wait for.
-
-`ActionBuilder` and `SagaStepBuilder` are constructed by the engine, and this release widens
-`retryOnSignal()` on both. That is reachable if you override the public `Workflow::action()` to
-return your own builder subclass: PHP refuses to load an override whose signature no longer matches,
-so widen it to `RetryPolicy|string $signal` and accept the fifth `?Closure $when` parameter.
-
-### 18. A run's relations read in a defined order
-
-`FlowRun`'s relations no longer come back in whatever order the driver chose: `actions()`,
-`compensations()`, `sideEffects()` and `children()` read by `sequence`, `events()` by
-`recorded_at`, and `signals()` and `tags()` by `id`.
-
-Nothing that was correct before changes. What to check is a read that appends its own order, or
-one that pages by id — both now land behind the default, so clear it first:
+**Likelihood of impact: low.** `actions()`, `compensations()`, `sideEffects()` and `children()` read by `sequence`,
+`events()` by `recorded_at`, `signals()` and `tags()` by `id`. A read that appends its own order, or pages by id, lands
+behind the default — clear it first. Eager loads,
+`withCount()`, `whereHas()` and plain `chunk()` need nothing.
 
 ```php
 $run->signals()->reorder()->orderByDesc('id')->first();
 $run->actions()->reorder()->chunkById(500, fn ($actions) => ...);
 ```
 
-Eager loads, `withCount()`, `whereHas()` and plain `chunk()` need nothing. See
-[Configuration](https://sagalaraflow.dev/configuration).
+#### Smaller adjustments
 
-### 19. The table prefix is capped at 24 bytes
+- **If you published the config file** *(medium)* — package config is merged only at the top level, so an array of your
+  own is taken as it stands. Add `locks.compensation_ttl_seconds` (default 900)
+  and `monitor.expiration.backoff` (`60` doubling to `3600`). A missing compensation TTL inherits
+  `action_ttl_seconds`, so nothing breaks if you forget.
+- **If you catch around `FlowHandle::cancel()` or `compensate()`** *(medium)* — both can now also raise
+  `ConcurrentFlowTransitionException`, when the run moved underneath the handle. Catch it alongside
+  `CannotCancelTerminalFlowException`, which stays distinct because it means the handle already knew the run was
+  finished. Neither extends `InvalidTransitionException`, deliberately:
+  that one means the state graph forbids the move, whereas a lost race is worth re-reading and retrying.
+- **If you observe the package's Eloquent models** *(medium)* — every status write is now a conditional `UPDATE`, so an
+  observer on a swapped-in `models.flow_run`, `models.action_run` or
+  `models.compensation_run` no longer sees `updating`/`updated` for a transition. Most publish a package event and a
+  `flow_events` entry instead; listen to those. Four write no replacement at all, by design — settling a parked step,
+  recording the queue's exhausted attempts, and the two settlements a terminal run makes over its open steps and waits —
+  so auditing those needs another mechanism. A listener that swallows a failed query now stops the step rather than
+  letting it run unrecorded (`claim_not_committed`).
+- **If you swapped in your own `models.flow_tag`** *(low)* — extend `Models\FlowTag` rather than reimplementing it: the
+  int-to-string normalisation of a tag value now also lives on that model as an `AsTagValue` cast, so a replacement
+  without it stores int values unnormalised.
+- **If you `match` over the status enums** *(medium)* — `ActionStatus::Cancelled` is now written and
+  `SignalStatus::Cancelled` is new, so a `match` that was exhaustive needs the new arm. See
+  [Statuses](https://sagalaraflow.dev/statuses).
+- **If you query step or signal status directly** *(medium)* — a dashboard counting `action_runs`
+  where `status = 'running'` stops counting runs that ended; those counts were wrong. A query that compensated by
+  joining `flow_runs` is now redundant rather than harmful.
+- **If you set a long `database.table_prefix`** *(low)* — it is capped at **24 bytes**, 24 ASCII characters and fewer
+  otherwise; the default `saga_` is five. Six indexes are named explicitly rather than derived to reach it. A database
+  that failed part-way on a too-long prefix needs its package tables dropped before `migrate` will get past the first.
+- **If you override `Workflow::action()` to return your own builder** *(low)* — `retryOnSignal()`
+  widens its first parameter to `RetryPolicy|string $signal` and appends a fifth `?Closure $when`. PHP refuses an
+  override whose signature no longer matches, so widen yours on both `ActionBuilder`
+  and `SagaStepBuilder`.
+- **If you call `FlowHandle::compensate()`** *(medium)* — planning the rollback replays `handle()`, and that replay no
+  longer settles a spent optional step (so no `OptionalActionFailed`) nor schedules a parallel block it had only reached
+  to read. It still writes tags, because a workflow branching on its own tag would otherwise plan a different stack. Six
+  exception classes end the plan; any other throw now surfaces out of `compensate()` with the run untouched, rather than
+  rolling back a truncated plan and reporting it complete — catch it if you did not before. The expiry sweep absorbs the
+  same throw instead, journalling `expiry_failed`.
+- **If you call the runtime classes directly** *(low)* — they are `@internal`, but an
+  `ActionRunRepository` implementation must add `dueForStaleRunningRepair()`, taking a limit and a max-attempts count
+  and returning `iterable`; `ActionDispatcher::dispatch()`, `runInline()` and
+  `ActionRecorder::scheduleAction()` take a readonly `Data\ActionSchedule` whose named parameters are the old tail of
+  optional arguments; and `execute()` on `ActionDispatcher` and
+  `CompensationExecutor`, plus `runInline()`, return `Enums\StepExecution` — `Executed`, `ClaimLost`
+  (nothing ran) or `Superseded` (it ran, but the row changed hands first) — rather than `void`. Call
+  `->settled()` if the distinction does not matter.
 
-`database.table_prefix` rides along in every derived index name, and past a point the driver refuses
-one outright (MySQL, at 7 characters) or truncates two onto each other (PostgreSQL, at 29). Six
-indexes are now named explicitly rather than derived, which lifts the supported prefix to **24
-bytes** — 24 characters of ASCII, fewer if you use anything else. The default `saga_` is five.
+### Behaviour changed
 
-Nothing to do on a database that installed. One that failed part-way on a too-long prefix needs its
-package tables dropped before `migrate` will get past the first one. The new names reach a fresh
-install only, nothing reads them, and there is no rename migration.
+Nothing below asks anything of you. Each links to the page that covers it.
 
-### 20. A claim is verified after the transaction that made it commits
+- **A recorded outcome is never demoted.** Outcome writes are fenced against the claim that produced them, so a
+  straggler cannot flip a succeeded step to `Failed`. Expect `outcome_rejected` lines when runs are cancelled while
+  steps are in flight: a refused outcome is not stored, and that line is what records
+  it. [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery)
+- **A run transition is refused if the row moved on**, rather than the last writer winning. A drive, an expiry and a
+  queued rollback continuation absorb the refusal and stop; `FlowHandle`
+  raises it, and a child-close job rethrows while the child is still live so the close is retried.
+  [Queues, locks & idempotency](https://sagalaraflow.dev/queues-locks-idempotency)
+- **A finished run settles what it was holding.** Steps in `pending`, `running` or `awaiting_retry`
+  become `cancelled`, as do open wait-markers; steps that reached an outcome are untouched.
+  [Statuses](https://sagalaraflow.dev/statuses)
+- **No sweep selects work belonging to a finished run.** The doctor's two scans and the monitor's two each exclude it,
+  so an unsettled row can no longer hold the head of every batch.
+  [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
+- **No step starts under a run that is rolling back.** A queued step, a doctor redispatch and a signal-gated retry are
+  all refused under `Cancelling`, where one could previously complete after the stack to undo had been planned. Settling
+  a row already started is unchanged.
+  [Statuses](https://sagalaraflow.dev/statuses)
+- **A rollback no longer stops at a child that already finished.** A parent that carried on past a failed child under
+  `->continueParentOnFailure()` used to roll back only the steps before it and report that as complete, so a
+  compensation you never saw run may start running.
+  [Child workflows](https://sagalaraflow.dev/child-workflows)
+- **An unfinished `Stop`-policy compensation stops a rollback.** One left `Pending` or `Running`
+  when its level finishes is treated the way a failed one is, and recorded under
+  `flow_run.exception['compensation']`. A `Continue`-policy compensation still does not halt the
+  unwind. [Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation)
+- **A run whose rollback the sweep cannot plan steps aside** for a widening window instead of holding its place in the
+  page. There is no attempt cap — the cause can be temporary.
+  [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
+- **Five recorder transitions write conditionally** — a give-up, a park, a rewind, settling a parked step, and the
+  queue's exhausted-attempts flag. One that loses writes nothing, journals
+  `write_refused` with a `site`, and returns `false` where it returned `void`.
+- **`RunCompensationJob` takes its own queue lock**, which compensations previously had none of.
 
-Claiming a step or an undo now reads the row back once its transaction has closed, and does not run
-the body unless the claim is really there. A commit reporting success is not proof: on PostgreSQL a
-failed statement aborts the transaction and turns the commit into a rollback, so a listener on
-`ActionStarted` — or a model observer on the `flow_events` insert — that runs a failing query and
-swallows it used to leave the step executing with nothing recording that it started.
+### Additions
 
-Nothing to do unless your listeners swallow query failures. One that does now stops the step,
-journalled as `claim_not_committed` and raised as `ActionClaimFailedException` in synchronous mode.
-See [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
+Nothing to do; each is opt-in or additive.
 
-### 21. `compensate()` plans the rollback without starting work, and stops if it cannot finish
-
-Planning a manual rollback replays `handle()` to find the compensations. That replay no longer
-settles a spent optional step (`action.optional_failed`, with its `OptionalActionFailed` event) and
-no longer schedules a parallel block it had only reached to read. Nor is every throw the end of the
-stack now: six classes end it, and an unexpected throw surfaces out of `compensate()`, run
-untouched, rather than rolling back a truncated plan and reporting it complete.
-
-Nothing to do unless a listener expected `OptionalActionFailed` during `compensate()`. The expiry
-sweep absorbs such a throw instead, journalling `expiry_failed` and stepping over the run. See
-[Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation).
-
-### 22. Writes to a step check the row is still the one they read
-
-Five recorder transitions — a give-up, a park, a rewind, settling a parked step, and the queue's
-exhausted-attempts flag — now state the row they expect and the run's liveness in one `UPDATE`. One
-that loses writes nothing, journals `write_refused` with a `site`, and returns `false` where it used
-to return `void`. The claim is fenced on the run too, and still reports `claim_lost` as before.
-
-The other thing to check: those five no longer call `save()`, so they raise no Eloquent model events
-— an observer on your `ActionRun` model stops seeing them. Three publish a package event instead,
-and settling a parked step and recording the queue's exhausted attempts publish none, by design. See
-[Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery).
-
-### 23. New: a refused outcome hands its payload to a listener
-
-A worker that finishes a step whose row has moved on has its outcome refused, and until now what it
-produced went nowhere. `ActionOutcomeRejected` and `CompensationOutcomeRejected` now carry it: the
-value the step returned in the form the row would have stored, or the throw the engine deliberately
-does not rethrow. Nothing is stored and nothing about the run changes. A listener that throws is
-journalled as `rejection_undelivered` rather than failing the job, since this path must stay quiet.
-See [Events](https://sagalaraflow.dev/events#refused-outcome).
-
-### 24. A run the sweep cannot expire now steps aside instead of holding the page
-
-The monitor reads one page of overdue runs, oldest first, and a run whose rollback it cannot plan
-kept its place in it — enough of them at the head and the runs behind were never inspected. Such a
-run is now held off for a widening window (`monitor.expiration.backoff`, 60s doubling to an hour)
-and counted in two new `flow_runs` columns, so the page moves on and the journal stops repeating
-itself. There is no attempt cap: the cause can be temporary. Run `php artisan migrate`.
-
-### 25. A rollback no longer stops at a child that already finished
-
-Planning a rollback treated any awaited child that was not `Completed` as the live frontier, so a
-parent that carried on past a failed one under `->continueParentOnFailure()` rolled back only the
-steps before it — and `compensate()` reported that partial unwind as complete. A terminal child is
-now read the way an ordinary replay reads it, and the two throws that follow from it end the plan
-like a recorded step failure does. Rollbacks that were silently short are now whole, so a
-compensation you never saw run may start running. See
-[Child workflows](https://sagalaraflow.dev/child-workflows).
-
-### 26. No step starts under a run that is rolling back
-
-A queued step could still be claimed and executed while its run was in `Cancelling` — a job already
-on the queue when the rollback began, one the doctor sent after it, or a signal-gated retry starting
-a fresh cycle. The step then completed after the stack to undo had been planned, so its compensation
-was in no plan and never ran, over a run reporting a complete unwind. Those four seams now ask
-whether the run may start new work, which `Cancelling` is not; settling a row already started is
-unchanged, so an overdue step is still expired and the rollback's own compensations still run. A
-step refused this way is left as the run's terminal settlement finds it. See
-[Statuses](https://sagalaraflow.dev/statuses).
-
-### Recommended while you are here
-
-- **Decide how a killed worker should be recovered** — see item 1. Leaving both reclaim and the
-  monitor off means such a run waits forever, which is safe but needs a human.
-- Read the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery) before enabling reclaim in
-  production: it changes which `Running` rows a redelivered job, or the doctor, may re-execute.
-- If you already turned `repair.enabled` on, note that its new R3 rule
-  (`repair.redispatch_stale_running_actions`, default `true`) acts on any row carrying a reclaim
-  window — including one enabled per step via `reclaimStaleAfter()` while
-  `actions.reclaim.stale_running.enabled` is globally `false`, since a per-step override outranks the
-  global switch everywhere else too.
+- **`reclaim`** (`actions.reclaim.stale_running`, `sagas.reclaim.stale_running`) lets a `Running`
+  row be claimed again once its window has passed, recognising a worker that died mid-execution. Off by default;
+  per-step via `reclaimStaleAfter()` and `enableStaleReclaim()`, and per-compensation via
+  `reclaimCompensationStaleAfter()` and `enableCompensationStaleReclaim()`.
+- **`logging`** — `anomaly_level` (default `info`, `null` to silence) and `channel`. The package's first logging: a
+  second journal beside `flow_events` for the refusals nothing else records. Writing is best-effort and never fails a
+  job.
+- **`RetryPolicy`** — `retryOnSignal()` accepts a policy object, and a `when:` predicate gates whether *this* failure is
+  worth parking. Every existing call site behaves identically.
+  [Retry on signal](https://sagalaraflow.dev/retry-on-signal)
+- **`ActionOutcomeRejected` and `CompensationOutcomeRejected`** carry what a refused outcome produced — the recorded
+  form of the result, or the throw the engine does not rethrow. Nothing is stored and nothing about the run changes.
+  [Events](https://sagalaraflow.dev/events#refused-outcome)
+- **`CompensationStepStarted`** marks one compensation beginning, distinct from
+  `CompensationStarted`, which marks the whole rollback once per run.
+- **`FlowStatus::terminal()`** lists the four statuses a run never leaves; `isTerminal()` reads from it.
+- **Two `FlowQuery` wait filters**, with the `index_signal_waits` indexes that serve them:
+  `flow_signals` gains `(status, name, flow_run_id)`, `action_runs`
+  `(status, retry_signal, flow_run_id)`.
+- **`Models\FlowTag`** also normalises an int tag *value* to a string as an `AsTagValue` cast, so
+  `FlowHandle::withTags()` and a direct model write get it too, not only `tag()`.
 
 ## From 1.0.x to 1.1.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,76 +2,80 @@
 
 ## From 1.1.x to 1.2.0
 
-> ### ⚠️ Run `php artisan migrate` after upgrading
->
-> Four migrations ship with this release — `add_reclaim_stale_running_columns`,
-> `index_signal_waits`, `unique_flow_tag_keys` and `add_expiry_backoff_to_flow_runs` — and the
-> engine writes their columns from the moment it starts. Deploy them together with the code. They
-> run from the package — do **not** `vendor:publish` them, or `migrate` would try both copies.
-> `unique_flow_tag_keys` deletes rows; read its item below before you run it.
+> ### ⚠️ Run `php artisan migrate` after upgrading  Four migrations ship with this release —
+> `add_reclaim_stale_running_columns`, `index_signal_waits`, `unique_flow_tag_keys` and
+> `add_expiry_backoff_to_flow_runs` — and the engine writes their columns from the moment it starts.
+> Deploy them together with the code. They run from the package — do **not** `vendor:publish` them,
+> or `migrate` would try both copies. `unique_flow_tag_keys` deletes rows; read its item below
+> before you run it.
 
 ### Action required
 
 #### Decide how a killed worker's step is recovered
 
-**Likelihood of impact: high.** A row that is already `Running` is no longer picked up by a redelivered job, so a worker
-killed mid-execution leaves a step nothing brings back — replay parks the run, and so does `saga-flow:kick`. Turn on one
-of the two recoveries, or accept that such a run waits for a human:
+**Likelihood of impact: high.** A row that is already `Running` is no longer picked up by a
+redelivered job, so a worker killed mid-execution leaves a step nothing brings back — replay parks
+the run, and so does `saga-flow:kick`. Turn on one of the two recoveries, or accept that such a run
+waits for a human:
 
-- **`reclaim`** — the row becomes claimable again after its window and the step **runs again**. Off by default; read
-  the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery) first.
+- **`reclaim`** — the row becomes claimable again after its window and the step **runs again**. Off
+  by default; read the [reclaim guide](https://sagalaraflow.dev/reclaim-and-recovery) first.
 - **The monitor** — set `monitor.expiration.defaults.action` (or `->expiresAt()`) and schedule
-  `saga-flow:monitor`. The step is marked `Expired`; a required step then fails the run as a business error, while an
-  optional one resolves through its fallback.
+  `saga-flow:monitor`. The step is marked `Expired`; a required step then fails the run as a
+  business error, while an optional one resolves through its fallback.
 
 If you already run the doctor, its new R3 rule (`repair.redispatch_stale_running_actions`, default
-`true`) redispatches **sequential actions only** — a parallel action or a compensation is bound to its batch and is
-recovered only by that job being redelivered. It reaches such a row whatever set its reclaim window,
-`reclaimStaleAfter()` included while the global switch is off, but not one whose run may no longer start work, one still
-inside its `repair_available_at` backoff, or one that has spent `repair.max_attempts`. A row past the cap stays as it is
-until a retry cycle reschedules it.
+`true`) redispatches **sequential actions only** — a parallel action or a compensation is bound to
+its batch and is recovered only by that job being redelivered. It reaches such a row whatever set
+its reclaim window, `reclaimStaleAfter()` included while the global switch is off, but not one whose
+run may no longer start work, one still inside its `repair_available_at` backoff, or one that has
+spent `repair.max_attempts`. A row past the cap stays as it is until a retry cycle reschedules it.
 
 #### `unique_flow_tag_keys` deletes duplicate rows
 
 **Likelihood of impact: high, if you have duplicates.** `flow_tags` uniqueness narrows from
 `(flow_run_id, key, value)` to `(flow_run_id, key)`. For each pair the row with the highest
-`updated_at` is kept — highest `id` breaking a tie — and the rest are deleted. The rollback restores the old constraint
-but cannot bring rows back. Count them first; the table carries your configured
+`updated_at` is kept — highest `id` breaking a tie — and the rest are deleted. The rollback restores
+the old constraint but cannot bring rows back. Count them first; the table carries your configured
 `database.table_prefix`, `saga_` by default:
 
 ```sql
-select flow_run_id, "key", count(*)
-from saga_flow_tags
-group by flow_run_id, "key"
-having count(*) > 1; -- MySQL: backticks around `key`
+-- MySQL
+select flow_run_id, `key`, count(*) from saga_flow_tags
+ group by flow_run_id, `key` having count(*) > 1;
+
+-- PostgreSQL, SQLite
+select flow_run_id, "key", count(*) from saga_flow_tags
+ group by flow_run_id, "key" having count(*) > 1;
 ```
 
-**Pause writes to `flow_tags` from the count until the migration finishes.** The count is only a snapshot: two
-concurrent first writes for one key can still insert a pair under the old constraint afterwards, and a write landing on
-an already-duplicated key between the winner being chosen and the losers being deleted is lost without a trace. An empty
-count means there is nothing to lose *at that moment*, not that the window is shut. This migration and
-`index_signal_waits` are both repeatable — MySQL runs neither in a transaction, so one that died part-way can simply be
-repeated.
+**Pause writes to `flow_tags` from the count until the migration finishes.** The count is only a
+snapshot: two concurrent first writes for one key can still insert a pair under the old constraint
+afterwards, and a write landing on an already-duplicated key between the winner being chosen and the
+losers being deleted is lost without a trace. An empty count means there is nothing to lose *at that
+moment*, not that the window is shut. This migration and `index_signal_waits` are both repeatable —
+MySQL runs neither in a transaction, so one that died part-way can simply be repeated.
 
 #### A scalar workflow result is no longer wrapped
 
-**Likelihood of impact: medium.** A workflow result that *serialized* to a scalar had its value stored as
-`{"value": ...}`, and nothing reversed the wrapper. It is now written straight through the serializer, so
-`$run->result['value']` is just `$run->result` and `$this->child(...)->run()`
-resolves what the child actually returned. What serialization produces is what counts: `null`, arrays, models and
-`Arrayable` were never wrapped, while a `JsonSerializable` whose
+**Likelihood of impact: medium.** A workflow result that *serialized* to a scalar had its value
+stored as `{"value": ...}`, and nothing reversed the wrapper. It is now written straight through the
+serializer, so `$run->result['value']` is just `$run->result` and `$this->child(...)->run()`
+resolves what the child actually returned. What serialization produces is what counts: `null`,
+arrays, models and `Arrayable` were never wrapped, while a `JsonSerializable` whose
 `jsonSerialize()` returns a scalar was, and is affected like any other scalar.
 
-Rows completed **before** the upgrade keep their envelope permanently — a wrapped `42` and a workflow that returned
-`['value' => 42]` are stored identically, so nothing can unwrap them safely. And because a parent replays from the top,
-one whose child completed before the upgrade reads the wrapper on *every* later replay. Code consuming a scalar has to
-accept both shapes while such rows are still read; draining the affected parents first avoids the mixed period.
+Rows completed **before** the upgrade keep their envelope permanently — a wrapped `42` and a
+workflow that returned `['value' => 42]` are stored identically, so nothing can unwrap them safely.
+And because a parent replays from the top, one whose child completed before the upgrade reads the
+wrapper on *every* later replay. Code consuming a scalar has to accept both shapes while such rows
+are still read; draining the affected parents first avoids the mixed period.
 
 #### Settle rows left by runs that finished before the upgrade
 
-**Likelihood of impact: low.** Terminal runs now settle the steps and wait-markers they were holding, but existing rows
-are not migrated — rewriting a host's history is not a migration's job. They are harmless and no sweep selects them, but
-`FlowQuery::whereAwaitingSignal()` and
+**Likelihood of impact: low.** Terminal runs now settle the steps and wait-markers they were
+holding, but existing rows are not migrated — rewriting a host's history is not a migration's job.
+They are harmless and no sweep selects them, but `FlowQuery::whereAwaitingSignal()` and
 `whereAwaitingRetrySignal()` keep matching their runs until you clear them:
 
 ```sql
@@ -95,9 +99,9 @@ Adjust the names for your `database.table_prefix`.
 
 #### A `FlowRun` relation now reads in a defined order
 
-**Likelihood of impact: low.** `actions()`, `compensations()`, `sideEffects()` and `children()` read by `sequence`,
-`events()` by `recorded_at`, `signals()` and `tags()` by `id`. A read that appends its own order, or pages by id, lands
-behind the default — clear it first. Eager loads,
+**Likelihood of impact: low.** `actions()`, `compensations()`, `sideEffects()` and `children()` read
+by `sequence`, `events()` by `recorded_at`, `signals()` and `tags()` by `id`. A read that appends
+its own order, or pages by id, lands behind the default — clear it first. Eager loads,
 `withCount()`, `whereHas()` and plain `chunk()` need nothing.
 
 ```php
@@ -107,49 +111,53 @@ $run->actions()->reorder()->chunkById(500, fn ($actions) => ...);
 
 #### Smaller adjustments
 
-- **If you published the config file** *(medium)* — package config is merged only at the top level, so an array of your
-  own is taken as it stands. Add `locks.compensation_ttl_seconds` (default 900)
+- **If you published the config file** *(medium)* — package config is merged only at the top level,
+  so an array of your own is taken as it stands. Add `locks.compensation_ttl_seconds` (default 900)
   and `monitor.expiration.backoff` (`60` doubling to `3600`). A missing compensation TTL inherits
   `action_ttl_seconds`, so nothing breaks if you forget.
-- **If you catch around `FlowHandle::cancel()` or `compensate()`** *(medium)* — both can now also raise
-  `ConcurrentFlowTransitionException`, when the run moved underneath the handle. Catch it alongside
-  `CannotCancelTerminalFlowException`, which stays distinct because it means the handle already knew the run was
-  finished. Neither extends `InvalidTransitionException`, deliberately:
-  that one means the state graph forbids the move, whereas a lost race is worth re-reading and retrying.
-- **If you observe the package's Eloquent models** *(medium)* — every status write is now a conditional `UPDATE`, so an
-  observer on a swapped-in `models.flow_run`, `models.action_run` or
-  `models.compensation_run` no longer sees `updating`/`updated` for a transition. Most publish a package event and a
-  `flow_events` entry instead; listen to those. Four write no replacement at all, by design — settling a parked step,
-  recording the queue's exhausted attempts, and the two settlements a terminal run makes over its open steps and waits —
-  so auditing those needs another mechanism. A listener that swallows a failed query now stops the step rather than
-  letting it run unrecorded (`claim_not_committed`).
-- **If you swapped in your own `models.flow_tag`** *(low)* — extend `Models\FlowTag` rather than reimplementing it: the
-  int-to-string normalisation of a tag value now also lives on that model as an `AsTagValue` cast, so a replacement
-  without it stores int values unnormalised.
+- **If you catch around `FlowHandle::cancel()` or `compensate()`** *(medium)* — both can now also
+  raise `ConcurrentFlowTransitionException`, when the run moved underneath the handle. Catch it
+  alongside `CannotCancelTerminalFlowException`, which stays distinct because it means the handle
+  already knew the run was finished. Neither extends `InvalidTransitionException`, deliberately:
+  that one means the state graph forbids the move, whereas a lost race is worth re-reading and
+  retrying.
+- **If you observe the package's Eloquent models** *(medium)* — every status write is now a
+  conditional `UPDATE`, so an observer on a swapped-in `models.flow_run`, `models.action_run` or
+  `models.compensation_run` no longer sees `updating`/`updated` for a transition. Most publish a
+  package event and a `flow_events` entry instead; listen to those. Four write no replacement at
+  all, by design — settling a parked step, recording the queue's exhausted attempts, and the two
+  settlements a terminal run makes over its open steps and waits — so auditing those needs another
+  mechanism. A listener that swallows a failed query now stops the step rather than letting it run
+  unrecorded (`claim_not_committed`).
+- **If you swapped in your own `models.flow_tag`** *(low)* — extend `Models\FlowTag` rather than
+  reimplementing it: the int-to-string normalisation of a tag value now also lives on that model as
+  an `AsTagValue` cast, so a replacement without it stores int values unnormalised.
 - **If you `match` over the status enums** *(medium)* — `ActionStatus::Cancelled` is now written and
   `SignalStatus::Cancelled` is new, so a `match` that was exhaustive needs the new arm. See
   [Statuses](https://sagalaraflow.dev/statuses).
 - **If you query step or signal status directly** *(medium)* — a dashboard counting `action_runs`
-  where `status = 'running'` stops counting runs that ended; those counts were wrong. A query that compensated by
-  joining `flow_runs` is now redundant rather than harmful.
-- **If you set a long `database.table_prefix`** *(low)* — it is capped at **24 bytes**, 24 ASCII characters and fewer
-  otherwise; the default `saga_` is five. Six indexes are named explicitly rather than derived to reach it. A database
-  that failed part-way on a too-long prefix needs its package tables dropped before `migrate` will get past the first.
+  where `status = 'running'` stops counting runs that ended; those counts were wrong. A query that
+  compensated by joining `flow_runs` is now redundant rather than harmful.
+- **If you set a long `database.table_prefix`** *(low)* — it is capped at **24 bytes**, 24 ASCII
+  characters and fewer otherwise; the default `saga_` is five. Six indexes are named explicitly
+  rather than derived to reach it. A database that failed part-way on a too-long prefix needs its
+  package tables dropped before `migrate` will get past the first.
 - **If you override `Workflow::action()` to return your own builder** *(low)* — `retryOnSignal()`
-  widens its first parameter to `RetryPolicy|string $signal` and appends a fifth `?Closure $when`. PHP refuses an
-  override whose signature no longer matches, so widen yours on both `ActionBuilder`
+  widens its first parameter to `RetryPolicy|string $signal` and appends a fifth `?Closure $when`.
+  PHP refuses an override whose signature no longer matches, so widen yours on both `ActionBuilder`
   and `SagaStepBuilder`.
-- **If you call `FlowHandle::compensate()`** *(medium)* — planning the rollback replays `handle()`, and that replay no
-  longer settles a spent optional step (so no `OptionalActionFailed`) nor schedules a parallel block it had only reached
-  to read. It still writes tags, because a workflow branching on its own tag would otherwise plan a different stack. Six
-  exception classes end the plan; any other throw now surfaces out of `compensate()` with the run untouched, rather than
-  rolling back a truncated plan and reporting it complete — catch it if you did not before. The expiry sweep absorbs the
-  same throw instead, journalling `expiry_failed`.
+- **If you call `FlowHandle::compensate()`** *(medium)* — planning the rollback replays `handle()`,
+  and that replay no longer settles a spent optional step (so no `OptionalActionFailed`) nor
+  schedules a parallel block it had only reached to read. It still writes tags, because a workflow
+  branching on its own tag would otherwise plan a different stack. Six exception classes end the
+  plan; any other throw now surfaces out of `compensate()` with the run untouched, rather than
+  rolling back a truncated plan and reporting it complete — catch it if you did not before. The
+  expiry sweep absorbs the same throw instead, journalling `expiry_failed`.
 - **If you call the runtime classes directly** *(low)* — they are `@internal`, but an
-  `ActionRunRepository` implementation must add `dueForStaleRunningRepair()`, taking a limit and a max-attempts count
-  and returning `iterable`; `ActionDispatcher::dispatch()`, `runInline()` and
-  `ActionRecorder::scheduleAction()` take a readonly `Data\ActionSchedule` whose named parameters are the old tail of
-  optional arguments; and `execute()` on `ActionDispatcher` and
+  `ActionRunRepository` implementation must add `dueForStaleRunningRepair()`, taking a limit and a
+  max-attempts count and returning `iterable`; `ActionDispatcher::dispatch()`, `runInline()` and
+  `ActionRecorder::scheduleAction()` take a readonly `Data\ActionSchedule` whose named parameters
+  are the old tail of optional arguments; and `execute()` on `ActionDispatcher` and
   `CompensationExecutor`, plus `runInline()`, return `Enums\StepExecution` — `Executed`, `ClaimLost`
   (nothing ran) or `Superseded` (it ran, but the row changed hands first) — rather than `void`. Call
   `->settled()` if the distinction does not matter.
@@ -158,37 +166,37 @@ $run->actions()->reorder()->chunkById(500, fn ($actions) => ...);
 
 Nothing below asks anything of you. Each links to the page that covers it.
 
-- **A recorded outcome is never demoted.** Outcome writes are fenced against the claim that produced them, so a
-  straggler cannot flip a succeeded step to `Failed`. Expect `outcome_rejected` lines when runs are cancelled while
-  steps are in flight: a refused outcome is not stored, and that line is what records
-  it. [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery)
-- **A run transition is refused if the row moved on**, rather than the last writer winning. A drive, an expiry and a
-  queued rollback continuation absorb the refusal and stop; `FlowHandle`
-  raises it, and a child-close job rethrows while the child is still live so the close is retried.
+- **A recorded outcome is never demoted.** Outcome writes are fenced against the claim that produced
+  them, so a straggler cannot flip a succeeded step to `Failed`. Expect `outcome_rejected` lines
+  when runs are cancelled while steps are in flight: a refused outcome is not stored, and that line
+  is what records it. [Reclaim & recovery](https://sagalaraflow.dev/reclaim-and-recovery)
+- **A run transition is refused if the row moved on**, rather than the last writer winning. A drive,
+  an expiry and a queued rollback continuation absorb the refusal and stop; `FlowHandle` raises it,
+  and a child-close job rethrows while the child is still live so the close is retried.
   [Queues, locks & idempotency](https://sagalaraflow.dev/queues-locks-idempotency)
 - **A finished run settles what it was holding.** Steps in `pending`, `running` or `awaiting_retry`
   become `cancelled`, as do open wait-markers; steps that reached an outcome are untouched.
   [Statuses](https://sagalaraflow.dev/statuses)
-- **No sweep selects work belonging to a finished run.** The doctor's two scans and the monitor's two each exclude it,
-  so an unsettled row can no longer hold the head of every batch.
+- **No sweep selects work belonging to a finished run.** The doctor's two scans and the monitor's
+  two each exclude it, so an unsettled row can no longer hold the head of every batch.
   [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
-- **No step starts under a run that is rolling back.** A queued step, a doctor redispatch and a signal-gated retry are
-  all refused under `Cancelling`, where one could previously complete after the stack to undo had been planned. Settling
-  a row already started is unchanged.
+- **No step starts under a run that is rolling back.** A queued step, a doctor redispatch and a
+  signal-gated retry are all refused under `Cancelling`, where one could previously complete after
+  the stack to undo had been planned. Settling a row already started is unchanged.
   [Statuses](https://sagalaraflow.dev/statuses)
-- **A rollback no longer stops at a child that already finished.** A parent that carried on past a failed child under
-  `->continueParentOnFailure()` used to roll back only the steps before it and report that as complete, so a
-  compensation you never saw run may start running.
+- **A rollback no longer stops at a child that already finished.** A parent that carried on past a
+  failed child under `->continueParentOnFailure()` used to roll back only the steps before it and
+  report that as complete, so a compensation you never saw run may start running.
   [Child workflows](https://sagalaraflow.dev/child-workflows)
 - **An unfinished `Stop`-policy compensation stops a rollback.** One left `Pending` or `Running`
   when its level finishes is treated the way a failed one is, and recorded under
   `flow_run.exception['compensation']`. A `Continue`-policy compensation still does not halt the
   unwind. [Sagas & compensation](https://sagalaraflow.dev/sagas-and-compensation)
-- **A run whose rollback the sweep cannot plan steps aside** for a widening window instead of holding its place in the
-  page. There is no attempt cap — the cause can be temporary.
+- **A run whose rollback the sweep cannot plan steps aside** for a widening window instead of
+  holding its place in the page. There is no attempt cap — the cause can be temporary.
   [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
-- **Five recorder transitions write conditionally** — a give-up, a park, a rewind, settling a parked step, and the
-  queue's exhausted-attempts flag. One that loses writes nothing, journals
+- **Five recorder transitions write conditionally** — a give-up, a park, a rewind, settling a parked
+  step, and the queue's exhausted-attempts flag. One that loses writes nothing, journals
   `write_refused` with a `site`, and returns `false` where it returned `void`.
 - **`RunCompensationJob` takes its own queue lock**, which compensations previously had none of.
 
@@ -197,21 +205,23 @@ Nothing below asks anything of you. Each links to the page that covers it.
 Nothing to do; each is opt-in or additive.
 
 - **`reclaim`** (`actions.reclaim.stale_running`, `sagas.reclaim.stale_running`) lets a `Running`
-  row be claimed again once its window has passed, recognising a worker that died mid-execution. Off by default;
-  per-step via `reclaimStaleAfter()` and `enableStaleReclaim()`, and per-compensation via
-  `reclaimCompensationStaleAfter()` and `enableCompensationStaleReclaim()`.
-- **`logging`** — `anomaly_level` (default `info`, `null` to silence) and `channel`. The package's first logging: a
-  second journal beside `flow_events` for the refusals nothing else records. Writing is best-effort and never fails a
-  job.
-- **`RetryPolicy`** — `retryOnSignal()` accepts a policy object, and a `when:` predicate gates whether *this* failure is
-  worth parking. Every existing call site behaves identically.
+  row be claimed again once its window has passed, recognising a worker that died mid-execution. Off
+  by default; per-step via `reclaimStaleAfter()` and `enableStaleReclaim()`, and per-compensation
+  via `reclaimCompensationStaleAfter()` and `enableCompensationStaleReclaim()`.
+- **`logging`** — `anomaly_level` (default `info`, `null` to silence) and `channel`. The package's
+  first logging: a second journal beside `flow_events` for the refusals nothing else records.
+  Writing is best-effort and never fails a job.
+- **`RetryPolicy`** — `retryOnSignal()` accepts a policy object, and a `when:` predicate gates
+  whether *this* failure is worth parking. Every existing call site behaves identically.
   [Retry on signal](https://sagalaraflow.dev/retry-on-signal)
-- **`ActionOutcomeRejected` and `CompensationOutcomeRejected`** carry what a refused outcome produced — the recorded
-  form of the result, or the throw the engine does not rethrow. Nothing is stored and nothing about the run changes.
+- **`ActionOutcomeRejected` and `CompensationOutcomeRejected`** carry what a refused outcome
+  produced — the recorded form of the result, or the throw the engine does not rethrow. Nothing is
+  stored and nothing about the run changes.
   [Events](https://sagalaraflow.dev/events#refused-outcome)
 - **`CompensationStepStarted`** marks one compensation beginning, distinct from
   `CompensationStarted`, which marks the whole rollback once per run.
-- **`FlowStatus::terminal()`** lists the four statuses a run never leaves; `isTerminal()` reads from it.
+- **`FlowStatus::terminal()`** lists the four statuses a run never leaves; `isTerminal()` reads from
+  it.
 - **Two `FlowQuery` wait filters**, with the `index_signal_waits` indexes that serve them:
   `flow_signals` gains `(status, name, flow_run_id)`, `action_runs`
   `(status, retry_signal, flow_run_id)`.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,12 +2,13 @@
 
 ## From 1.1.x to 1.2.0
 
-> ### ⚠️ Run `php artisan migrate` after upgrading  Four migrations ship with this release —
-> `add_reclaim_stale_running_columns`, `index_signal_waits`, `unique_flow_tag_keys` and
-> `add_expiry_backoff_to_flow_runs` — and the engine writes their columns from the moment it starts.
-> Deploy them together with the code. They run from the package — do **not** `vendor:publish` them,
-> or `migrate` would try both copies. `unique_flow_tag_keys` deletes rows; read its item below
-> before you run it.
+> ### ⚠️ Run `php artisan migrate` immediately after upgrading
+>
+> Four migrations ship with this release — `add_reclaim_stale_running_columns`,
+> `index_signal_waits`, `unique_flow_tag_keys` and `add_expiry_backoff_to_flow_runs` — and the
+> engine writes their columns from the moment it starts. Deploy them together with the code. They
+> run from the package — do **not** `vendor:publish` them, or `migrate` would try both copies.
+> `unique_flow_tag_keys` deletes rows; read its item below before you run it.
 
 ### Action required
 
@@ -97,7 +98,7 @@ WHERE status = 'waiting'
 
 Adjust the names for your `database.table_prefix`.
 
-#### A `FlowRun` relation now reads in a defined order
+#### `FlowRun` relations now read in a defined order
 
 **Likelihood of impact: low.** `actions()`, `compensations()`, `sideEffects()` and `children()` read
 by `sequence`, `events()` by `recorded_at`, `signals()` and `tags()` by `id`. A read that appends

--- a/docs/docs/queues-locks-idempotency.md
+++ b/docs/docs/queues-locks-idempotency.md
@@ -150,11 +150,13 @@ between them for a condition to catch. That is what the lock is for.
 
 ## When a step is quietly skipped
 
-Three things can happen to a worker without failing its job: it loses the claim to whoever already
-owns the row, it finishes but has been superseded meanwhile so its outcome is rejected, or it
-finishes a parallel step whose batch a duplicate had already closed. All three are ordinary
-consequences of at-least-once delivery, and none of them leaves a trace in the run's history — so the
-package keeps a second journal for them:
+Several things can happen to a worker without failing its job: it loses the claim to whoever already
+owns the row, its claim turns out not to have survived its own transaction, it finishes but has been
+superseded meanwhile so its outcome is rejected, a write to the step is refused because the row
+moved on, or it finishes a parallel step whose batch a duplicate had already closed. Most are
+ordinary consequences of at-least-once delivery — a refused write can equally come from an operator
+or from terminal settlement — and none leaves a trace in the run's history, so the package keeps a
+second journal for them:
 
 ```php
 'logging' => [
@@ -176,9 +178,9 @@ written to `flow_events`, which records the run's business history — an abando
 nothing in it. See [Reclaim & recovery](./reclaim-and-recovery.md) for what each one means and what
 to do about it.
 
-The middle one is the only one that discards something the work produced, so it also raises an event
-carrying it — see [A refused outcome](./events.md#refused-outcome). `rejection_undelivered` is that
-hand-over failing, and the one way the payload is lost anyway.
+A rejected outcome is the only one that discards something the work produced, so it also raises an
+event carrying it — see [A refused outcome](./events.md#refused-outcome).
+`rejection_undelivered` is that hand-over failing, and the one way the payload is lost anyway.
 
 :::tip A lock TTL is not the same as reclaim
 `action_ttl_seconds` does not answer "when can a stuck `Running` step be retried". It governs a

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -223,8 +223,11 @@ discarded (see [Events](./events.md#refused-outcome)):
 ],
 ```
 
-Seven reason codes to grep for. All but one carry the run id, row id, sequence and class; `expiry_failed`
-is about a run rather than a row, and carries the run id, its workflow class and the throw:
+Nine reason codes exist; the seven raised on the paths this page covers are below. The other two are
+`transition_lost`, which belongs to [run transitions](./queues-locks-idempotency.md), and
+`retry_policy_threw`, which belongs to [retry policies](./retry-on-signal.md). All but one of the
+seven carry the run id, row id, sequence and class; `expiry_failed` is about a run rather than a row,
+and carries the run id, its workflow class and the throw:
 
 - **`claim_lost`** — a worker found the row already owned and did not execute the step.
 - **`outcome_rejected`** — a worker finished, but the row had changed hands and its result was dropped. Listen for

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -45,7 +45,8 @@ use Throwable;
 /**
  * Fluent builder for a single action step. run() is the replay seam: it identifies the
  * step by its (flow_run_id, sequence) ordinal and either returns the stored result,
- * rethrows the stored failure, or schedules the step and suspends the flow.
+ * rethrows the stored failure, or schedules the step — executing it inline in sync mode —
+ * and suspends the flow.
  * compensateWith() registers a compensation pushed onto the saga stack when the step
  * resolves Completed; the step's OWN failure does not trigger it unless
  * compensateStepOnSelfFailure() opts in. That and onCompensationFailure() resolve with

--- a/src/Builders/ActionBuilder.php
+++ b/src/Builders/ActionBuilder.php
@@ -43,28 +43,14 @@ use InvalidArgumentException;
 use Throwable;
 
 /**
- * Fluent builder for a single action step. run() is the replay seam: it
- * identifies the step by its (flow_run_id, sequence) ordinal and either returns
- * the stored result, rethrows the stored failure, or schedules/executes the
- * step and suspends the flow.
- *
- * compensateWith() registers a compensation (a class or a closure) that is pushed
- * onto the saga stack when the step resolves Completed (deterministically on every
- * replay), so a later business failure rolls it back. By default the step's OWN
- * failure does not trigger its compensation (classic saga: only completed steps are
- * undone); compensateStepOnSelfFailure() opts a non-atomic step into being compensated when
- * it fails too — its compensation must then be idempotent and safe when the step did
- * nothing. onCompensationFailure() overrides the default Stop policy. All three
- * resolve with precedence action > group (saga()) > config.
- *
- * Constructed by the engine, and reachable for subclassing only by overriding
- * Workflow::action(): its method signatures are treated as internal.
- *
- * retryOnSignal() turns a failure into a wait: the step parks on a named signal, and
- * each delivery re-runs THIS step alone at the very same ordinal. The seam is the only
- * decision-maker, so nothing else resolves the row it reads back. Its policy may be
- * four arguments or a RetryPolicy object; either way nothing about it is persisted
- * beyond the signal name and the ceiling, and the decision is retaken on every replay.
+ * Fluent builder for a single action step. run() is the replay seam: it identifies the
+ * step by its (flow_run_id, sequence) ordinal and either returns the stored result,
+ * rethrows the stored failure, or schedules the step and suspends the flow.
+ * compensateWith() registers a compensation pushed onto the saga stack when the step
+ * resolves Completed; the step's OWN failure does not trigger it unless
+ * compensateStepOnSelfFailure() opts in. That and onCompensationFailure() resolve with
+ * precedence action > group (saga()) > config. Constructed by the engine, and reachable
+ * for subclassing only by overriding Workflow::action(): its signatures are internal.
  */
 class ActionBuilder
 {
@@ -242,27 +228,13 @@ class ActionBuilder
     }
 
     /**
-     * Wait for a named signal instead of failing this step. When the step gives up
-     * (its queue $tries are spent) the flow parks: the step lands AwaitingRetry, a
-     * wait-signal is recorded, and the run goes Waiting. Delivering $signal re-runs
-     * THIS step alone — the same (flow_run_id, sequence) ordinal, the same arguments,
-     * no new sequence — so replay and every downstream step stay deterministic. A
-     * failure of the retry parks again.
-     *
-     * $maxRetries caps the signal-gated cycles (null falls back to
-     * actions.retry_on_signal.max_retries, and null there means unbounded);
-     * $waitSeconds bounds ONE wait (null falls back to the configured default signal
-     * timeout);
-     * $only restricts the policy to the listed exception classes and their
-     * subclasses (null reacts to every failure);
-     * $when has the final say on a failure that passed $only, and returning false
-     * from it ends the policy for that failure. Once the budget is spent, the wait
-     * times out, the failure falls outside $only, or $when refuses it, the step
-     * fails exactly as it would have without this policy.
-     *
-     * A RetryPolicy passed as $signal carries all four itself, and combining it with
-     * any of them is refused. See RetryPolicy for which of its values survive a
-     * deploy and which do not.
+     * Wait for a named signal instead of failing this step. When the step gives up (its queue
+     * $tries are spent) the flow parks: the step lands AwaitingRetry, a wait-signal is
+     * recorded, and the run goes Waiting. Delivering $signal re-runs THIS step alone, at the
+     * same ordinal with the same arguments, so replay stays deterministic. $maxRetries caps
+     * the cycles, $waitSeconds bounds ONE wait, $only restricts the policy to exception
+     * classes and $when has the final say; once any refuses, the step fails as it would have
+     * without a policy. A RetryPolicy passed as $signal carries all four instead.
      *
      * @param  list<class-string<Throwable>>|null  $only
      * @param  ?Closure(RetryContext): bool  $when
@@ -698,16 +670,12 @@ class ActionBuilder
 
     /**
      * Write the parking — the wait-signal at this ordinal and the step's transition to
-     * AwaitingRetry — in one transaction, so a process that dies mid-parking leaves
-     * either all of it or none. Suspending stays outside: it throws, and a throw inside
-     * would roll the parking back.
+     * AwaitingRetry — in one transaction, so a process that dies mid-parking leaves either all
+     * of it or none. Suspending stays outside: it throws, and a throw inside would roll the
+     * parking back. $record is false when an open signal from an earlier pass was adopted.
      *
-     * $record is false when an open signal from an earlier pass was adopted.
-     *
-     * A parking that loses its fence — the row moved on, or the run finished — writes
-     * neither row, fires no ActionAwaitingRetry, and suspends like a won one. Whatever
-     * moved the row wrote where the step really is, and a run that ended has nothing
-     * left to resolve; either way this pass has no state left to decide from, and the
+     * A parking that loses its fence writes neither row, fires no ActionAwaitingRetry, and
+     * suspends like a won one: whatever moved the row wrote where the step really is, and the
      * suspension leaves no wait behind because none was recorded.
      *
      * @throws FlowSuspended

--- a/src/Retry/RetryPolicy.php
+++ b/src/Retry/RetryPolicy.php
@@ -10,7 +10,7 @@ use Throwable;
  * parking at all. Pass an instance to ActionBuilder::retryOnSignal().
  *
  * Nothing about it is persisted — handle() rebuilds it on every replay — so all five
- * members must be deterministic, and only maxRetries() has its value frozen, onto the
+ * members must be deterministic, and only maxRetries() has its value frozen onto the
  * row at scheduling. shouldRetry() may not write to the run it is deciding for, nor
  * drive any run; the engine refuses that with RetryPolicyReentryException.
  */

--- a/src/Retry/RetryPolicy.php
+++ b/src/Retry/RetryPolicy.php
@@ -5,44 +5,14 @@ namespace DiscoveryUkraine\SagaLaraFlow\Retry;
 use Throwable;
 
 /**
- * A named, reusable retryOnSignal() policy: one object that owns which signal a
- * failed step parks on, how long it may keep parking, and — the part four scalar
- * arguments could never express — whether THIS failure is worth parking at all.
+ * A named, reusable retryOnSignal() policy: one object owning which signal a failed
+ * step parks on, how long it may keep parking, and whether THIS failure is worth
+ * parking at all. Pass an instance to ActionBuilder::retryOnSignal().
  *
- * Pass an instance to ActionBuilder::retryOnSignal(); the builder reads it and the
- * step behaves exactly as it would have with the equivalent arguments.
- *
- * Your handle() builds the policy afresh on every replay, so nothing about it is
- * persisted. The builder reads signal(), maxRetries(), waitSeconds() and only() the
- * moment it is handed the object, and it does so on every pass — including a pass
- * that only replays a step already scheduled or completed. shouldRetry() is stored
- * rather than called: it runs at the gate, and only for a step that has failed. What
- * is frozen is one value, not one method:
- *
- * - maxRetries() is read when the step is SCHEDULED into
- *   action_runs.retry_signal_max_attempts, and every later replay enforces the row.
- *   Raising it in a deploy does not lift the ceiling of a step already parked.
- * - signal(), waitSeconds(), only() and shouldRetry() take effect immediately, so a
- *   deploy changes them for runs already in flight. action_runs.retry_signal records
- *   the name a step last parked on but is rewritten at every parking and never read
- *   back: renaming a signal moves what a parked step will next wait for, and abandons
- *   a delivery already made under the old name.
- *
- * None of the five is asked once and remembered, so all five must be deterministic —
- * the same question must get the same answer on every pass. Two further obligations:
- *
- * - The first four are called while the workflow is still building the step, before
- *   the seam has resolved anything, so one that throws takes the whole run down with
- *   it and the step it was attached to never registers its compensation — exactly as
- *   an argument expression that throws would. Only shouldRetry() is guarded.
- * - shouldRetry() is not called exactly once (a process that dies between the
- *   decision and the parking makes the next replay ask again), so it must be a pure
- *   predicate and leave side effects to a listener. It also may not write to the run
- *   it is deciding for — no seam, and no FlowHandle mutation on that run: it is not
- *   asked again once the step it guards succeeds, so an ordinal it consumed would be
- *   left for nobody to replay, and a run it cancelled would be handed a live wait the
- *   moment it returned. RetryPolicyReentryException refuses the attempt before
- *   anything is written. Other runs are fair game.
+ * Nothing about it is persisted — handle() rebuilds it on every replay — so all five
+ * members must be deterministic, and only maxRetries() has its value frozen, onto the
+ * row at scheduling. shouldRetry() may not write to the run it is deciding for, nor
+ * drive any run; the engine refuses that with RetryPolicyReentryException.
  */
 abstract class RetryPolicy
 {

--- a/src/Runtime/ActionRecorder.php
+++ b/src/Runtime/ActionRecorder.php
@@ -143,37 +143,14 @@ final readonly class ActionRecorder
     }
 
     /**
-     * Atomically claim the row and move it to Running, returning false when the row
-     * is no longer claimable and the caller must not execute the step.
-     *
-     * The condition lives in the UPDATE itself — the same compare-and-swap shape as
-     * SignalRecorder::claimWaiting(), the only form every supported driver enforces
-     * atomically (lockForUpdate() compiles to nothing on SQLite). This transition
-     * therefore raises no Eloquent model events; ActionStarted and the action.started
-     * flow_events entry are the supported way to observe it.
-     *
-     * Claimable statuses are Pending, Failed, and Running past its reclaim deadline.
-     * Failed is not terminal here: it is what the row shows between two of the
-     * action's own native $tries, which Laravel redelivers as the very same job.
-     *
-     * `attempts` is incremented by the database, so two racing claims can never
-     * persist the same count, and the value a claim produces identifies it.
-     *
-     * $expectedRetryGeneration constrains retry_signal_attempts, folding a caller's
-     * stale-cycle check into this same atomic write so a cycle change landing after
-     * the row was read still loses the claim. Null imposes no constraint.
-     *
-     * The run's own state is folded in the same way, and for a reason the row cannot see
-     * on its own: terminal settlement leaves a Failed row — the state between two of the
-     * queue's own native tries — exactly as it found it, so without this a job already on
-     * the queue when the run was cancelled still claims it and runs the business logic.
-     * A run rolling back is fenced against too, and not because it has finished: it has
-     * already planned the stack it will undo, and a step starting now lands outside it.
-     *
-     * The claim and its two records share one transaction: a listener throwing on
-     * ActionStarted would otherwise leave the row Running with nothing executing it.
-     * A commit is not proof the claim survived one, so the row is read back afterwards
-     * — see claimSurvivedCommit().
+     * Atomically claim the row and move it to Running, returning false when the row is no
+     * longer claimable and the caller must not execute the step. Claimable statuses are
+     * Pending, Failed, and Running past its reclaim deadline — Failed is not terminal here, it
+     * is what the row shows between two of the action's own native $tries. The condition lives
+     * in the UPDATE, so this raises no Eloquent model events; ActionStarted and action.started
+     * are how to observe it. The run is fenced on mayStartWork() rather than on being
+     * unfinished: a run rolling back has already planned the stack it will undo, so a step
+     * starting now would land outside it.
      *
      * @throws Throwable
      */
@@ -244,27 +221,12 @@ final readonly class ActionRecorder
     }
 
     /**
-     * Whether the claim is on record now the transaction that made it has closed. A
-     * commit reporting success is not proof: PostgreSQL aborts a transaction on the
-     * first failed statement and turns the eventual COMMIT into a rollback, reporting
-     * success either way, so any caller code running inside it — a listener on
-     * ActionStarted, a model observer on the flow_events insert — that runs a failing
-     * query and swallows it discards the claim while the caller is told it holds one.
-     * The row is the only answer that covers every such shape: the claim is visible or
-     * it is not.
-     *
-     * Refusing a row a second worker legitimately took between the commit and this read
-     * is the same answer for the same reason — it is no longer ours to execute. The row
-     * is what answers, though, not a token: a claim of ours that rolled back and a second
-     * worker's claim that replaced it read alike, so a claim lost to that race is
-     * narrowed rather than caught. Telling those two apart needs a value per claim that a
-     * rollback cannot reproduce, which the schema does not carry.
-     *
-     * What the read proves is that the claim is visible on the connection that wrote it,
-     * which is durability only while the engine's transaction is the outermost one. A
-     * host transaction wrapped around a run can still discard every row the run recorded
-     * with its side effects already spent — on any driver, and whatever this check said —
-     * which is why the documentation asks hosts not to open one.
+     * Whether the claim is on record now the transaction that made it has closed. A commit
+     * reporting success is not proof: PostgreSQL aborts a transaction on the first failed
+     * statement and turns the eventual COMMIT into a rollback, so caller code inside it that
+     * swallows a failing query discards the claim while the caller is told it holds one. The
+     * row is what answers, not a token, so a claim lost to a second worker between commit and
+     * read is narrowed rather than caught.
      */
     private function claimSurvivedCommit(ActionRun $actionRun): bool
     {
@@ -445,27 +407,12 @@ final readonly class ActionRecorder
     }
 
     /**
-     * Persist the pending attribute changes only if the row is still the one the caller
-     * read and the run under it has not finished. The values come from getDirty(), so
-     * the model's own casts encode them exactly as save() would; $expected names the
-     * stored values the caller's decision rested on, and the run's liveness rides in the
-     * same statement rather than a read before it, so no row this pass already saw can
-     * move between the check and the write.
-     *
-     * It fences against what is committed, which is what terminal settlement leaves
-     * behind, and not against a transition still in flight — that one is invisible to a
-     * snapshot until it commits. The values are dirty attributes, so a caller with
-     * nothing to write would report a refusal it never made; every site reaches this
-     * with a change.
-     *
-     * Every $expected key that the write also sets names the value being REPLACED, so a
-     * matching row always changes — which keeps the count off the zero MySQL reports for
-     * an update that changed nothing and FlowStateMachine::write() has to disambiguate.
-     *
-     * $runFence is which boundary the run is held to, because the callers do not all ask
-     * the same thing: writing down what a step already did needs a run that has not
-     * finished, while a caller that starts the step again needs one that may still start
-     * work at all.
+     * Persist the pending attribute changes only if the row is still the one the caller read
+     * and the run under it passes $runFence. Every $expected key the write also sets names
+     * the value being REPLACED, so a matching row always changes — which keeps the count off
+     * the zero MySQL reports for an update that changed nothing. $runFence differs by caller:
+     * writing down what a step already did needs a run that has not finished, starting it
+     * again needs one that may still start work at all.
      *
      * @param  array<string, mixed|list<mixed>>  $expected
      * @param  array<string, mixed>  $context

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -6,28 +6,15 @@ use Illuminate\Support\Facades\Log;
 use Throwable;
 
 /**
- * The engine's second journal: what it absorbed while running.
+ * The engine's second journal: what it absorbed while running. EventLog records what
+ * happened to a run in business terms; this records the moments where the world turned
+ * out not to be what the engine assumed — a lost claim, a refused write, a batch already
+ * closed, a policy that threw. Each reason is a REASON_* constant below.
  *
- * EventLog records what happened to a run in business terms. This records the moments
- * where the world turned out not to be what the engine assumed — a claim lost to
- * whoever already owned the row, a claim the transaction that made it did not keep, an
- * outcome write refused because the row had changed hands, a step write refused because
- * the row had moved on since it was read, a batch already closed by a duplicate before
- * its own job reported, a run transition refused because the row had moved on, a retry
- * policy that threw, a rejection notice no listener could be given, an overdue run
- * whose rollback could not be planned. Most are ordinary consequences of at-least-once delivery and of nothing
- * serialising an operator against a worker; the claim that did not commit and the last
- * two are defects in the caller's own code, journalled here for the same reason as the
- * rest — the engine carried on, so nothing else records it.
- *
- * None of them fails a job. A refused transition also reaches its caller: the engine
- * absorbs it and stops, but FlowHandle lets it surface, because an operator whose
- * cancellation did not happen has to be told.
- *
- * Which is why they need a journal of their own: the job succeeds, flow_events stays
- * silent, and an operator investigating a step that ran twice would have nothing to go
- * on. They stay out of flow_events because an abandoned attempt changed nothing in the
- * run's history.
+ * They need a journal of their own because the job usually succeeds and flow_events stays
+ * silent: an abandoned attempt changed nothing in the run's history, so nothing else
+ * records it. A refused transition is the exception that can still surface — FlowHandle
+ * raises it, and a child-close job rethrows while the child it was sent to close is live.
  */
 final readonly class AnomalyLog
 {

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -20,9 +20,10 @@ use Throwable;
 /**
  * The opt-in repair pass — the "doctor". Distinct from the expiration monitor
  * (FlowMonitor): it recovers progress lost to a *dropped job*, not a passed deadline. It only ever
- * re-dispatches an existing job or re-wakes a run, so it creates no new step and no new result row
- * — but R3 can start a second execution of one step, since a reclaim window expiring does not
- * prove the first worker is dead.
+ * re-dispatches an existing job or re-wakes a run, so it writes no step and no outcome of its own
+ * and cannot duplicate an ordinal — the run carries on normally from there, scheduling whatever
+ * comes next. R3 can still start a second execution of one step, since a reclaim window expiring
+ * does not prove the first worker is dead.
  *
  *   R1  a stuck sequential Pending action (its RunActionJob was lost) → re-dispatch.
  *   R2  a stuck Waiting run with nothing in flight (its resume was lost) → re-wake.

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -18,30 +18,21 @@ use Illuminate\Support\Facades\DB;
 use Throwable;
 
 /**
- * The opt-in repair pass — the "doctor". Distinct from the
- * expiration monitor (FlowMonitor): it recovers progress lost to a *dropped job*,
- * not a passed deadline. It is configured, scheduled, and looped independently
- * (config repair.*, command saga-flow:repair, its own queue-looping lock).
- *
- * It only ever re-dispatches an existing job or re-wakes a flow — never creating
- * duplicate work or mutating a business result. Two automatic cases, both safe
- * under repeated passes thanks to the jobs' own idempotency (skip-set on settled
- * steps, terminal-run guard) and replay:
+ * The opt-in repair pass — the "doctor". Distinct from the expiration monitor
+ * (FlowMonitor): it recovers progress lost to a *dropped job*, not a passed deadline. It only ever
+ * re-dispatches an existing job or re-wakes a run, so it creates no new step and no new result row
+ * — but R3 can start a second execution of one step, since a reclaim window expiring does not
+ * prove the first worker is dead.
  *
  *   R1  a stuck sequential Pending action (its RunActionJob was lost) → re-dispatch.
- *   R2  a stuck Waiting run with nothing in flight (its resume was lost) → re-wake;
- *       replay then advances it or parks it again.
- *   R3  a stuck sequential Running action past its own reclaim window (opt-in via
- *       actions.reclaim.stale_running — a worker died mid-execution) → re-dispatch.
+ *   R2  a stuck Waiting run with nothing in flight (its resume was lost) → re-wake.
+ *   R3  a stuck sequential Running action past its own reclaim window → re-dispatch.
  *
- * Each repaired entity carries repair_attempts + repair_available_at so a pass is
- * throttled per entity (exponential backoff) and gives up after max_attempts —
- * saga-flow:kick is the manual escape hatch. Batch-bound work (compensations,
- * parallel actions) is out of scope even for R3: recovering them would mean
- * adding a job back into their Bus::batch, which needs the batch's id — not stored
- * anywhere in this package's tables, only recoverable by looking its deterministic
- * name up in Laravel's own job_batches table, a detail of the database batch driver
- * specifically and not guaranteed for every host.
+ * repair_attempts + repair_available_at throttle a pass per entity and give up after max_attempts.
+ * saga-flow:kick re-wakes a run by hand, which is the manual answer to R2; it does not reset a
+ * counter, so an action the doctor has given up on waits for a retry cycle to reschedule it.
+ * Batch-bound work (parallel actions, compensations) is out of scope even for R3: adding a job back
+ * into a Bus::batch needs an id this package does not store.
  */
 final readonly class FlowDoctor
 {

--- a/src/Runtime/SignalRecorder.php
+++ b/src/Runtime/SignalRecorder.php
@@ -195,19 +195,15 @@ final readonly class SignalRecorder
     }
 
     /**
-     * Move a wait-signal out of Waiting in a single conditional write, and sync the
-     * in-memory model to match when it lands. Returns false when the row is no longer
-     * Waiting: someone else moved it first and this caller must not write over them.
+     * Move a wait-signal out of Waiting in a single conditional write, and sync the in-memory
+     * model to match when it lands. Returns false when the row is no longer Waiting: someone
+     * else moved it first and this caller must not write over them.
      *
-     * The condition lives in the UPDATE itself: it is the only form every supported
-     * driver enforces atomically, since lockForUpdate() compiles to nothing on SQLite.
-     * The price is that these transitions raise no Eloquent model events, so an
-     * observer on a swapped-in models.flow_signal will not see them; flow_events and
-     * the package's own Laravel events still record every one.
-     *
-     * The model is re-read rather than filled from the values just written: those are
-     * already database-ready, and pushing an encoded JSON payload back through the
-     * casts would encode it twice.
+     * The condition lives in the UPDATE — the only form every supported driver enforces
+     * atomically — so these transitions raise no Eloquent model events. flow_events records
+     * every one that lands; a Laravel event accompanies only the paths documented as raising
+     * one, and a timeout deliberately raises none. The model is re-read rather than filled
+     * from the values just written, which are already database-ready.
      *
      * @param  array<string, mixed>  $values
      */

--- a/tests/Feature/ChildScalarResultTest.php
+++ b/tests/Feature/ChildScalarResultTest.php
@@ -104,7 +104,7 @@ it('rehydrates a model a child returned', function () {
 });
 
 // Pinning: a row written before the envelope was dropped keeps it, and the seam
-// resolves it as stored on every replay — the behaviour UPGRADING describes
+// resolves it as stored on every replay — the behaviour UPGRADING.md describes
 // under the scalar result. Unwrapping it here would corrupt a child that legitimately
 // returned ['value' => ...].
 it('resolves a child stored with the old envelope exactly as it stands', function () {

--- a/tests/Feature/ChildScalarResultTest.php
+++ b/tests/Feature/ChildScalarResultTest.php
@@ -104,8 +104,8 @@ it('rehydrates a model a child returned', function () {
 });
 
 // Pinning: a row written before the envelope was dropped keeps it, and the seam
-// resolves it as stored on every replay — the behaviour UPGRADING item 12
-// describes. Unwrapping it here would corrupt a child that legitimately
+// resolves it as stored on every replay — the behaviour UPGRADING describes
+// under the scalar result. Unwrapping it here would corrupt a child that legitimately
 // returned ['value' => ...].
 it('resolves a child stored with the old envelope exactly as it stands', function () {
     $run = SagaFlow::create(ChildThenSignalWorkflow::class)->runSync();


### PR DESCRIPTION
Text only: `git diff -U0 src/` contains nothing but comment lines. SQLite 462/4, MySQL 462/4, Pint
PASS on 370 files, PHPStan clean, the docs site builds.

## What this does

`UPGRADING.md` **617 → 289**; the `From 1.1.x to 1.2.0` section **547 → 219**. The 1.1.0 section is
untouched — it documents a released version. Twenty-six numbered items become the Laravel shape: a
migrate banner, then `### Action required` (five subsections carrying code or SQL, plus ten folded
bullets each marked `*(medium)*`/`*(low)*`), `### Behaviour changed` (a line or two plus a link to
the page that covers it), `### Additions`.

Ten docblocks in `src/` go from 249 lines together to about a third of that, and two pages of
`docs/` get factual corrections.

**Acceptance criterion (the sum must fall, not move between files):**

```
UPGRADING.md   617 → 289
docs/         2690 → 2695   (+2, +3 — both correctness fixes)
SUM           3307 → 2984   −323
```

## Why so little moved into docs

Measured before any editing: the 1.2.0 section decomposed paragraph by paragraph is 194 lines of
"what the host must do", 137 of mechanism, 41 of rationale, 18 of history. Of the 137 mechanism
lines, **about 115 were already in `docs/`, some of them verbatim and more complete** — item 15
whole in `queues-locks-idempotency.md:125-148`, the anomaly journal in
`reclaim-and-recovery.md:220-258`, the retry-policy semantics in `retry-on-signal.md:186-215`. So
those become links rather than moves, and the sum falls instead of shuffling. Same story in `src/`:
the 39-line `RetryPolicy` docblock duplicated `retry-on-signal.md:186-215` in full.

One paragraph was the sole carrier of its fact (`grep` over all of `docs/` returned nothing):
`ConcurrentFlowTransitionException` is deliberately not a subclass of `InvalidTransitionException`.
It stayed.

## Fourteen false statements removed

Four found by my own pre-work audit, ten by two adversarial review passes. Every one verified in the
code before acting on it.

**Contradictions the file had with itself or with the code**

| where | what it said | what the code says |
|---|---|---|
| old item 14 | "Four scans gained the same condition" | three different conditions: `mayStartWork()`, `live()`, and `dueForExpiration()`'s own `whereIn([Running, Waiting])` |
| old item 14 | "the monitor has no counter at all" | #52 gave it `expiry_attempts`; item 24 of the same file described that |
| `reclaim-and-recovery.md:226` | "Seven reason codes" | `AnomalyLog` has nine constants |
| `queues-locks-idempotency.md:153` | "Three things can happen to a worker" | the next paragraph grepped for four, and `claim_not_committed` makes five |

**Universal claims that lost their qualifier when the prose was compressed** — this was the dominant
failure mode, six of them in one pass:

| claim | measurement |
|---|---|
| "Each still publishes its package event and `flow_events` entry" | four transitions publish neither: `settleAwaitingRetry`, `markQueueAttemptsExhausted`, `settleOpenSteps`, `settleOpenWaits` |
| "That replay writes nothing at all now" | `tag()` calls `updateOrCreate` with no `isCollecting()` guard |
| "An unfinished compensation stops a rollback" | `SagaRunner::levelStopped():302` has `->where('continue_on_failure', false)` |
| "R3 acts on any row carrying a reclaim window" | `dueForStaleRunningRepair()` also filters on `parallel_group`, `mayStartWork()`, the backoff window, and the attempt cap |
| "the run fails as a business error" (the monitor) | `ActionBuilder:447` returns an optional step's fallback |
| "The engine absorbs the refusal and stops" | `CancelChildWorkflowJob:60-70` rethrows while the child is live, so the close retries |
| "anything but an array was wrapped" | the removed `normalizeResult()` tested the **serialized** value and passed `null` through; a `JsonSerializable` returning a scalar *was* wrapped |
| `FlowTag` "normalises int **keys**" | `casts():34` puts `AsTagValue` on `value` |
| `claimWaiting()` "the package's own events record every one" | `timeoutSignal()` raises no Laravel event |
| `FlowDoctor` "never creating duplicate work" | R3 redispatches on a window expiring, which does not prove the first worker died |

**Knowledge that was dropped and is now back:** the `vendor:publish` prohibition in the banner; the
`database.table_prefix` note on the duplicate-count query; that an unexpected planning throw now
surfaces out of `compensate()` with the run untouched; the compensation reclaim method pair.

## Filed, not fixed here

**#67** — `saga-flow:kick` is documented as the manual escape hatch, but `kick():238-249` only
dispatches a `ResumeWorkflowJob`; the replay parks again on the recorded step, and nothing resets
`repair_attempts`. Probe with a two-hour-old `Pending` action, its job deleted, `repair_attempts=10`:

```
after doctor:        redispatchedActions=0  jobs=0
jobs queued by kick: 1                      (the resume, nothing else)
after drain:         run=waiting  step=pending  attempts=0  repair_attempts=10
```

A pre-existing defect, so only the docblock claim is corrected here.

## Notes

The target was ~130 lines for the 1.2.0 section and the result is 219. The floor is arithmetic: the
"what the host must do" basket alone is 194 lines, 48 of them fenced code and SQL a host copies.
Both review passes then traded roughly 40 lines back for accuracy, which is the right way round.