### PR TITLE
Hold signal delivery to the runs that can consume it

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,15 @@ sets and are not interchangeable. `Cancelling` is **not** terminal — it is a r
 Swapping one boundary for the other changes public behaviour and needs its own exception and its own
 documentation.
 
+**Signal delivery is a check, not a fence.** `SignalDispatcher::deliver()` reads the run from the
+writer and refuses anything outside `signalable()`. That narrows the window; it does not close it. A
+run entering `Cancelling` in the moment after the read still takes the delivery, which then stays a
+floating `Received` row like any other nobody consumed — the documented outcome for a signal no
+`awaitSignal()` matched. This is the intended shape, **not an open defect**: do not file it as one,
+and do not widen the change to chase it. A real fence means conditional writes inside
+`SignalRecorder`, which the retry seam shares, bought for a window whose worst outcome is already
+documented behaviour.
+
 The one that decides a write is `mayStartWork()` versus `live()`: ask the narrower one wherever work
 would **begin** (the action claim, the repair rules that send another job, the retry that spends a
 signal to start a fresh cycle), and `live()` wherever a row already started is settled or written

--- a/README.md
+++ b/README.md
@@ -355,9 +355,14 @@ Deliver a signal from anywhere via the handle:
 ```php
 SagaFlow::loadFlow($runId)->signal('approval', ['approved' => true]);
 
-// safe variant that returns false instead of throwing on a terminal run:
+// safe variant that returns false instead of throwing:
 SagaFlow::loadFlow($runId)->signalIfRunning('approval', ['approved' => true]);
 ```
+
+A signal is accepted only by a run that can still consume one — `Pending`, `Running` or `Waiting`.
+`signal()` throws `CannotSignalTerminalFlowException` on a finished run and
+`CannotSignalCancellingFlowException` on one that is rolling back; both extend
+`CannotSignalFlowException`. A refusal writes nothing.
 
 No `$runId`? Find the run by workflow and tag, then signal it. Use `signalable()` (alias `active()`),
 **not** `running()` — a flow parked on `awaitSignal()` is `Waiting`, not `Running`:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,21 @@
 # Upgrading
 
