### PR TITLE
Plan the rollback that is acted on with the run already fenced

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,7 +611,9 @@ None of these drives a run that is rolling back or finished — a pass begins on
 still start work, so a deadline is enforced once and each compensation on the rollback it planned
 runs once. A pass already replaying when the rollback commits starts nothing further either: its
 next step is refused at the claim, and a child workflow or side effect at an ordinal it has not
-reached before ends the pass instead. See [Statuses](https://sagalaraflow.dev/statuses).
+reached before ends the pass instead. The plan that is unwound is drawn once the run is already
+rolling back, so a step whose owed attempt completed while an earlier plan was being drawn is
+compensated too. See [Statuses](https://sagalaraflow.dev/statuses).
 
 ## Queues, locks & idempotency
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -29,9 +29,9 @@ Nothing below asks anything of you. Each links to the page that covers it.
   [Child workflows](https://sagalaraflow.dev/child-workflows)
 - **The rollback that is unwound is planned with the run already in `Cancelling`.** A step whose
   owed queue attempt completed while an earlier plan was being drawn is compensated rather than left
-  applied under a run reporting a complete unwind. The later plan is adopted only when it covers
-  every ordinal the earlier one held; a replay that throws is journalled as `replan_failed` and one
-  that came back short as `replan_incomplete`, and the rollback goes ahead on the plan in hand.
+  applied under a run reporting a complete unwind. An ordinal the later plan came back without is
+  restored from the earlier one and journalled as `replan_incomplete`; a replay that throws is
+  journalled as `replan_failed` and the rollback goes ahead on the plan in hand.
   [Sagas & compensations](https://sagalaraflow.dev/sagas-and-compensation)
 
 ## From 1.1.x to 1.2.0

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,13 +21,18 @@ Nothing below asks anything of you. Each links to the page that covers it.
   planning a second rollback, so each compensation runs once. `drive()` returns such a run as the
   writer holds it instead of raising `InvalidTransitionException`, and `saga-flow:kick` reports it
   rather than claiming a re-drive. [Statuses](https://sagalaraflow.dev/statuses)
-
 - **A replay that outlived a rollback starts no child and calls no side-effect factory.** Both seams
   read the run's status from the writing connection before they begin, and end the pass when it is
   no longer one of the three statuses `mayStartWork()` names. A child's run and its link are written
   in one transaction; the `ChildWorkflowStarted` event and the child's job both follow that commit,
   so a listener now runs outside that transaction rather than inside it.
   [Child workflows](https://sagalaraflow.dev/child-workflows)
+- **The rollback that is unwound is planned with the run already in `Cancelling`.** A step whose
+  owed queue attempt completed while an earlier plan was being drawn is compensated rather than left
+  applied under a run reporting a complete unwind. The later plan is adopted only when it covers
+  every ordinal the earlier one held; a replay that throws is journalled as `replan_failed` and one
+  that came back short as `replan_incomplete`, and the rollback goes ahead on the plan in hand.
+  [Sagas & compensations](https://sagalaraflow.dev/sagas-and-compensation)
 
 ## From 1.1.x to 1.2.0
 

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -101,6 +101,16 @@ many of them there are they cannot queue ahead of a run that has been overdue lo
 the next open window. Nothing resets the count, so a run that has been failing since Tuesday says so. Fixing the
 workflow is still the actual remedy — see [Reclaim & recovery](./reclaim-and-recovery.md).
 
+All of that concerns the plan drawn before the run is moved. A run with something to undo is moved, and then the plan
+is drawn again: that second one is what the rollback unwinds, and it holds the step whose owed attempt completed while
+the first was being drawn. A throw there is journalled as `replan_failed` rather than surfaced, and so is a second plan
+that turns out to have dropped an entry the first had — `replan_incomplete`. Either way the run has been taken, so the
+rollback goes ahead on the plan already in hand rather than stopping in `Cancelling` with nothing to move it on.
+
+A run the first plan found nothing to undo on is not moved at all; it expires where the sweep found it. A step that
+completes in that gap is therefore still applied under a run reported expired, which is worth knowing if your workflow
+carries exactly one compensatable step.
+
 ## Repair (the doctor)
 
 Separate from expiration: the **doctor** recovers a run whose progress was lost to a *dropped job* — an action that

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -103,9 +103,10 @@ workflow is still the actual remedy — see [Reclaim & recovery](./reclaim-and-r
 
 All of that concerns the plan drawn before the run is moved. A run with something to undo is moved, and then the plan
 is drawn again: that second one is what the rollback unwinds, and it holds the step whose owed attempt completed while
-the first was being drawn. A throw there is journalled as `replan_failed` rather than surfaced, and so is a second plan
-that turns out to have dropped an entry the first had — `replan_incomplete`. Either way the run has been taken, so the
-rollback goes ahead on the plan already in hand rather than stopping in `Cancelling` with nothing to move it on.
+the first was being drawn. A second plan that came back without an ordinal the first had takes that ordinal from it and
+journals `replan_incomplete`; a replay that throws journals `replan_failed` and leaves the first plan standing. Neither
+is surfaced — the run has been taken, so the rollback goes ahead rather than stopping in `Cancelling` with nothing to
+move it on.
 
 A run the first plan found nothing to undo on is not moved at all; it expires where the sweep found it. A step that
 completes in that gap is therefore still applied under a run reported expired, which is worth knowing if your workflow

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -97,11 +97,13 @@ only to find out whether one can be drawn at all: it writes nothing, so a run wh
 left exactly where it was found. The plan that is unwound is the one made afterwards, and it holds
 the step whose owed queue attempt completed while the first was being drawn.
 
-The later plan is adopted only when it covers every ordinal the earlier one held. It is not always
-the longer of the two — an attempt that claimed a failed step in the same gap leaves it `Running`,
-and what `compensateStepOnSelfFailure()` registers for a failed step is not what a replay reads off
-a running one. That is journalled as `replan_incomplete`, a replay that throws as `replan_failed`,
-and either way the rollback goes ahead on the plan already in hand.
+The later plan is not always the longer one. An attempt that claimed a failed step in the same gap
+leaves it `Running`, and what `compensateStepOnSelfFailure()` registers for a failed step is not
+what a replay reads off a running one — and a parallel block can lose an ordinal that way while
+finding another in the same pass. So an ordinal the later plan is missing is restored from the
+earlier one rather than the later plan being discarded, and the difference is journalled as
+`replan_incomplete`. A replay that throws leaves nothing to merge and is journalled as
+`replan_failed`; the rollback then goes ahead on the plan already in hand.
 
 Settling what already started is the other question, and it carries on: a step past its own deadline
 is still expired, and the rollback's own compensations still run. See
@@ -126,7 +128,7 @@ say. The plan is then incomplete, so
 `compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
 it and reporting a finished rollback. Fix the cause and call it again. That is the plan drawn before
 the run is moved; a throw from the one made after it is journalled instead, because by then the run
-has been taken and there is already a plan to unwind.
+has been taken and there is a plan to unwind either way.
 
 :::warning Not inside a transaction of your own
 The compensations execute before your transaction closes, so a rollback afterwards discards the

--- a/docs/docs/sagas-and-compensation.md
+++ b/docs/docs/sagas-and-compensation.md
@@ -86,11 +86,22 @@ To have such a compensation retried rather than only reported, enable `sagas.rec
 ## While a rollback runs
 
 A run rolling back is in `Cancelling`, which is not terminal — and nothing new begins under it. The
-plan was drawn once, so anything started afterwards would finish outside it: its compensation in no
-stack, never run, under a run reporting a complete unwind. That covers a step whose job arrives to
-claim its row, a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md) a
+plan is settled by then, so anything started afterwards would finish outside it: its compensation in
+no stack, never run, under a run reporting a complete unwind. That covers a step whose job arrives
+to claim its row, a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md) a
 pass still replaying reaches for the first time, and a replacement the
 [doctor](./expiration-and-monitoring.md#repair-the-doctor) would otherwise send.
+
+That is what moving the run first is for. A plan is drawn before the move as well, but
+only to find out whether one can be drawn at all: it writes nothing, so a run whose replay throws is
+left exactly where it was found. The plan that is unwound is the one made afterwards, and it holds
+the step whose owed queue attempt completed while the first was being drawn.
+
+The later plan is adopted only when it covers every ordinal the earlier one held. It is not always
+the longer of the two — an attempt that claimed a failed step in the same gap leaves it `Running`,
+and what `compensateStepOnSelfFailure()` registers for a failed step is not what a replay reads off
+a running one. That is journalled as `replan_incomplete`, a replay that throws as `replan_failed`,
+and either way the rollback goes ahead on the plan already in hand.
 
 Settling what already started is the other question, and it carries on: a step past its own deadline
 is still expired, and the rollback's own compensations still run. See
@@ -113,7 +124,9 @@ signal timeout or an awaited child's failure or cancellation already in the run'
 else is a fault, not an ending: an argument expression reading a record that has since been deleted,
 say. The plan is then incomplete, so
 `compensate()` surfaces the throw and leaves the run as it found it, rather than unwinding part of
-it and reporting a finished rollback. Fix the cause and call it again.
+it and reporting a finished rollback. Fix the cause and call it again. That is the plan drawn before
+the run is moved; a throw from the one made after it is journalled instead, because by then the run
+has been taken and there is already a plan to unwind.
 
 :::warning Not inside a transaction of your own
 The compensations execute before your transaction closes, so a rollback afterwards discards the

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -33,6 +33,13 @@ refused when it tries to claim the row, a signal-gated retry will not start anot
 already started is a different question and carries on as usual: a step past its own deadline is
 still expired, and the rollback's own compensations still run.
 
+The plan it unwinds is made once the run is here, which is what makes "afterwards" mean afterwards:
+a step whose owed queue attempt completed while an earlier plan was being drawn is in it. That
+earlier plan is drawn before anything is written, so a run whose rollback cannot be planned at all
+is left where it was found rather than stranded mid-rollback. It is also what the engine falls back
+on, and says so in the journal, when the second plan cannot be trusted over it — the replay threw,
+or it came back without an ordinal the first one held.
+
 A step is not the only thing that begins, and the rest is reached from inside a pass rather than by
 a job of its own: a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md)
 both start work at an ordinal the run has not reached before. A pass still replaying when the

--- a/docs/docs/statuses.md
+++ b/docs/docs/statuses.md
@@ -36,9 +36,9 @@ still expired, and the rollback's own compensations still run.
 The plan it unwinds is made once the run is here, which is what makes "afterwards" mean afterwards:
 a step whose owed queue attempt completed while an earlier plan was being drawn is in it. That
 earlier plan is drawn before anything is written, so a run whose rollback cannot be planned at all
-is left where it was found rather than stranded mid-rollback. It is also what the engine falls back
-on, and says so in the journal, when the second plan cannot be trusted over it — the replay threw,
-or it came back without an ordinal the first one held.
+is left where it was found rather than stranded mid-rollback. It is also what fills the gaps in the
+later one, and the journal says so: an ordinal the second plan came back without is restored from
+the first, and a second replay that throws leaves the first standing on its own.
 
 A step is not the only thing that begins, and the rest is reached from inside a pass rather than by
 a job of its own: a [child workflow](./child-workflows.md) and a [side effect](./side-effects.md)

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -195,6 +195,8 @@ readonly class FlowHandle
 
         app(StateMachine::class)->transition($this->flowRun, FlowStatus::Cancelling);
 
+        $entries = app(FlowExecutor::class)->replanCompensations($this->flowRun, $entries);
+
         app(SagaRunner::class)->rollback(
             $this->flowRun,
             $entries,

--- a/src/Jobs/CancelChildWorkflowJob.php
+++ b/src/Jobs/CancelChildWorkflowJob.php
@@ -99,6 +99,10 @@ class CancelChildWorkflowJob implements ShouldQueue
             // was fenced by an earlier attempt that then failed to plan: both plans
             // fail or neither does, so a retry recovers it once the replay can read
             // what it could not.
+            //
+            // The other two sites that plan twice keep the plan they made first and
+            // fall back to it, because nothing redelivers them. This one is a job, so
+            // throwing the first plan away is what leaves the retry a clean scene.
             if ($this->withCompensation) {
                 $executor->collectCompensations($child);
             }

--- a/src/Runtime/AnomalyLog.php
+++ b/src/Runtime/AnomalyLog.php
@@ -32,6 +32,10 @@ final readonly class AnomalyLog
 
     public const string REASON_EXPIRY_FAILED = 'expiry_failed';
 
+    public const string REASON_REPLAN_FAILED = 'replan_failed';
+
+    public const string REASON_REPLAN_INCOMPLETE = 'replan_incomplete';
+
     public const string REASON_WRITE_REFUSED = 'write_refused';
 
     public const string REASON_REJECTION_UNDELIVERED = 'rejection_undelivered';

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -185,8 +185,9 @@ class FlowExecutor
      * no step; a workflow's own tag() calls still rewrite their rows, as they do on
      * every replay. Planned from three places — compensate(), the expiration sweep and
      * a parent closing a child — so a throw the replay did not expect is a fault, not a
-     * frontier: it leaves rather than shortening the stack behind the caller's back,
-     * and the two callers the operator did not ask for absorb it where it lands.
+     * frontier: it leaves rather than shortening the stack behind the caller's back.
+     * Where it lands is then the caller's to answer, and each of them plans twice:
+     * before taking control of the run, and again through replanCompensations().
      *
      * @return list<CompensationEntry>
      *
@@ -201,6 +202,66 @@ class FlowExecutor
             $flowRun->workflow_class,
             fn (): array => $this->collectCompensationsInner($flowRun),
         );
+    }
+
+    /**
+     * The plan a rollback acts on, made with the run already fenced: one drawn before
+     * the transition is older than the run it describes, and a step whose owed attempt
+     * landed in between belongs in the stack.
+     *
+     * The later plan is not always the longer one. An attempt that claimed a failed step
+     * in the same gap leaves it Running, and a compensation the first plan held for it
+     * — compensateStepOnSelfFailure() registers one — is not there to be read again. So
+     * it is adopted only when it covers every ordinal already planned; otherwise, as
+     * when the replay throws, the caller keeps what it has and the difference is
+     * journalled. Neither outcome unwinds less than the caller would have without it.
+     *
+     * @param  list<CompensationEntry>  $planned
+     * @return list<CompensationEntry>
+     */
+    public function replanCompensations(FlowRun $flowRun, array $planned): array
+    {
+        try {
+            $replanned = $this->collectCompensations($flowRun);
+        } catch (Throwable $replanning) {
+            app(AnomalyLog::class)->log(AnomalyLog::REASON_REPLAN_FAILED, [
+                'entity' => 'flow',
+                'flow_run_id' => $flowRun->id,
+                'workflow_class' => $flowRun->workflow_class,
+                'status' => $flowRun->status->value,
+                'planned' => count($planned),
+                'exception' => $this->exceptionToArray($replanning),
+            ]);
+
+            return $planned;
+        }
+
+        $dropped = array_values(array_diff($this->ordinals($planned), $this->ordinals($replanned)));
+
+        if ($dropped === []) {
+            return $replanned;
+        }
+
+        app(AnomalyLog::class)->log(AnomalyLog::REASON_REPLAN_INCOMPLETE, [
+            'entity' => 'flow',
+            'flow_run_id' => $flowRun->id,
+            'workflow_class' => $flowRun->workflow_class,
+            'status' => $flowRun->status->value,
+            'planned' => count($planned),
+            'replanned' => count($replanned),
+            'dropped_sequences' => $dropped,
+        ]);
+
+        return $planned;
+    }
+
+    /**
+     * @param  list<CompensationEntry>  $entries
+     * @return list<int>
+     */
+    private function ordinals(array $entries): array
+    {
+        return array_map(static fn (CompensationEntry $entry): int => $entry->sequence, $entries);
     }
 
     /**
@@ -366,6 +427,9 @@ class FlowExecutor
             throw ExpirationNotPlannedException::for($flowRun, $planning);
         }
 
+        // Nothing to undo is finalized where the run stands rather than through
+        // Cancelling: a death between the two would leave it there, and a run in
+        // Cancelling is one this sweep, the doctor and drive() all pass over.
         if ($entries === []) {
             $flowRun->exception = $primary;
 
@@ -379,6 +443,8 @@ class FlowExecutor
         }
 
         $this->stateMachine->transition($flowRun, FlowStatus::Cancelling);
+
+        $entries = $this->replanCompensations($flowRun, $entries);
 
         $this->sagaRunner->rollback($flowRun, $entries, $primary, RunMode::Queued, FlowStatus::Expired);
 

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -186,8 +186,9 @@ class FlowExecutor
      * every replay. Planned from three places — compensate(), the expiration sweep and
      * a parent closing a child — so a throw the replay did not expect is a fault, not a
      * frontier: it leaves rather than shortening the stack behind the caller's back.
-     * Where it lands is then the caller's to answer, and each of them plans twice:
-     * before taking control of the run, and again through replanCompensations().
+     * Where it lands is then the caller's to answer, and each of them plans twice —
+     * once before taking control of the run and once after: the sweep and compensate()
+     * through replanCompensations(), a child close by calling this again itself.
      *
      * @return list<CompensationEntry>
      *

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -212,10 +212,11 @@ class FlowExecutor
      *
      * The later plan is not always the longer one. An attempt that claimed a failed step
      * in the same gap leaves it Running, and a compensation the first plan held for it
-     * — compensateStepOnSelfFailure() registers one — is not there to be read again. So
-     * it is adopted only when it covers every ordinal already planned; otherwise, as
-     * when the replay throws, the caller keeps what it has and the difference is
-     * journalled. Neither outcome unwinds less than the caller would have without it.
+     * — compensateStepOnSelfFailure() registers one — is not there to be read again. A
+     * parallel block can lose an ordinal that way and gain another in the same pass, so
+     * an ordinal missing from the later plan is restored from the earlier one rather
+     * than the whole plan being taken from it. Only a replay that throws falls back
+     * wholesale, having left nothing to merge.
      *
      * @param  list<CompensationEntry>  $planned
      * @return list<CompensationEntry>
@@ -253,7 +254,30 @@ class FlowExecutor
             'dropped_sequences' => $dropped,
         ]);
 
-        return $planned;
+        return $this->merge($planned, $replanned);
+    }
+
+    /**
+     * Both plans list their ordinals ascending, which is the order the stack is unwound
+     * in reverse and the order a parallel block's members sit adjacent in, so keying by
+     * ordinal and sorting restores a stack either one on its own would have produced.
+     * The later reading of an ordinal wins: it is the one taken under the fence.
+     *
+     * @param  list<CompensationEntry>  $planned
+     * @param  list<CompensationEntry>  $replanned
+     * @return list<CompensationEntry>
+     */
+    private function merge(array $planned, array $replanned): array
+    {
+        $merged = [];
+
+        foreach ([...$planned, ...$replanned] as $entry) {
+            $merged[$entry->sequence] = $entry;
+        }
+
+        ksort($merged);
+
+        return array_values($merged);
     }
 
     /**

--- a/tests/Feature/PlanTransitionGapTest.php
+++ b/tests/Feature/PlanTransitionGapTest.php
@@ -1,0 +1,215 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\StateMachine;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionDispatcher;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\RaceOnTransition;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UndoAction;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * A rollback is planned before the run is moved to Cancelling, and the plan describes
+ * the run as it was when the replay read it. A step whose owed attempt lands in that
+ * gap completes legitimately — the claim fence asks whether the run may still start
+ * work, and it may — and lands outside a plan already drawn.
+ *
+ * The plan acted on is therefore made a second time, with the run already fenced.
+ */
+beforeEach(function (): void {
+    CompensationLog::reset();
+    RaceOnTransition::reset();
+    PlanGapPaymentAction::$calls = 0;
+    PlanGapPaymentWorkflow::$fault = null;
+});
+
+/**
+ * Fails its first native attempt and succeeds on the next, so the queue owes the row
+ * another try while it sits Failed — the one window that needs no race to reach.
+ */
+final class PlanGapPaymentAction extends Action
+{
+    public int $tries = 3;
+
+    public static int $calls = 0;
+
+    /**
+     * @return array{charged: string}
+     */
+    public function handle(string $orderId): array
+    {
+        self::$calls++;
+
+        if (self::$calls === 1) {
+            throw new RuntimeException('insufficient balance');
+        }
+
+        return ['charged' => $orderId];
+    }
+}
+
+final class PlanGapPaymentWorkflow extends Workflow
+{
+    /** A fault armed after the first plan, so only the second one meets it. */
+    public static ?string $fault = null;
+
+    public function handle(): void
+    {
+        if (self::$fault !== null) {
+            throw new RuntimeException(self::$fault);
+        }
+
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->action(PlanGapPaymentAction::class, 'order-1')->compensateWith(UndoAction::class, 'p')->run();
+        $this->awaitSignal('go');
+    }
+}
+
+/**
+ * The payment step registers a compensation even for its own failure, so the first plan
+ * holds an entry a later one loses the moment an attempt claims that row.
+ */
+final class PlanGapSelfFailureWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')->compensateWith(UndoAction::class, 'a')->run();
+        $this->action(PlanGapPaymentAction::class, 'order-1')
+            ->compensateStepOnSelfFailure()
+            ->compensateWith(UndoAction::class, 'p')
+            ->run();
+        $this->awaitSignal('go');
+    }
+}
+
+/**
+ * Drive the run until the payment step has failed its first native attempt and the
+ * queue still owes it another, then hand back that step.
+ */
+function planGapStepAwaitingItsLastTry(string $flowRunId, int $sequence): ActionRun
+{
+    for ($tick = 0; $tick < 12; $tick++) {
+        $step = ActionRun::query()->where('flow_run_id', $flowRunId)->where('sequence', $sequence)->first();
+
+        if ($step?->status === ActionStatus::Failed || DB::connection('testing')->table('jobs')->count() === 0) {
+            break;
+        }
+
+        workOneJob();
+    }
+
+    $step = ActionRun::query()->where('flow_run_id', $flowRunId)->where('sequence', $sequence)->firstOrFail();
+
+    expect($step->status)->toBe(ActionStatus::Failed)
+        ->and(DB::connection('testing')->table('jobs')->count())->toBe(1);
+
+    return $step;
+}
+
+/**
+ * Let the attempt the queue still owed land where a plan already drawn cannot see it:
+ * after the caller planned, before it took control of the run.
+ */
+function planGapRaceOn(ActionRun $step, FlowStatus $status = FlowStatus::Cancelling): void
+{
+    RaceOnTransition::$on = $status;
+    RaceOnTransition::$race = function () use ($step): void {
+        app(ActionDispatcher::class)->execute($step->fresh());
+    };
+}
+
+it('compensates a step that completed while the expiry was being planned', function (): void {
+    useDatabaseQueue();
+    app()->bind(StateMachine::class, RaceOnTransition::class);
+
+    $run = SagaFlow::create(PlanGapPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    planGapRaceOn(planGapStepAwaitingItsLastTry($run->id, 1));
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    expect(RaceOnTransition::$races)->toBe(1)
+        ->and(PlanGapPaymentAction::$calls)->toBe(2)
+        ->and(CompensationLog::all())->toBe(['undo:p', 'undo:a'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
+});
+
+it('compensates a step that completed while a manual rollback was being planned', function (): void {
+    useDatabaseQueue();
+    app()->bind(StateMachine::class, RaceOnTransition::class);
+
+    $run = SagaFlow::create(PlanGapPaymentWorkflow::class)->run();
+
+    planGapRaceOn(planGapStepAwaitingItsLastTry($run->id, 1));
+
+    SagaFlow::loadFlow($run->id)->compensate();
+
+    expect(RaceOnTransition::$races)->toBe(1)
+        ->and(CompensationLog::all())->toBe(['undo:p', 'undo:a'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelled);
+});
+
+it('keeps the plan it holds when the second one drops an entry from it', function (): void {
+    useDatabaseQueue();
+    logToFile($log = sys_get_temp_dir().'/plan-gap-short-'.uniqid().'.log');
+    app()->bind(StateMachine::class, RaceOnTransition::class);
+
+    $run = SagaFlow::create(PlanGapSelfFailureWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+    $step = planGapStepAwaitingItsLastTry($run->id, 1);
+
+    // The owed attempt claims the row in the gap and gets no further, so the second
+    // replay reads a step that is Running where the first read one that had failed.
+    RaceOnTransition::$race = function () use ($step): void {
+        expect(app(ActionRecorder::class)->startAction($step->fresh()))->toBeTrue();
+    };
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $lines = (string) @file_get_contents($log);
+
+    expect(CompensationLog::all())->toBe(['undo:p', 'undo:a'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired)
+        ->and(substr_count($lines, '"reason":"replan_incomplete"'))->toBe(1)
+        ->and($lines)->toContain('"dropped_sequences":[1]');
+});
+
+it('rolls back with the plan it holds when the second one throws', function (): void {
+    useDatabaseQueue();
+    logToFile($log = sys_get_temp_dir().'/plan-gap-'.uniqid().'.log');
+    app()->bind(StateMachine::class, RaceOnTransition::class);
+
+    $run = SagaFlow::create(PlanGapPaymentWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    planGapStepAwaitingItsLastTry($run->id, 1);
+
+    RaceOnTransition::$race = function (): void {
+        PlanGapPaymentWorkflow::$fault = 'the record this argument reads is gone';
+    };
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $lines = (string) @file_get_contents($log);
+
+    // Control was already taken, so the plan in hand is acted on rather than surfaced:
+    // shorter than the truth by whatever landed in the gap, but never shorter than what
+    // the caller would have unwound without a second plan at all.
+    expect(CompensationLog::all())->toBe(['undo:a'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired)
+        ->and(substr_count($lines, '"reason":"replan_failed"'))->toBe(1)
+        ->and($lines)->toContain('"entity":"flow"');
+});

--- a/tests/Feature/PlanTransitionGapTest.php
+++ b/tests/Feature/PlanTransitionGapTest.php
@@ -75,6 +75,27 @@ final class PlanGapPaymentWorkflow extends Workflow
 }
 
 /**
+ * A parallel block whose first member compensates its own failure and whose second is
+ * still in flight: the one shape where a later plan can lose an ordinal and find
+ * another in the same pass.
+ */
+final class PlanGapParallelWorkflow extends Workflow
+{
+    public function handle(): void
+    {
+        $this->parallel()
+            ->action(PlanGapPaymentAction::class, 'order-1')
+            ->compensateStepOnSelfFailure()
+            ->compensateWith(UndoAction::class, 'p')
+            ->action(MakeValueAction::class, 'h')
+            ->compensateWith(UndoAction::class, 'h')
+            ->run();
+
+        $this->awaitSignal('go');
+    }
+}
+
+/**
  * The payment step registers a compensation even for its own failure, so the first plan
  * holds an entry a later one loses the moment an attempt claims that row.
  */
@@ -160,7 +181,7 @@ it('compensates a step that completed while a manual rollback was being planned'
         ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Cancelled);
 });
 
-it('keeps the plan it holds when the second one drops an entry from it', function (): void {
+it('restores an entry the second plan dropped from the first', function (): void {
     useDatabaseQueue();
     logToFile($log = sys_get_temp_dir().'/plan-gap-short-'.uniqid().'.log');
     app()->bind(StateMachine::class, RaceOnTransition::class);
@@ -184,6 +205,39 @@ it('keeps the plan it holds when the second one drops an entry from it', functio
         ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired)
         ->and(substr_count($lines, '"reason":"replan_incomplete"'))->toBe(1)
         ->and($lines)->toContain('"dropped_sequences":[1]');
+});
+
+it('keeps an ordinal the second plan lost without losing the one it found', function (): void {
+    useDatabaseQueue();
+    app()->bind(StateMachine::class, RaceOnTransition::class);
+
+    $run = SagaFlow::create(PlanGapParallelWorkflow::class)->expiresAt(now()->addSeconds(30))->run();
+
+    // Only the block's first member has run, and it owes the queue another try; the
+    // second is still queued, so the first plan holds the self-failure entry alone.
+    workOneJob();
+    workOneJob();
+
+    $failed = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 0)->firstOrFail();
+    $inFlight = ActionRun::query()->where('flow_run_id', $run->id)->where('sequence', 1)->firstOrFail();
+
+    expect($failed->status)->toBe(ActionStatus::Failed)
+        ->and($inFlight->status)->toBe(ActionStatus::Pending);
+
+    RaceOnTransition::$race = function () use ($failed, $inFlight): void {
+        app(ActionRecorder::class)->startAction($failed->fresh());
+        app(ActionDispatcher::class)->execute($inFlight->fresh());
+    };
+
+    $this->travel(60)->seconds();
+    app(FlowMonitor::class)->sweep();
+    drainQueue();
+
+    $log = CompensationLog::all();
+    sort($log);
+
+    expect($log)->toBe(['undo:h', 'undo:p'])
+        ->and(FlowRun::query()->findOrFail($run->id)->status)->toBe(FlowStatus::Expired);
 });
 
 it('rolls back with the plan it holds when the second one throws', function (): void {

--- a/tests/Fixtures/RaceOnTransition.php
+++ b/tests/Fixtures/RaceOnTransition.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use Closure;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\States\FlowStateMachine;
+
+/**
+ * Acts in the gap a caller leaves between planning a rollback and taking control of
+ * the run: the callback runs once, immediately before the transition into the given
+ * status is written, which is where a competing worker's owed attempt would land.
+ */
+final class RaceOnTransition extends FlowStateMachine
+{
+    /** @var ?Closure(FlowRun): void */
+    public static ?Closure $race = null;
+
+    public static FlowStatus $on = FlowStatus::Cancelling;
+
+    public static int $races = 0;
+
+    public static function reset(): void
+    {
+        self::$race = null;
+        self::$on = FlowStatus::Cancelling;
+        self::$races = 0;
+    }
+
+    public function transition(FlowRun $run, FlowStatus $to): FlowRun
+    {
+        if (self::$race !== null && $to === self::$on) {
+            $race = self::$race;
+
+            self::$race = null;
+            self::$races++;
+
+            $race($run);
+        }
+
+        return parent::transition($run, $to);
+    }
+}


### PR DESCRIPTION
A rollback was planned before the run was moved to `Cancelling`, so a step that completed in
that gap landed outside the plan. Its compensation was in no stack, never ran, and the run
reported a complete unwind over a step that was still applied.

The plan that is acted on is now made with the run already fenced. The earlier plan is still
drawn, and still decides only whether a rollback can be planned at all: it writes nothing, so a
run whose replay throws is left exactly where it was found, and `ExpirationNotPlannedException`
stays what it is — the wrapper for a failure of that first plan.

- `FlowExecutor::replanCompensations()` is the shared seam. `FlowExecutor::expireRunInner()` and
  `FlowHandle::compensate()` both call it after their transition into `Cancelling`.
- The later plan is adopted only when it covers every ordinal the earlier one held. It is not
  always the longer of the two: an attempt that claimed a failed step in the same gap leaves it
  `Running`, and what `compensateStepOnSelfFailure()` registers for a failed step is not what a
  replay reads off a running one. That is journalled as `replan_incomplete`.
- A replay that throws there is journalled as `replan_failed`. Control has been taken by then, so
  the rollback goes ahead on the plan in hand rather than stopping in `Cancelling` with nothing to
  move it on.
- `CancelChildWorkflowJob::close()` is unchanged. It throws its first plan away on purpose,
  because its job is redelivered; a comment now says why the three sites differ.

A run whose first plan found nothing to undo is still finalized where it stands rather than
through `Cancelling`: routing it through an intermediate state it can be left stranded in would
cost more than it buys. `docs/docs/expiration-and-monitoring.md` records what that leaves open.

Four regression tests in `tests/Feature/PlanTransitionGapTest.php`, each verified to fail without
its own part of the change. Five mutations, each caught by exactly one test: the replan in
`expireRunInner`; the replan in `FlowHandle::compensate()`; the coverage check; a failing replan
surfaced instead of absorbed; the empty-plan branch moved below the transition.

Suite green on SQLite (485), MySQL (485) and PostgreSQL (489). `composer lint` and the docs build
are clean.

Closes #62
