### PR TITLE
Refuse to drive a run that has already left the startable set

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,6 +603,10 @@ it off the worker (`repair.queue_looping.enabled`), or kick a single run manuall
 `saga-flow:kick {run}` / `SagaFlow::kick($id)`. Each config key is documented in
 [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring).
 
+None of these drives a run that is rolling back or finished — a pass begins only for a run that may
+still start work, so a deadline is enforced once and each compensation on the rollback it planned
+runs once. See [Statuses](https://sagalaraflow.dev/statuses).
+
 ## Queues, locks & idempotency
 
 Every workflow and action runs as a queued job on the configured connection/queue. A run is driven

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,10 +17,10 @@ Nothing below asks anything of you. Each links to the page that covers it.
   other refusal. [Signals](https://sagalaraflow.dev/signals)
 - **A run that is rolling back is no longer driven.** A pass begins only for a run in one of the
   three statuses `mayStartWork()` names, decided on the writing connection, and the deadline is
-  weighed after that — so a resume queued before the sweep expired the run no longer plans a second
-  rollback and runs every compensation twice. `drive()` returns such a run as the writer holds it
-  instead of raising `InvalidTransitionException`, and `saga-flow:kick` reports it rather than
-  claiming a re-drive. [Statuses](https://sagalaraflow.dev/statuses)
+  weighed after that. A resume queued before the sweep expired the run is turned away rather than
+  planning a second rollback, so each compensation runs once. `drive()` returns such a run as the
+  writer holds it instead of raising `InvalidTransitionException`, and `saga-flow:kick` reports it
+  rather than claiming a re-drive. [Statuses](https://sagalaraflow.dev/statuses)
 
 ## From 1.1.x to 1.2.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,12 @@ Nothing below asks anything of you. Each links to the page that covers it.
 - **A signal to a run that has been pruned raises `FlowNotFoundException`** rather than writing a
   row that references nothing. `signalIfRunning()` absorbs it and returns `false`, as it does every
   other refusal. [Signals](https://sagalaraflow.dev/signals)
+- **A run that is rolling back is no longer driven.** A pass begins only for a run in one of the
+  three statuses `mayStartWork()` names, decided on the writing connection, and the deadline is
+  weighed after that — so a resume queued before the sweep expired the run no longer plans a second
+  rollback and runs every compensation twice. `drive()` returns such a run as the writer holds it
+  instead of raising `InvalidTransitionException`, and `saga-flow:kick` reports it rather than
+  claiming a re-drive. [Statuses](https://sagalaraflow.dev/statuses)
 
 ## From 1.1.x to 1.2.0
 

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -75,6 +75,10 @@ A sweep only ever looks at work belonging to a run that is still going. A run th
 and waits as it ends (see [statuses](./statuses.md)), and the scan skips whatever was left unsettled before that, so a
 batch is always filled with candidates a sweep can actually act on.
 
+A deadline is also enforced only once. The sweep moves a run it expires into `Cancelling`, and no pass is driven for a
+run there, so a job queued before the sweep — a resume owed to a wait it then expired — ends without re-entering
+expiration. The rollback the sweep planned is the only one, and each compensation on it runs once.
+
 ## A run the sweep cannot expire
 
 Expiring a run means replaying it to find what to undo, and that replay can throw — a workflow reading something that
@@ -164,6 +168,9 @@ To re-drive a single stuck run by hand:
 SagaFlow::kick($runId);          // or:
 // php artisan saga-flow:kick {run}
 ```
+
+A kick re-drives a run that may still start work. A run that has finished, or is rolling back, is left exactly as it
+was; the command reports its status instead of claiming a re-drive.
 
 ## Pruning
 

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -33,6 +33,15 @@ refused when it tries to claim the row, a signal-gated retry will not start anot
 already started is a different question and carries on as usual: a step past its own deadline is
 still expired, and the rollback's own compensations still run.
 
+Neither is the run itself driven. A pass begins only for a run in one of the three statuses
+`mayStartWork()` names, decided on the run as the writing connection holds it, and its deadline is
+weighed after that. A job that arrives for a run outside them — a redelivery, a resume queued while
+the run was still `Waiting`, a manual
+[`saga-flow:kick`](./expiration-and-monitoring.md#repair-the-doctor) — ends without entering the
+pass, and the executor hands its caller the run as the writer holds it rather than throwing. So a
+run is expired once: the rollback the sweep planned is the only one, and each compensation on it
+runs once.
+
 It takes no [signal](./signals.md) either, for the same reason read from the other end: the resume a
 delivery queues cannot drive a rolling-back run, and terminal settlement closes wait-markers, not
 received rows, so the delivery would sit unread forever. Delivery is held to the three statuses

--- a/src/Console/Commands/FlowKickCommand.php
+++ b/src/Console/Commands/FlowKickCommand.php
@@ -29,8 +29,8 @@ class FlowKickCommand extends Command
             return self::FAILURE;
         }
 
-        if ($run->isTerminal()) {
-            $this->warn("Flow run [{$id}] is terminal ({$run->status->value}); nothing to re-drive.");
+        if (! $run->status->canStartWork()) {
+            $this->warn("Flow run [{$id}] is {$run->status->value}; nothing to re-drive.");
 
             return self::SUCCESS;
         }

--- a/src/Console/Commands/FlowKickCommand.php
+++ b/src/Console/Commands/FlowKickCommand.php
@@ -29,13 +29,13 @@ class FlowKickCommand extends Command
             return self::FAILURE;
         }
 
+        $run = $doctor->kick($run);
+
         if (! $run->status->canStartWork()) {
             $this->warn("Flow run [{$id}] is {$run->status->value}; nothing to re-drive.");
 
             return self::SUCCESS;
         }
-
-        $doctor->kick($run);
 
         $this->info("Flow run [{$id}] re-driven.");
 

--- a/src/Jobs/ResumeWorkflowJob.php
+++ b/src/Jobs/ResumeWorkflowJob.php
@@ -30,7 +30,7 @@ class ResumeWorkflowJob implements ShouldQueue
     {
         $flowRun = $repository->find($this->flowRunId);
 
-        if ($flowRun === null || $flowRun->isTerminal()) {
+        if ($flowRun === null || ! $flowRun->status->canStartWork()) {
             return;
         }
 

--- a/src/Jobs/RunWorkflowJob.php
+++ b/src/Jobs/RunWorkflowJob.php
@@ -29,7 +29,7 @@ class RunWorkflowJob implements ShouldQueue
     {
         $flowRun = $repository->find($this->flowRunId);
 
-        if ($flowRun === null || $flowRun->isTerminal()) {
+        if ($flowRun === null || ! $flowRun->status->canStartWork()) {
             return;
         }
 

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -235,11 +235,11 @@ final readonly class FlowDoctor
      * the automatic pass, this is unthrottled and ignores positive-evidence — a human
      * decided the run is stuck. Works for Pending/Waiting/Running (a same-state
      * Running transition is an idempotent no-op and the run lock serializes against
-     * any live job); a terminal run is left untouched.
+     * any live job); a run that may not start work is left untouched.
      */
     public function kick(FlowRun $run): FlowRun
     {
-        if ($run->isTerminal()) {
+        if (! $run->status->canStartWork()) {
             return $run;
         }
 

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -236,18 +236,29 @@ final readonly class FlowDoctor
      * decided the run is stuck. Works for Pending/Waiting/Running (a same-state
      * Running transition is an idempotent no-op and the run lock serializes against
      * any live job); a run that may not start work is left untouched.
+     *
+     * Decided on the writer, and the run it decided on is what comes back: a lagging
+     * replica would answer with the status this read exists to replace, and an operator
+     * would be told a run was re-driven while it was rolling back.
      */
     public function kick(FlowRun $run): FlowRun
     {
-        if (! $run->status->canStartWork()) {
-            return $run;
+        $current = $this->rereadFlow($run);
+
+        if (! $current->status->canStartWork()) {
+            return $current;
         }
 
-        $this->lifecycle->flowRewoken($run, 'manual');
+        $this->lifecycle->flowRewoken($current, 'manual');
 
-        $this->dispatchResume($run);
+        $this->dispatchResume($current);
 
-        return $run;
+        return $current;
+    }
+
+    private function rereadFlow(FlowRun $run): FlowRun
+    {
+        return $run->newQuery()->useWritePdo()->find($run->getKey()) ?? $run;
     }
 
     /**

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -96,10 +96,22 @@ class FlowExecutor
     }
 
     /**
+     * The deadline is weighed after this check, never before: a run already rolling back
+     * would otherwise be expired a second time, and a second plan runs every
+     * compensation on it twice. Only the check reads from the writer; the pass goes on
+     * with the caller's snapshot, which is the value every transition below is fenced
+     * on, and a second driver holding a stale one must not match it.
+     *
      * @throws Throwable
      */
     private function driveInner(FlowRun $flowRun, RunMode $mode): FlowRun
     {
+        $current = $this->reread($flowRun);
+
+        if (! $current->status->canStartWork()) {
+            return $current;
+        }
+
         if ($this->isExpired($flowRun)) {
             return $this->expireRun($flowRun);
         }
@@ -110,21 +122,22 @@ class FlowExecutor
 
         $resuming ? $this->recorder->flowResumed($flowRun) : $this->recorder->flowStarted($flowRun);
 
+        return $this->replay($flowRun, $mode);
+    }
+
+    /**
+     * Replay handle() until the pass ends, interpreting what it throws.
+     *
+     * @throws Throwable
+     */
+    private function replay(FlowRun $flowRun, RunMode $mode): FlowRun
+    {
         while (true) {
             $this->runtime->bind($flowRun, $mode);
             $this->runtime->reset();
 
             try {
-                try {
-                    $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
-
-                    /** @var array<int, mixed> $arguments */
-                    $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
-
-                    $result = $this->callWithDependencies($workflow, 'handle', $arguments);
-                } finally {
-                    $this->runtime->clear();
-                }
+                $result = $this->callHandle($flowRun);
             } catch (FlowSuspended $suspended) {
                 if ($suspended->inlineResolved) {
                     continue; // Sync: the step ran inline; replay from the top.
@@ -142,6 +155,26 @@ class FlowExecutor
             }
 
             return $this->completeFlow($flowRun, $result);
+        }
+    }
+
+    /**
+     * Run the workflow's handle(). The runtime is unbound however the call leaves, so
+     * the throw an ending is read from is already outside the pass when it is caught.
+     *
+     * @throws Throwable
+     */
+    private function callHandle(FlowRun $flowRun): mixed
+    {
+        try {
+            $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
+
+            /** @var array<int, mixed> $arguments */
+            $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
+
+            return $this->callWithDependencies($workflow, 'handle', $arguments);
+        } finally {
+            $this->runtime->clear();
         }
     }
 
@@ -306,9 +339,9 @@ class FlowExecutor
     }
 
     /**
-     * Read the run as the winner of a refused transition left it. From the writer: the
-     * whole point of this read is the state that was just committed, and it is what a
-     * caller — a parent resolving this run as a child among them — decides on.
+     * Read the run as the writer holds it. Every caller of this decides something on the
+     * answer — whether a pass may begin, or how a parent resolves this run as a child —
+     * and a lagging replica would answer with the state the read exists to replace.
      */
     private function reread(FlowRun $flowRun): FlowRun
     {

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -159,8 +159,8 @@ class FlowExecutor
     }
 
     /**
-     * Run the workflow's handle(). The runtime is unbound however the call leaves, so
-     * the throw an ending is read from is already outside the pass when it is caught.
+     * Run the workflow's handle(). The runtime is unbound however the call leaves, so it
+     * is already unbound by the time the caller reads the throw that ended the pass.
      *
      * @throws Throwable
      */
@@ -341,7 +341,9 @@ class FlowExecutor
     /**
      * Read the run as the writer holds it. Every caller of this decides something on the
      * answer — whether a pass may begin, or how a parent resolves this run as a child —
-     * and a lagging replica would answer with the state the read exists to replace.
+     * and a lagging replica would answer with the state the read exists to replace. A
+     * pruned row has no answer to give, so the caller's snapshot stands in; nothing acts
+     * on it that a fenced write would not refuse anyway.
      */
     private function reread(FlowRun $flowRun): FlowRun
     {

--- a/tests/Feature/CollectCompensationsReadOnlyTest.php
+++ b/tests/Feature/CollectCompensationsReadOnlyTest.php
@@ -4,7 +4,6 @@ use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
 use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
-use DiscoveryUkraine\SagaLaraFlow\Exceptions\InvalidTransitionException;
 use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
 use DiscoveryUkraine\SagaLaraFlow\Jobs\CancelChildWorkflowJob;
 use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
@@ -199,12 +198,14 @@ it('fences a child before planning the rollback it will act on', function () {
     app(StateMachine::class)->transition($child, FlowStatus::Cancelling);
 
     // This is what makes a plan made after the transition final, and a plan made
-    // before it a guess: nothing can drive a Cancelling run, so no further step can
+    // before it a guess: nothing drives a Cancelling run, so no further step can
     // complete under one. The close plans on this side of the fence for that reason
     // — the transition's own guard reads status alone, so a child resumed and
     // re-parked while an earlier plan was being made would still match it.
-    expect(fn () => app(FlowExecutor::class)->drive(SagaFlow::findRun($child->id), RunMode::Queued))
-        ->toThrow(InvalidTransitionException::class);
+    $driven = app(FlowExecutor::class)->drive(SagaFlow::findRun($child->id), RunMode::Queued);
+
+    expect($driven->status)->toBe(FlowStatus::Cancelling)
+        ->and(SagaFlow::findRun($child->id)->status)->toBe(FlowStatus::Cancelling);
 });
 
 it('retries a child close that failed after it had taken control', function () {

--- a/tests/Feature/StaleResumeRollbackTest.php
+++ b/tests/Feature/StaleResumeRollbackTest.php
@@ -96,6 +96,8 @@ it('decides on the status the writer holds, not the one the caller carries', fun
 });
 
 it('leaves a rolling-back run where a kick found it', function (): void {
+    config()->set('saga-lara-flow.models.flow_run', WriterRoutedFlowRun::class);
+
     useDatabaseQueue();
 
     $run = SagaFlow::create(StaleResumeWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
@@ -105,14 +107,21 @@ it('leaves a rolling-back run where a kick found it', function (): void {
     $this->travel(60)->seconds();
     app(FlowMonitor::class)->sweep();
 
-    $rollingBack = FlowRun::query()->findOrFail($run->id);
+    $rollingBack = WriterRoutedFlowRun::query()->findOrFail($run->id);
 
     expect($rollingBack->status)->toBe(FlowStatus::Cancelling);
 
     $events = DB::connection('testing')->table('saga_flow_events')->count();
     $jobs = DB::connection('testing')->table('jobs')->count();
 
+    // A kick decides on the writer, so a caller holding a snapshot from before the sweep
+    // is not what tells it the run is still worth re-driving.
+    $rollingBack->status = FlowStatus::Waiting;
+
+    WriterRoutedFlowRun::reset();
+
     expect(app(FlowDoctor::class)->kick($rollingBack)->status)->toBe(FlowStatus::Cancelling)
+        ->and(WriterRoutedFlowRun::$writerReads)->toBe(1)
         ->and(DB::connection('testing')->table('saga_flow_events')->count())->toBe($events)
         ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs);
 

--- a/tests/Feature/StaleResumeRollbackTest.php
+++ b/tests/Feature/StaleResumeRollbackTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\ResumeWorkflowJob;
+use DiscoveryUkraine\SagaLaraFlow\Jobs\RunWorkflowJob;
+use DiscoveryUkraine\SagaLaraFlow\Models\CompensationRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\WriterRoutedFlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A rollback plans the stack it will undo once, so a run must be driven once. A job
+ * queued while the run could still start work — a resume owed to a wait the sweep then
+ * expired — arrives to find it rolling back, and a pass entered there plans a second
+ * rollback and runs every compensation on it twice.
+ *
+ * The three statuses mayStartWork() names are therefore what a pass begins on, weighed
+ * before the deadline and read from the writer.
+ */
+beforeEach(function (): void {
+    CompensationLog::reset();
+    WriterRoutedFlowRun::reset();
+});
+
+final class StaleResumeWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+it('runs a compensation once when a resume queued before the sweep arrives after it', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(StaleResumeWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Waiting);
+
+    // The run is still Waiting, so the delivery is legitimate and queues a resume. The
+    // deadline passes while that job waits its turn behind the sweep.
+    $this->travel(60)->seconds();
+
+    SagaFlow::loadFlow($run->id)->signal('go');
+
+    expect(app(FlowMonitor::class)->sweep()['runs'])->toBe(1);
+
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling);
+
+    drainQueue();
+
+    expect(CompensationLog::all())->toBe(['undo:a'])
+        ->and(CompensationRun::query()->count())->toBe(1)
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('decides on the status the writer holds, not the one the caller carries', function (): void {
+    config()->set('saga-lara-flow.models.flow_run', WriterRoutedFlowRun::class);
+
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(StaleResumeWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    // Read while the run may still start work; the sweep moves it underneath.
+    $stale = WriterRoutedFlowRun::query()->findOrFail($run->id);
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+
+    expect($stale->status)->toBe(FlowStatus::Waiting);
+
+    WriterRoutedFlowRun::reset();
+
+    $driven = app(FlowExecutor::class)->drive($stale, RunMode::Queued);
+
+    // The caller is handed the run the writer holds rather than having the instance it
+    // still owns refreshed underneath it, and nothing was planned a second time.
+    expect($driven->status)->toBe(FlowStatus::Cancelling)
+        ->and($stale->status)->toBe(FlowStatus::Waiting)
+        ->and(WriterRoutedFlowRun::$writerReads)->toBe(1)
+        ->and(CompensationRun::query()->count())->toBe(1);
+});
+
+it('leaves a rolling-back run where a kick found it', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(StaleResumeWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+
+    $rollingBack = FlowRun::query()->findOrFail($run->id);
+
+    expect($rollingBack->status)->toBe(FlowStatus::Cancelling);
+
+    $events = DB::connection('testing')->table('saga_flow_events')->count();
+    $jobs = DB::connection('testing')->table('jobs')->count();
+
+    expect(app(FlowDoctor::class)->kick($rollingBack)->status)->toBe(FlowStatus::Cancelling)
+        ->and(DB::connection('testing')->table('saga_flow_events')->count())->toBe($events)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs);
+
+    $this->artisan('saga-flow:kick', ['run' => $run->id])
+        ->expectsOutputToContain("Flow run [{$run->id}] is cancelling; nothing to re-drive.")
+        ->assertSuccessful();
+});
+
+it('turns a stale job away before the pass is set up', function (string $job): void {
+    config()->set('saga-lara-flow.models.flow_run', WriterRoutedFlowRun::class);
+
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(StaleResumeWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    drainQueue();
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+
+    $jobs = DB::connection('testing')->table('jobs')->count();
+
+    WriterRoutedFlowRun::reset();
+
+    app()->call([new $job($run->id), 'handle']);
+
+    // The job answers from its own read: no pass is entered, so the executor never
+    // reaches the writer, and nothing new is queued.
+    expect(WriterRoutedFlowRun::$writerReads)->toBe(0)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe($jobs);
+})->with([ResumeWorkflowJob::class, RunWorkflowJob::class]);


### PR DESCRIPTION
A run is driven only while it may still start work.

`FlowExecutor::driveInner()` reads the run from the write connection and returns it unchanged when
its status is outside `FlowStatus::mayStartWork()`. The deadline is weighed after that check, so a
run already rolling back is never expired a second time — a `ResumeWorkflowJob` queued while the run
was still `Waiting` and delivered after the sweep expired it no longer plans a second rollback and
runs every compensation on it twice.

`RunWorkflowJob`, `ResumeWorkflowJob` and `FlowDoctor::kick()` now hold the same predicate, turning
such a job away before the pass is set up. `kick()` decides on the writer too and returns the run it
decided on, so `saga-flow:kick` reports that status rather than claiming a re-drive.

`drive()` returns a run it will not drive as the writer holds it, rather than raising
`InvalidTransitionException` from the refused `Cancelling → Running` transition. The caller's own
instance is left as it was.

Only the check reads from the writer. The pass goes on with the caller's snapshot, which is the
value every transition below is fenced on, so two drivers holding stale snapshots still cannot both
win.

`driveInner()` keeps the decisions and hands the replay loop to `replay()`, which calls the
workflow through `callHandle()`. No behaviour changes with it; the cognitive complexity of
`driveInner()` drops from 15 to 3.

### Tests

`tests/Feature/StaleResumeRollbackTest.php` stages the defect naturally — database queue, no
hand-written statuses: a signal delivered while the run is `Waiting` queues the resume, the sweep
then expires the run, and the queue drains. On `main` it records `["undo:a", "undo:a"]` and two
`compensation_runs` rows.

Every part of the fix was mutated separately and each is caught: removing the refusal in
`driveInner()` reddens three cases; dropping `useWritePdo()` from `reread()` reddens the
writer-routed read count; returning either job guard, the doctor's or the command's to
`isTerminal()` reddens one each. The suite runs a single PDO, so the writer-routed reads are counted
through the `WriterRoutedFlowRun` fixture.

`CollectCompensationsReadOnlyTest`'s "fences a child before planning the rollback it will act on"
asserts the same boundary in its new shape: driving a `Cancelling` child leaves it exactly there.

Green on SQLite, MySQL and PostgreSQL.

Closes #64