+## From 1.2.x to 1.3.0
+
+### Behaviour changed
+
+Nothing below asks anything of you. Each links to the page that covers it.
+
+- **A signal is refused by a run that is rolling back.** Delivery is held to the three statuses
+  `signalable()` already named — `Pending`, `Running`, `Waiting` — so `Cancelling` raises
+  `CannotSignalCancellingFlowException` and writes nothing. It and
+  `CannotSignalTerminalFlowException` share a new parent, `CannotSignalFlowException`; catch that
+  to cover both, and `signalIfRunning()` already does.
+  [Signals](https://sagalaraflow.dev/signals)
+- **A signal to a run that has been pruned raises `FlowNotFoundException`** rather than writing a
+  row that references nothing. `signalIfRunning()` absorbs it and returns `false`, as it does every
+  other refusal. [Signals](https://sagalaraflow.dev/signals)
+
 ## From 1.1.x to 1.2.0
 
 > ### ⚠️ Run `php artisan migrate` immediately after upgrading

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -289,7 +289,8 @@ php artisan saga-flow:signal 01JABCDEF... balance-refilled
 ```
 
 Usually you do not have the run id at hand. Query for it with `whereAwaitingRetrySignal()`, and
-filter with `signalable()` (a parked run is `Waiting`, never `Running`):
+filter with `signalable()` — a parked run is `Waiting`, never `Running`, and delivery is held to
+the same three statuses the filter names:
 
 ```php
 SagaFlow::query()

--- a/docs/docs/signals.md
+++ b/docs/docs/signals.md
@@ -63,16 +63,23 @@ use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 SagaFlow::loadFlow($runId)->signal('approval', ['approved' => true]);
 ```
 
-`signal()` throws `CannotSignalTerminalFlowException` if the run has already finished. Use the safe
-variant to no-op instead:
+A signal is accepted only by a run that can still consume one: `Pending`, `Running` or `Waiting`.
+`signal()` throws `CannotSignalTerminalFlowException` on a finished run and
+`CannotSignalCancellingFlowException` on one that is rolling back; both extend
+`CannotSignalFlowException`, so a single `catch` covers every refusal. Nothing is written on a
+refusal — no signal row, no event, no resume job. A run
+[pruned](./expiration-and-monitoring.md#pruning) out from under the handle raises
+`FlowNotFoundException` rather than writing a row that references nothing. Use the safe variant to
+no-op instead:
 
 ```php
 $delivered = SagaFlow::loadFlow($runId)->signalIfRunning('approval', ['approved' => true]);
-// $delivered === false on a terminal run
+// false on a terminal run, one that is rolling back, and one that has been pruned
 ```
 
-`signalIfRunning()` means *"unless the run has already finished"* — it delivers to **any
-non-terminal run**, not only a `Running` one.
+`signalIfRunning()` means *"unless the run is past taking one"* — it delivers to **any run in
+`Pending`, `Running` or `Waiting`**, not only a `Running` one, and returns `false` for every reason
+`signal()` would raise.
 
 Neither may be called inside a `DB::transaction()` of your own: a rollback afterwards takes the
 delivery with it, the wait stays open, and nothing tells you. See
@@ -92,8 +99,8 @@ SagaFlow::query()
     ?->signal('owner-synced');
 ```
 
-Use `signalable()` (alias `active()`), **not** `running()`. A signal is accepted by any
-non-terminal run — `Pending`, `Running`, or `Waiting` — and a flow parked on `awaitSignal()` sits in
+Use `signalable()` (alias `active()`), **not** `running()`. It names the same three statuses
+delivery accepts — `Pending`, `Running`, or `Waiting` — and a flow parked on `awaitSignal()` sits in
 **`Waiting`**, not `Running`. Filtering by `running()` would silently miss exactly the run you are
 trying to wake.
 

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -33,6 +33,13 @@ refused when it tries to claim the row, a signal-gated retry will not start anot
 already started is a different question and carries on as usual: a step past its own deadline is
 still expired, and the rollback's own compensations still run.
 
+It takes no [signal](./signals.md) either, for the same reason read from the other end: the resume a
+delivery queues cannot drive a rolling-back run, and terminal settlement closes wait-markers, not
+received rows, so the delivery would sit unread forever. Delivery is held to the three statuses
+`signalable()` names, decided on the run as the writing connection holds it. That is a check at
+delivery time, not a lock: a run that enters `Cancelling` immediately afterwards still takes the
+signal, which then stays a floating `Received` row like any other nobody consumed.
+
 ## `ActionStatus` — one step
 
 | Case | Meaning |
@@ -61,7 +68,8 @@ because nothing happened to the step — the run under it ended.
 | `Cancelled` | The run finished while the wait was still open. |
 
 A delivered signal that no `awaitSignal()` ever matched keeps its `Received` status for good — it
-records that a signal arrived and nobody used it.
+records that a signal arrived and nobody used it. Such a row can only come from a run that was
+still open to one: a delivery to a finished or rolling-back run writes nothing at all.
 
 ## What a finished run leaves behind
 

--- a/src/Console/Commands/FlowSignalCommand.php
+++ b/src/Console/Commands/FlowSignalCommand.php
@@ -2,7 +2,7 @@
 
 namespace DiscoveryUkraine\SagaLaraFlow\Console\Commands;
 
-use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
 use DiscoveryUkraine\SagaLaraFlow\FlowManager;
 use Illuminate\Console\Command;
@@ -48,10 +48,14 @@ class FlowSignalCommand extends Command
 
         try {
             $handle->signal($name, $payload);
-        } catch (CannotSignalTerminalFlowException) {
-            $this->warn("Flow run [{$handle->id()}] is terminal; signal [$name] not delivered.");
+        } catch (CannotSignalFlowException $refused) {
+            $this->warn($refused->getMessage());
 
             return self::SUCCESS;
+        } catch (FlowNotFoundException) {
+            $this->error("Flow run [{$handle->id()}] not found.");
+
+            return self::FAILURE;
         }
 
         $this->info("Signal [$name] delivered to flow run [{$handle->id()}].");

--- a/src/Exceptions/CannotSignalCancellingFlowException.php
+++ b/src/Exceptions/CannotSignalCancellingFlowException.php
@@ -4,12 +4,12 @@ namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
 
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
-class CannotSignalTerminalFlowException extends CannotSignalFlowException
+class CannotSignalCancellingFlowException extends CannotSignalFlowException
 {
     public static function for(FlowRun $flowRun): self
     {
         return new self(
-            "Flow run [{$flowRun->id}] is already terminal ([{$flowRun->status->value}]) and cannot be signalled."
+            "Flow run [{$flowRun->id}] is rolling back ([{$flowRun->status->value}]) and cannot be signalled."
         );
     }
 }

--- a/src/Exceptions/CannotSignalFlowException.php
+++ b/src/Exceptions/CannotSignalFlowException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Exceptions;
+
+/**
+ * A signal was refused before delivery. Catch this to handle every refusal there is;
+ * catch a subclass to tell a finished run from one that is rolling back.
+ */
+class CannotSignalFlowException extends FlowException {}

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -6,8 +6,9 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotCancelTerminalFlowException;
-use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\ConcurrentFlowTransitionException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\ChildWorkflowManager;
@@ -110,11 +111,13 @@ readonly class FlowHandle
     }
 
     /**
-     * Deliver an external signal to this run and wake it. Throws on a terminal run.
+     * Deliver an external signal to this run and wake it. Throws unless the run can
+     * still consume one: a finished run and a run rolling back are both refused.
      *
      * @param  array<int|string, mixed>  $payload
      *
-     * @throws CannotSignalTerminalFlowException
+     * @throws CannotSignalFlowException
+     * @throws FlowNotFoundException
      */
     public function signal(string $name, array $payload = []): FlowRun
     {
@@ -126,12 +129,11 @@ readonly class FlowHandle
     }
 
     /**
-     * Safe variant of signal(): swallows the terminal-run rejection and reports
-     * whether the signal was delivered. "IfRunning" means "unless the run has
-     * already finished" — a signal reaches any non-terminal run (Pending, Running,
-     * or Waiting, e.g. one parked on awaitSignal()), not only a Running one. (A
-     * missing run cannot reach here — loadFlow() throws FlowNotFoundException before
-     * a handle is created.)
+     * Safe variant of signal(): swallows the rejection and reports whether the signal
+     * was delivered. "IfRunning" means "unless the run is past taking one" — a signal
+     * reaches any run in Pending, Running or Waiting (e.g. one parked on
+     * awaitSignal()), not only a Running one — and a run pruned out from under the
+     * handle, which is past taking one for good.
      *
      * @param  array<int|string, mixed>  $payload
      */
@@ -141,7 +143,7 @@ readonly class FlowHandle
             $this->signal($name, $payload);
 
             return true;
-        } catch (CannotSignalTerminalFlowException) {
+        } catch (CannotSignalFlowException|FlowNotFoundException) {
             return false;
         }
     }

