### PR TITLE
Refuse to start a child or a side effect under a rolling-back run

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,9 @@ not `FlowHandle`, not the monitor's inline sweep. Changes to `src/Runtime`, `src
   events the engine fires inside its own transactions run there.
 - **A transaction that runs caller code must verify its own outcome.** The commit reporting success
   is the caller's word for it, and the paragraph above is why that word is worth nothing. Read the
-  row back afterwards and act on what it says — see `ActionRecorder::claimSurvivedCommit()`. Moving
+  row back afterwards and act on what it says — see `ActionRecorder::claimSurvivedCommit()` and
+  `ChildWorkflowManager::requireStartSurvivedCommit()`, which is why a child is announced and
+  dispatched only after its link is read back. Moving
   the event out of the transaction is not the same fix: a model observer on a row the transaction
   writes runs there whatever the event does, which is what `TransactionIntegrityTest`'s observer
   case pins. What such a read proves is visibility on the writing connection, which equals
@@ -118,6 +120,15 @@ floating `Received` row like any other nobody consumed — the documented outcom
 and do not widen the change to chase it. A real fence means conditional writes inside
 `SignalRecorder`, which the retry seam shares, bought for a window whose worst outcome is already
 documented behaviour.
+
+**So is a seam that starts work.** `StartWorkGuard` reads the run's status from the writer before a
+child workflow or a side effect begins, because a pass that outlived a rollback holds an instance
+from before it. Same shape, same limit: the child's two writes are only fenced against a status read
+a moment earlier inside their own transaction, and a side-effect factory has no durable write to
+fence at all — its row is written after the call returns. A run entering `Cancelling` between the
+read and the work still starts that one. Intended, **not an open defect**. A real fence for the
+factory means a start-marker row before every side effect on the hot replay path, which is a design
+decision of its own rather than this one's price.
 
 The one that decides a write is `mayStartWork()` versus `live()`: ask the narrower one wherever work
 would **begin** (the action claim, the repair rules that send another job, the retry that spends a

--- a/README.md
+++ b/README.md
@@ -458,6 +458,10 @@ public function handle(): void
 ```
 
 The first execution records the value; every later replay of the run returns the same stored value.
+A factory is not called once the run is rolling back: the seam reads the run's status from the
+connection that wrote it and ends the pass first, so host code does not run outside a plan that is
+already being unwound. The same holds for a child workflow started at a new ordinal. See
+[Statuses](https://sagalaraflow.dev/statuses).
 
 ## Parallel actions
 
@@ -605,7 +609,9 @@ it off the worker (`repair.queue_looping.enabled`), or kick a single run manuall
 
 None of these drives a run that is rolling back or finished — a pass begins only for a run that may
 still start work, so a deadline is enforced once and each compensation on the rollback it planned
-runs once. See [Statuses](https://sagalaraflow.dev/statuses).
+runs once. A pass already replaying when the rollback commits starts nothing further either: its
+next step is refused at the claim, and a child workflow or side effect at an ordinal it has not
+reached before ends the pass instead. See [Statuses](https://sagalaraflow.dev/statuses).
 
 ## Queues, locks & idempotency
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,13 @@ Nothing below asks anything of you. Each links to the page that covers it.
   writer holds it instead of raising `InvalidTransitionException`, and `saga-flow:kick` reports it
   rather than claiming a re-drive. [Statuses](https://sagalaraflow.dev/statuses)
 
+- **A replay that outlived a rollback starts no child and calls no side-effect factory.** Both seams
+  read the run's status from the writing connection before they begin, and end the pass when it is
+  no longer one of the three statuses `mayStartWork()` names. A child's run and its link are written
+  in one transaction; the `ChildWorkflowStarted` event and the child's job both follow that commit,
+  so a listener now runs outside that transaction rather than inside it.
+  [Child workflows](https://sagalaraflow.dev/child-workflows)
+
 ## From 1.1.x to 1.2.0
 
 > ### ⚠️ Run `php artisan migrate` immediately after upgrading

--- a/docs/docs/child-workflows.md
+++ b/docs/docs/child-workflows.md
@@ -64,3 +64,13 @@ A parent that carries on this way keeps collecting compensations, and a later ro
 child that has already finished is history the plan reads, not a frontier it stops at. A child still
 in flight is a frontier, so a rollback planned while one runs covers only the steps before it — the
 child rolls itself back through its own [close policy](#close-policies) instead.
+
+## A parent that is rolling back
+
+No child starts under a parent that is rolling back. The seam reads the parent's status from the
+connection that wrote it and ends the pass instead: a rollback plans the stack it will undo once, so
+a child started afterwards would run to completion outside that plan, and under the default
+`Abandon` policy nothing closes it. The child's run and its link are written together, so an ordinal
+that does not finish leaves behind no run without an owner. The `ChildWorkflowStarted` event and the
+child's own job both follow that commit and only once it is read back, so a listener never sees a
+child the write did not keep.

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -83,6 +83,19 @@ before the live worker recorded its success — see
 To have such a compensation retried rather than only reported, enable `sagas.reclaim.stale_running`
 — see [Reclaim & recovery](./reclaim-and-recovery.md).
 
+## While a rollback runs
+
+A run rolling back is in `Cancelling`, which is not terminal — and nothing new begins under it. The
+plan was drawn once, so anything started afterwards would finish outside it: its compensation in no
+stack, never run, under a run reporting a complete unwind. That covers a step whose job arrives to
+claim its row, a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md) a
+pass still replaying reaches for the first time, and a replacement the
+[doctor](./expiration-and-monitoring.md#repair-the-doctor) would otherwise send.
+
+Settling what already started is the other question, and it carries on: a step past its own deadline
+is still expired, and the rollback's own compensations still run. See
+[Statuses](./statuses.md) for the boundary in full.
+
 ## Manual compensation
 
 You can trigger a rollback from outside the workflow through the handle:

--- a/docs/docs/side-effects.md
+++ b/docs/docs/side-effects.md
@@ -40,3 +40,9 @@ across replays.
 By default a side-effect reuse only dispatches the `SideEffectReused` event (no extra `flow_events`
 row), keeping the event log bounded. Enable `history.record_side_effect_reuse` if you need a full
 audit trail of every reuse. See also [Determinism rules](./determinism-rules.md).
+
+A factory is not called once the run is rolling back. It is your code — an HTTP call, a charge, an
+id handed out — and the recorded row is the only durable trace of it, so there is nothing to hold it
+back after the fact; the seam reads the run's status from the connection that wrote it and ends the
+pass first. That is a check taken immediately before the call, not a lock: a rollback committing in
+the moment between the two does not reach back into a factory already running.

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -33,6 +33,14 @@ refused when it tries to claim the row, a signal-gated retry will not start anot
 already started is a different question and carries on as usual: a step past its own deadline is
 still expired, and the rollback's own compensations still run.
 
+A step is not the only thing that begins, and the rest is reached from inside a pass rather than by
+a job of its own: a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md)
+both start work at an ordinal the run has not reached before. A pass still replaying when the
+rollback committed carries the run as it was before it, so both seams read the status from the
+writing connection and end the pass instead of starting anything. That is a check taken immediately
+before the work, not a lock — a run that enters `Cancelling` in the moment between them still starts
+that one.
+
 Neither is the run itself driven. A pass begins only for a run in one of the three statuses
 `mayStartWork()` names, decided on the run as the writing connection holds it, and its deadline is
 weighed after that. A job that arrives for a run outside them — a redelivery, a resume queued while

--- a/src/Exceptions/Internal/FlowSuspended.php
+++ b/src/Exceptions/Internal/FlowSuspended.php
@@ -10,7 +10,7 @@ namespace DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal;
 final class FlowSuspended extends InternalFlowControl
 {
     /**
-     * @param  string  $reason  What suspended the flow: 'action' | 'signal' | 'child' | 'parallel'.
+     * @param  string  $reason  What suspended the flow: 'action' | 'signal' | 'child' | 'parallel' | 'side_effect'.
      * @param  int  $sequence  The (flow_run_id, sequence) ordinal of the suspending step.
      * @param  array<string, mixed>  $context  Optional diagnostic context.
      * @param  bool  $inlineResolved  Sync mode: the step was executed inline and the loop should replay.

--- a/src/Runtime/ChildRecorder.php
+++ b/src/Runtime/ChildRecorder.php
@@ -25,7 +25,9 @@ final readonly class ChildRecorder
     ) {}
 
     /**
-     * Record the link for a newly started child and append the child.started event.
+     * Record the link for a newly started child and append the child.started event. The
+     * host hears about it from childStarted() below rather than here, so its listeners
+     * run outside the transaction these two writes share.
      */
     public function startChild(
         FlowRun $parent,
@@ -55,9 +57,15 @@ final readonly class ChildRecorder
             'child_workflow_class' => $child->workflow_class,
         ]);
 
-        event(new ChildWorkflowStarted($parent, $child));
-
         return $link;
+    }
+
+    /**
+     * Announce a child whose link is on record.
+     */
+    public function childStarted(FlowRun $parent, FlowRun $child): void
+    {
+        event(new ChildWorkflowStarted($parent, $child));
     }
 
     public function recordCompleted(FlowChild $link, FlowRun $child): void

--- a/src/Runtime/ChildWorkflowManager.php
+++ b/src/Runtime/ChildWorkflowManager.php
@@ -41,6 +41,8 @@ readonly class ChildWorkflowManager
         private FlowSuspender $suspender,
         private Serializer $serializer,
         private FlowExecutor $executor,
+        private StartWorkGuard $startWork,
+        private AnomalyLog $anomalies,
     ) {}
 
     /**
@@ -80,9 +82,7 @@ readonly class ChildWorkflowManager
         }
 
         // First encounter: create and start the child, then suspend the parent.
-        $child = $this->createChild($parent, $workflowClass, $arguments, $closePolicy);
-
-        $this->recorder->startChild($parent, $child, $sequence, $closePolicy, $continueParentOnFailure);
+        $child = $this->startChild($parent, $workflowClass, $arguments, $closePolicy, $sequence, $continueParentOnFailure);
 
         if ($runtime->mode() === RunMode::Sync) {
             $driven = $this->executor->drive($child, RunMode::Sync);
@@ -140,6 +140,88 @@ readonly class ChildWorkflowManager
             // Still in flight (Pending/Running/Waiting): park until it finalizes.
             default => $this->suspender->suspend('child', $sequence),
         };
+    }
+
+    /**
+     * The parent is asked inside the same transaction as the two writes, so a check lost to
+     * a rollback takes both down rather than leaving a FlowRun nobody owns. The host hears
+     * about the child, and its job goes out, only once that transaction is on record.
+     *
+     * @param  array<int, mixed>  $arguments
+     *
+     * @throws FlowSuspended
+     * @throws Throwable
+     */
+    private function startChild(
+        FlowRun $parent,
+        string $workflowClass,
+        array $arguments,
+        ChildClosePolicy $closePolicy,
+        int $sequence,
+        bool $continueParentOnFailure,
+    ): FlowRun {
+        $child = $parent->getConnection()->transaction(function () use (
+            $parent,
+            $workflowClass,
+            $arguments,
+            $closePolicy,
+            $sequence,
+            $continueParentOnFailure,
+        ): FlowRun {
+            $this->startWork->expect($parent, 'child', $sequence);
+
+            $child = $this->createChild($parent, $workflowClass, $arguments, $closePolicy);
+
+            $this->recorder->startChild($parent, $child, $sequence, $closePolicy, $continueParentOnFailure);
+
+            return $child;
+        });
+
+        $this->requireStartSurvivedCommit($parent, $child, $sequence);
+
+        $this->recorder->childStarted($parent, $child);
+
+        return $child;
+    }
+
+    /**
+     * Whether the link is on record now the transaction that wrote it has closed. Mirrors
+     * ActionRecorder::claimSurvivedCommit(): a commit reporting success is not proof, since
+     * a model observer on either row can run a failing query and swallow it, which on
+     * PostgreSQL turns the eventual COMMIT into a rollback.
+     *
+     * Neither row survives such a rollback, so nothing is half-written and no child is
+     * announced or driven that the writes did not keep. The ordinal is simply not reached
+     * and the parent parks on one it comes back to — which without this read it would do
+     * with nothing anywhere to say why.
+     *
+     * @throws FlowSuspended
+     */
+    private function requireStartSurvivedCommit(FlowRun $parent, FlowRun $child, int $sequence): void
+    {
+        /** @var class-string<FlowChild> $model */
+        $model = config('saga-lara-flow.models.flow_child');
+
+        $onRecord = $model::query()
+            ->useWritePdo()
+            ->where('parent_flow_run_id', $parent->id)
+            ->where('child_flow_run_id', $child->id)
+            ->where('sequence', $sequence)
+            ->exists();
+
+        if ($onRecord) {
+            return;
+        }
+
+        $this->anomalies->log(AnomalyLog::REASON_CLAIM_NOT_COMMITTED, [
+            'entity' => 'child',
+            'flow_run_id' => $parent->id,
+            'child_flow_run_id' => $child->id,
+            'sequence' => $sequence,
+            'child_workflow_class' => $child->workflow_class,
+        ]);
+
+        $this->suspender->suspend('child', $sequence);
     }
 
     /**

--- a/src/Runtime/SideEffectStore.php
+++ b/src/Runtime/SideEffectStore.php
@@ -24,6 +24,7 @@ readonly class SideEffectStore
         private SideEffectRecorder $recorder,
         private Serializer $serializer,
         private FlowSuspender $suspender,
+        private StartWorkGuard $startWork,
     ) {}
 
     /**
@@ -55,6 +56,9 @@ readonly class SideEffectStore
 
             return $this->serializer->deserialize($existing->value);
         }
+
+        // Before the call, never after it: a factory that has run cannot be taken back.
+        $this->startWork->expect($flowRun, 'side_effect', $sequence);
 
         $sideEffectResult = $sideEffectCallback();
 

--- a/src/Runtime/StartWorkGuard.php
+++ b/src/Runtime/StartWorkGuard.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Runtime;
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\Internal\FlowSuspended;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * Asked by the seams that begin something other than a step — a child workflow, a side
+ * effect — whether work may still begin under this run. A step folds the same question
+ * into its own claim; these have no comparable write to fold it into.
+ *
+ * The status is read from the connection that wrote it because the instance the seam was
+ * handed is exactly what must not answer: a pass that outlived a rollback holds one from
+ * before it. Only the status is read — the pass keeps the instance it has, which is what
+ * every transition below it is fenced on.
+ */
+final readonly class StartWorkGuard
+{
+    public function __construct(
+        private FlowSuspender $suspender,
+    ) {}
+
+    /**
+     * End the pass unless the run may still start work.
+     *
+     * @throws FlowSuspended
+     */
+    public function expect(FlowRun $flowRun, string $reason, int $sequence): void
+    {
+        if ($this->mayStartWork($flowRun)) {
+            return;
+        }
+
+        $this->suspender->suspend($reason, $sequence);
+    }
+
+    /**
+     * A pruned run answers null and starts nothing: whatever it wrote would point at a
+     * run that is not there.
+     */
+    private function mayStartWork(FlowRun $flowRun): bool
+    {
+        /** @var ?FlowStatus $status */
+        $status = $flowRun->newQuery()
+            ->useWritePdo()
+            ->whereKey($flowRun->getKey())
+            ->value('status');
+
+        return $status?->canStartWork() ?? false;
+    }
+}

--- a/tests/Feature/ReplayOutlivingRollbackTest.php
+++ b/tests/Feature/ReplayOutlivingRollbackTest.php
@@ -1,0 +1,183 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Events\ChildWorkflowStarted;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowChild;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowEvent;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\SideEffect;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompetingRollback;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\EchoValueChildWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\SideEffectCounter;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnwritableFlowChild;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\WriterRoutedFlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
+
+/**
+ * A pass already replaying when a rollback commits keeps going, and every ordinal it
+ * reaches for the first time starts work of its own: a child workflow that runs to
+ * completion outside the plan, and a side-effect factory — host code — called for
+ * real. Neither is a step, so the claim that holds a step to mayStartWork() never sees
+ * them.
+ *
+ * The rollback is committed from inside a side-effect factory, host code the engine
+ * calls at a legitimate seam, so one process reaches the state two would.
+ */
+beforeEach(function (): void {
+    SideEffectCounter::reset();
+    WriterRoutedFlowRun::reset();
+});
+
+final class RollbackDuringSideEffectWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+
+        $this->sideEffect('one', function (): string {
+            CompetingRollback::commit($this->runtime->run()->id);
+
+            return 'first';
+        });
+
+        $this->sideEffect('two', function (): string {
+            SideEffectCounter::$count++;
+
+            return 'second';
+        });
+    }
+}
+
+final class RollbackDuringChildWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+
+        $this->sideEffect('one', function (): string {
+            CompetingRollback::commit($this->runtime->run()->id);
+
+            return 'first';
+        });
+
+        $this->child(EchoValueChildWorkflow::class, ['done'])->run();
+    }
+}
+
+final class OneSideEffectWorkflow extends Workflow
+{
+    public function handle(): string
+    {
+        return $this->sideEffect('one', fn (): string => 'value');
+    }
+}
+
+final class OneChildWorkflow extends Workflow
+{
+    public function handle(): mixed
+    {
+        return $this->child(EchoValueChildWorkflow::class, ['done'])->run();
+    }
+}
+
+it('leaves a side-effect factory uncalled once the run is rolling back', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RollbackDuringSideEffectWorkflow::class)->run();
+
+    drainQueue();
+
+    // The first factory ran while the run could still start work, so its value is
+    // history. The second is reached afterwards, and a factory is host code: an HTTP
+    // call, a charge, an id handed out.
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling)
+        ->and(SideEffectCounter::$count)->toBe(0)
+        ->and(SideEffect::query()->count())->toBe(1);
+});
+
+it('starts no child once the run is rolling back', function (): void {
+    useDatabaseQueue();
+
+    $run = SagaFlow::create(RollbackDuringChildWorkflow::class)->run();
+
+    drainQueue();
+
+    // Neither the link nor a run of its own: a child started here would finish under a
+    // parent reporting a complete unwind, and the default Abandon policy closes nothing.
+    expect(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelling)
+        ->and(FlowChild::query()->count())->toBe(0)
+        ->and(FlowRun::query()->count())->toBe(1);
+});
+
+it('leaves no child run behind when the link cannot be written', function (): void {
+    config()->set('saga-lara-flow.models.flow_child', UnwritableFlowChild::class);
+
+    $run = SagaFlow::create(OneChildWorkflow::class)->runSync();
+
+    // The child and its link are one write or neither, so a run nobody owns is not
+    // what a half-written ordinal leaves behind.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(FlowRun::query()->count())->toBe(1);
+});
+
+it('asks the connection that wrote the run whether work may begin', function (string $workflow): void {
+    config()->set('saga-lara-flow.models.flow_run', WriterRoutedFlowRun::class);
+
+    useDatabaseQueue();
+
+    $run = SagaFlow::create($workflow)->run();
+
+    WriterRoutedFlowRun::reset();
+
+    app(FlowExecutor::class)->drive(WriterRoutedFlowRun::query()->findOrFail($run->id), RunMode::Queued);
+
+    // Two reads for the pass: the boundary it begins on, and the seam's own before it
+    // starts the one thing this run has to start.
+    expect(WriterRoutedFlowRun::$writerReads)->toBe(2);
+})->with([[OneSideEffectWorkflow::class], [OneChildWorkflow::class]]);
+
+it('keeps a child whose announcement a listener threw over', function (): void {
+    Event::listen(ChildWorkflowStarted::class, function (): void {
+        throw new RuntimeException('a listener with an opinion');
+    });
+
+    $run = SagaFlow::create(OneChildWorkflow::class)->runSync();
+
+    // The host is told after the transaction, not inside it, so a listener cannot undo
+    // rows that are already on record — nor start work of its own against a child that
+    // is about to stop existing.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(FlowChild::query()->count())->toBe(1)
+        ->and(FlowRun::query()->count())->toBe(2);
+});
+
+it('never announces a child without its link, poisoned through a model observer', function (): void {
+    // No listener anywhere: the engine's own child.started insert carries the failure in,
+    // and PostgreSQL turns the COMMIT that reports success into a rollback.
+    FlowEvent::created(function (): void {
+        try {
+            DB::connection('testing')->statement('insert into no_such_table (id) values (1)');
+        } catch (Throwable) {
+            // An observer that eats its own failure — broken, but nothing stops it.
+        }
+    });
+
+    $announced = 0;
+
+    Event::listen(ChildWorkflowStarted::class, function () use (&$announced): void {
+        $announced++;
+    });
+
+    SagaFlow::create(OneChildWorkflow::class)->runSync();
+
+    // Whether the write held is the driver's business; that the announcement agrees with
+    // it is not.
+    expect($announced)->toBe(FlowChild::query()->count());
+});

--- a/tests/Fixtures/CompetingRollback.php
+++ b/tests/Fixtures/CompetingRollback.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+
+/**
+ * Commits, from inside a pass that is still replaying, what a competing process
+ * commits first when it rolls the same run back: the move into Cancelling, made
+ * through the engine's own state machine on a row this pass does not hold. One
+ * process reaches the state two would, and the unwind that follows plays no part in
+ * what the seams are asked afterwards.
+ */
+final class CompetingRollback
+{
+    public static function commit(string $flowRunId): void
+    {
+        $run = app(FlowRepository::class)->findOrFail($flowRunId);
+
+        app(StateMachine::class)->transition($run, FlowStatus::Cancelling);
+    }
+}

--- a/tests/Fixtures/UnwritableFlowChild.php
+++ b/tests/Fixtures/UnwritableFlowChild.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowChild;
+use RuntimeException;
+
+/**
+ * A FlowChild that reads normally and refuses to be written, so a link write can fail
+ * for real without a mock while the history lookup that precedes it still answers.
+ * Swapped in through config('saga-lara-flow.models.flow_child').
+ */
+final class UnwritableFlowChild extends FlowChild
+{
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function save(array $options = []): bool
+    {
+        throw new RuntimeException('flow child link could not be written');
+    }
+}


### PR DESCRIPTION
A replay that was already under way when a rollback committed kept going, and every ordinal it
reached for the first time started work of its own. Two seams start something that is not a step, so
the `mayStartWork()` fence on the action claim never saw them: `child()->run()` created a `FlowRun`,
wrote its `flow_children` link and dispatched the child's job, and `sideEffect()` called the host's
factory — an HTTP call, a charge, an id handed out — and recorded it. Both with `Cancelling` already
committed on the run's row, so neither is in the stack the rollback planned, and under the default
`ChildClosePolicy::Abandon` nothing closes the child afterwards.

Both seams now ask one shared guard whether work may still begin under this run. It reads the run's
status from the connection that wrote it, because the instance the seam holds is exactly the stale
value, and ends the pass when the status is outside the three `mayStartWork()` names. That is one
read per ordinal that is about to start work; a replayed ordinal resolves from history on an earlier
branch and reads nothing.

The child's run and its link are written in one transaction with the check inside it, so a check
lost to a rollback takes both rows down rather than leaving a `FlowRun` nobody owns. The
`ChildWorkflowStarted` event and the child's job both follow that commit, and only once the link has
been read back from the writer — a commit reporting success is not proof, since a model observer
that swallows a failing query turns it into a rollback on PostgreSQL. A child is therefore never
announced or driven on rows the write did not keep, and the seam records an anomaly instead of
parking the parent with nothing to say why.

The side-effect check sits immediately before the factory call. No durable start marker is written
ahead of it: that is a cost on the hot replay path and a design decision of its own. The window
between the check and the work stays open on both seams, in the shape CONTRIBUTING already documents
for signal delivery — a check, not a fence — and it is recorded there as intended rather than open.

Verified: the two defect cases reproduce on `main` with exactly the numbers in the issue
(`factoryCalls=1 rows=2`; `children=["completed"] links=1 runs=2`) and pass with the change. Seven
mutations, each caught by exactly one test: the check in `SideEffectStore`; the check in
`ChildWorkflowManager`; `useWritePdo()` in the guard; the transaction; the check moved after the
factory; the event moved back inside the transaction; the read-back after commit (that one on
PostgreSQL, where the swallowed observer failure actually aborts the transaction).

Suite green on SQLite (481 passed, 4 skipped), MySQL (481, 4 skipped) and PostgreSQL (485).
`composer lint` clean, docs build clean.

Closes #65