--- a/src/Runtime/SignalDispatcher.php
+++ b/src/Runtime/SignalDispatcher.php
@@ -3,7 +3,10 @@
 namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
 
 use DiscoveryUkraine\SagaLaraFlow\Contracts\SignalRepository;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalCancellingFlowException;
 use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
@@ -14,7 +17,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\FlowSignal;
  * signal is stored as a floating Received row for a future awaitSignal to consume
  * (FIFO). Delivery runs outside the queue and holds no lock, so filling a signal is
  * a conditional write that falls back to the floating row when it loses.
- * Terminal runs reject signals.
+ * Only a run that can still consume one accepts a signal: FlowStatus::signalable().
  */
 readonly class SignalDispatcher
 {
@@ -27,11 +30,19 @@ readonly class SignalDispatcher
      * @param  array<int|string, mixed>  $payload
      *
      * @throws CannotSignalTerminalFlowException
+     * @throws CannotSignalCancellingFlowException
+     * @throws FlowNotFoundException
      */
     public function deliver(FlowRun $flowRun, string $name, array $payload): FlowSignal
     {
-        if ($flowRun->isTerminal()) {
-            throw CannotSignalTerminalFlowException::for($flowRun);
+        $current = $this->reread($flowRun);
+
+        if ($current->isTerminal()) {
+            throw CannotSignalTerminalFlowException::for($current);
+        }
+
+        if (! in_array($current->status, FlowStatus::signalable(), true)) {
+            throw CannotSignalCancellingFlowException::for($current);
         }
 
         $waitingSignal = $this->repository->earliestWaiting($flowRun->id, $name);
@@ -50,6 +61,17 @@ readonly class SignalDispatcher
         }
 
         return $signal;
+    }
+
+    /**
+     * The run this delivery is decided on. Falling back to the caller's snapshot when
+     * the writer has no row would trust the state this read exists to replace, so a
+     * run that is gone raises instead.
+     */
+    private function reread(FlowRun $flowRun): FlowRun
+    {
+        return $flowRun->newQuery()->useWritePdo()->find($flowRun->getKey())
+            ?? throw FlowNotFoundException::for((string) $flowRun->getKey());
     }
 
     private function wake(FlowRun $flowRun): void

--- a/tests/Feature/SignalDeliveryBoundaryTest.php
+++ b/tests/Feature/SignalDeliveryBoundaryTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalCancellingFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalTerminalFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\FlowNotFoundException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\WriterRoutedFlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A run rolling back can never consume a signal: the resume that a delivery queues
+ * cannot drive Cancelling, and terminal settlement closes only Waiting wait-markers.
+ * Accepting one writes a row nobody reads and tells the caller it landed.
+ */
+beforeEach(function (): void {
+    CompensationLog::reset();
+    WriterRoutedFlowRun::reset();
+});
+
+final class SignalBoundaryWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+/**
+ * A run parked on awaitSignal whose own deadline the sweep then enforces: the rollback
+ * it plans is queued, so the run sits in Cancelling with its compensation still owed.
+ */
+function runRollingBack(): FlowRun
+{
+    $run = SagaFlow::create(SignalBoundaryWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Waiting);
+
+    test()->travel(60)->seconds();
+
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1);
+
+    $rollingBack = FlowRun::query()->findOrFail($run->id);
+
+    expect($rollingBack->status)->toBe(FlowStatus::Cancelling);
+
+    return $rollingBack;
+}
+
+it('refuses a signal delivered to a run that is rolling back', function (): void {
+    useDatabaseQueue();
+
+    $run = runRollingBack();
+
+    $signals = DB::connection('testing')->table('saga_flow_signals')->count();
+    $events = DB::connection('testing')->table('saga_flow_events')->count();
+    $jobs = DB::connection('testing')->table('jobs')->count();
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->signal('go'))
+        ->toThrow(CannotSignalCancellingFlowException::class);
+
+    expect(DB::connection('testing')->table('saga_flow_signals')->count())->toBe($signals)
+        ->and(DB::connection('testing')->table('saga_flow_events')->count())->toBe($events)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs);
+});
+
+it('reports the refusal through signalIfRunning', function (): void {
+    useDatabaseQueue();
+
+    $run = runRollingBack();
+
+    expect(SagaFlow::loadFlow($run->id)->signalIfRunning('go'))->toBeFalse();
+});
+
+it('decides on the status the writer holds, not the one the handle carries', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(SignalBoundaryWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    // handles() takes a page of snapshots in one pass, so by the time a bulk loop
+    // reaches one its run has moved on. This handle still reads Waiting.
+    $handle = SagaFlow::query()->signalable()->handles()->firstOrFail();
+
+    expect($handle->status())->toBe(FlowStatus::Waiting);
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling)
+        ->and($handle->status())->toBe(FlowStatus::Waiting);
+
+    // An attribute the caller has not saved: refusing must not refresh() the model the
+    // handle keeps handing back, which would discard it.
+    $handle->run()->queue = 'unsaved-by-the-caller';
+
+    expect(fn () => $handle->signal('go'))->toThrow(CannotSignalCancellingFlowException::class);
+
+    expect($handle->status())->toBe(FlowStatus::Waiting)
+        ->and($handle->run()->queue)->toBe('unsaved-by-the-caller');
+});
+
+it('reads the status it decides on from the write connection', function (): void {
+    config()->set('saga-lara-flow.models.flow_run', WriterRoutedFlowRun::class);
+
+    useDatabaseQueue();
+
+    $run = runRollingBack();
+
+    // Every writer-bound read the scene itself made is behind us; what follows counts
+    // only the delivery's own.
+    WriterRoutedFlowRun::reset();
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->signal('go'))
+        ->toThrow(CannotSignalCancellingFlowException::class);
+
+    expect(WriterRoutedFlowRun::$writerReads)->toBe(1);
+});
+
+it('refuses to signal a run the writer no longer holds', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(SignalBoundaryWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    $handle = SagaFlow::loadFlow($run->id);
+
+    // A prune between loading the handle and using it. Nothing references the run any
+    // more, so a delivery would write a signal row pointing at a run that is not there.
+    FlowRun::query()->whereKey($run->id)->delete();
+
+    $signals = DB::connection('testing')->table('saga_flow_signals')->count();
+
+    expect(fn () => $handle->signal('go'))->toThrow(FlowNotFoundException::class)
+        ->and(DB::connection('testing')->table('saga_flow_signals')->count())->toBe($signals);
+
+    // The safe variant absorbs it like every other reason a run cannot take a signal.
+    expect($handle->signalIfRunning('go'))->toBeFalse()
+        ->and(DB::connection('testing')->table('saga_flow_signals')->count())->toBe($signals);
+});
+
+it('keeps both refusals under one parent so an existing catch still holds', function (): void {
+    useDatabaseQueue();
+
+    $run = runRollingBack();
+
+    expect(fn () => SagaFlow::loadFlow($run->id)->signal('go'))
+        ->toThrow(CannotSignalFlowException::class);
+
+    $completed = SagaFlow::create(SignalBoundaryWorkflow::class)->run();
+
+    drainQueue();
+    SagaFlow::loadFlow($completed->id)->signal('go');
+    drainQueue();
+
+    expect(SagaFlow::findRun($completed->id)->status)->toBe(FlowStatus::Completed);
+
+    expect(fn () => SagaFlow::loadFlow($completed->id)->signal('go'))
+        ->toThrow(CannotSignalTerminalFlowException::class)
+        ->and(fn () => SagaFlow::loadFlow($completed->id)->signal('go'))
+        ->toThrow(CannotSignalFlowException::class);
+});

--- a/tests/Fixtures/WriterRoutedBuilder.php
+++ b/tests/Fixtures/WriterRoutedBuilder.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Eloquent forwards useWritePdo() to the query builder rather than declaring it, so
+ * counting it means declaring it here and delegating by hand.
+ *
+ * @template TModel of \Illuminate\Database\Eloquent\Model
+ *
+ * @extends Builder<TModel>
+ */
+final class WriterRoutedBuilder extends Builder
+{
+    public function useWritePdo(): static
+    {
+        WriterRoutedFlowRun::$writerReads++;
+
+        $this->getQuery()->useWritePdo();
+
+        return $this;
+    }
+}

--- a/tests/Fixtures/WriterRoutedFlowRun.php
+++ b/tests/Fixtures/WriterRoutedFlowRun.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use Illuminate\Database\Eloquent\Builder;
+
+/**
+ * Counts the reads against it that asked for the write connection. The suite runs a
+ * single PDO, so nothing else can tell a writer-bound read from an ordinary one —
+ * without this, dropping useWritePdo() would leave every assertion green. Swapped in
+ * through config('saga-lara-flow.models.flow_run').
+ */
+final class WriterRoutedFlowRun extends FlowRun
+{
+    public static int $writerReads = 0;
+
+    public static function reset(): void
+    {
+        self::$writerReads = 0;
+    }
+
+    /**
+     * @param  \Illuminate\Database\Query\Builder  $query
+     * @return Builder<self>
+     */
+    public function newEloquentBuilder($query): Builder
+    {
+        return new WriterRoutedBuilder($query);
+    }
+}

--- a/tests/Unit/CannotSignalCancellingFlowExceptionTest.php
+++ b/tests/Unit/CannotSignalCancellingFlowExceptionTest.php
@@ -1,0 +1,18 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\CannotSignalCancellingFlowException;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+it('builds a clear message naming the run and the rollback it is in', function () {
+    $run = new FlowRun;
+    $run->id = '01J000000000000000000RUNID';
+    $run->status = FlowStatus::Cancelling;
+
+    $exception = CannotSignalCancellingFlowException::for($run);
+
+    expect($exception->getMessage())
+        ->toContain('01J000000000000000000RUNID')
+        ->toContain('cancelling')
+        ->toContain('cannot be signalled');
+});


### PR DESCRIPTION
`SignalDispatcher::deliver()` is held to `FlowStatus::signalable()` — `Pending`, `Running`,
`Waiting` — rather than to `isTerminal()` alone. A run in `Cancelling` refuses the delivery and
writes nothing: no signal row, no event, no resume job.

The status is read from the write connection immediately before the decision. The caller's model is
a snapshot, and a replica would answer with the very state the check is there to catch. A run the
writer no longer holds — pruned out from under the handle — raises `FlowNotFoundException` instead
of writing a row that references nothing.

## Exceptions

`CannotSignalFlowException` is a new common parent. `CannotSignalTerminalFlowException` becomes one
of its children and `CannotSignalCancellingFlowException` the other, so an existing `catch` on the
terminal one keeps working and a single `catch` on the parent covers every refusal.

`FlowHandle::signalIfRunning()` returns `false` for every reason `signal()` raises, a pruned run
included. `saga-flow:signal` reports a refusal as a warning and a missing run as a failure.

## Boundary

Delivery is a check at delivery time, not a lock. A run that enters `Cancelling` in the moment after
the read still takes the signal, which then stays a floating `Received` row like any other nobody
consumed. Recorded under the status boundaries in `CONTRIBUTING.md`.

## Tests

`tests/Feature/SignalDeliveryBoundaryTest.php` reaches `Cancelling` naturally — a run parked on
`awaitSignal()` whose own deadline the sweep enforces, leaving its rollback queued. Every case fails
without the change, each against the part of it that it covers:

| Removed | Red |
|---|---|
| the `signalable()` branch | all cases |
| deciding on the writer's row rather than the caller's | the stale-handle case |
| `useWritePdo()` on that read | the write-connection case |
| raising on a row the writer cannot find | the pruned-run case |

The suite runs a single PDO, so `WriterRoutedFlowRun` — swapped in through
`saga-lara-flow.models.flow_run` — counts the reads that asked for the write connection; without it
dropping `useWritePdo()` leaves every assertion green. The stale-handle case also asserts that an
attribute the caller has not saved survives the refusal, so the read cannot become a `refresh()`.

Full suite green on SQLite and MySQL; `composer lint` clean; `cd docs && npm run build` passes.

Closes #63
