### PR TITLE
Let a kick reach the step the doctor gave up on

### DIFF
--- a/README.md
+++ b/README.md
@@ -604,7 +604,10 @@ For runs whose progress was lost to a *dropped job* (rather than a deadline), th
 re-dispatch missing actions (`repair.redispatch_lost_actions`) and re-wake stuck waits
 (`repair.wake_stuck_flows`) — enable `repair.enabled` and either schedule `saga-flow:repair` or loop
 it off the worker (`repair.queue_looping.enabled`), or kick a single run manually with
-`saga-flow:kick {run}` / `SagaFlow::kick($id)`. Each config key is documented in
+`saga-flow:kick {run}` / `SagaFlow::kick($id)`. A kick refills the repair budget that
+`repair.max_attempts` caps and sends the sequential step the run is parked on its own job back, so
+the cap holds the automatic pass off rather than ending the run's recovery. Each config key is
+documented in
 [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring).
 
 None of these drives a run that is rolling back or finished — a pass begins only for a run that may
@@ -742,7 +745,7 @@ reaches somewhere you chose rather than nowhere. See
 | `saga-flow:show {run} {--compact}`                               | Inspect a run: header, actions, signals, compensations, history. |
 | `saga-flow:signal {run} {name} {--payload=}`                     | Deliver a JSON-payload signal and wake the run.                  |
 | `saga-flow:cancel {run} {--compensate}`                          | Cancel a non-terminal run; `--compensate` rolls back first.      |
-| `saga-flow:kick {run}`                                           | Manually re-drive a stuck run.                                   |
+| `saga-flow:kick {run}`                                           | Re-drive a stuck run and the step it is parked on.               |
 | `saga-flow:monitor`                                              | Expire overdue runs/actions and time out waits.                  |
 | `saga-flow:repair`                                               | Recover runs whose progress was lost to a dropped job.           |
 | `saga-flow:prune {--days=} {--before=} {--dry-run}`              | Delete old terminal runs and related rows.                       |

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -33,6 +33,13 @@ Nothing below asks anything of you. Each links to the page that covers it.
   restored from the earlier one and journalled as `replan_incomplete`; a replay that throws is
   journalled as `replan_failed` and the rollback goes ahead on the plan in hand.
   [Sagas & compensations](https://sagalaraflow.dev/sagas-and-compensation)
+- **A kick reaches the step, not just the run.** `saga-flow:kick` / `SagaFlow::kick()` now refills
+  the repair budget of the run and of every step it has not finished, and sends a fresh job for the
+  sequential step the run is parked on — the rows R1 and R3 read (`Pending`, or `Running` past its
+  reclaim deadline), without their throttle. `repair.max_attempts` therefore holds the automatic
+  pass off rather than ending a run's recovery. The claim still decides whether that job runs the
+  step, and a parallel block gets its budget back and nothing else.
+  [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
 
 ## From 1.1.x to 1.2.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -36,8 +36,9 @@ Nothing below asks anything of you. Each links to the page that covers it.
 - **A kick reaches the step, not just the run.** `saga-flow:kick` / `SagaFlow::kick()` now refills
   the repair budget of the run and of every step it has not finished, and sends a fresh job for the
   sequential step the run is parked on — the rows R1 and R3 read (`Pending`, or `Running` past its
-  reclaim deadline), without their throttle. `repair.max_attempts` therefore holds the automatic
-  pass off rather than ending a run's recovery. The claim still decides whether that job runs the
+  reclaim deadline), without their throttle. The refilled rows are held off for `grace_seconds`, as
+  a freshly dispatched row is. `repair.max_attempts` therefore holds the automatic pass off rather
+  than ending a run's recovery. The claim still decides whether that job runs the
   step, and a parallel block gets its budget back and nothing else.
   [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
 

--- a/docs/docs/artisan-commands.md
+++ b/docs/docs/artisan-commands.md
@@ -15,7 +15,7 @@ routes** — everything is done through Artisan or the `SagaFlow` facade.
 | `saga-flow:show {run} {--compact}` | Inspect a run: header, actions, signals, compensations, history. |
 | `saga-flow:signal {run} {name} {--payload=}` | Deliver a JSON-payload signal and wake the run. |
 | `saga-flow:cancel {run} {--compensate}` | Cancel a non-terminal run; `--compensate` rolls back first. |
-| `saga-flow:kick {run}` | Manually re-drive a stuck run. |
+| `saga-flow:kick {run}` | Manually re-drive a stuck run and the step it is parked on. |
 | `saga-flow:monitor` | Expire overdue runs/actions and time out waits. |
 | `saga-flow:repair` | Recover runs whose progress was lost to a dropped job. |
 | `saga-flow:prune {--days=} {--before=} {--dry-run}` | Delete old terminal runs and related rows. |
@@ -44,6 +44,10 @@ php artisan saga-flow:kick 01JABCDEF...
 A run parked by [retry on signal](./retry-on-signal.md) shows up as `waiting` in `saga-flow:list`,
 annotated with the signal it needs; `saga-flow:show` adds a **Retry** column with the signal, the
 spent budget, and the wait deadline. `saga-flow:signal` delivers the signal that restarts the step.
+
+`saga-flow:kick` re-drives one run by hand. It refills the repair budget of the run and its
+unfinished steps and puts a sequential step's job back on the queue, which is the manual answer to a
+step the doctor has given up on.
 
 Schedule `saga-flow:monitor` and `saga-flow:repair` for background maintenance — see
 [Expiration & monitoring](./expiration-and-monitoring.md).

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -141,7 +141,8 @@ Every parameter:
 - **`batch_size`** — how many candidate entities one repair pass inspects at most. Only entities of runs that have not
   finished are counted against it.
 - **`max_attempts`** — per-entity cap. After this many repair attempts the doctor gives up on that entity and leaves it
-  alone. A kick refills that budget, so the cap holds the automatic pass off rather than ending the run's recovery.
+  alone. A kick refills that budget — held off for `grace_seconds` first, like any freshly dispatched row — so the cap
+  holds the automatic pass off rather than ending the run's recovery.
 - **`backoff`** — exponential backoff between repair attempts for a single entity, clamped between
   `base_seconds` and `max_seconds`. Prevents the doctor from hammering the same stuck entity.
 - **`redispatch_lost_actions`** — enable R1: re-dispatch a lost queue job for a stuck sequential

--- a/docs/docs/expiration-and-monitoring.md
+++ b/docs/docs/expiration-and-monitoring.md
@@ -141,7 +141,7 @@ Every parameter:
 - **`batch_size`** — how many candidate entities one repair pass inspects at most. Only entities of runs that have not
   finished are counted against it.
 - **`max_attempts`** — per-entity cap. After this many repair attempts the doctor gives up on that entity and leaves it
-  alone (re-drive it by hand with `saga-flow:kick`).
+  alone. A kick refills that budget, so the cap holds the automatic pass off rather than ending the run's recovery.
 - **`backoff`** — exponential backoff between repair attempts for a single entity, clamped between
   `base_seconds` and `max_seconds`. Prevents the doctor from hammering the same stuck entity.
 - **`redispatch_lost_actions`** — enable R1: re-dispatch a lost queue job for a stuck sequential
@@ -182,6 +182,13 @@ SagaFlow::kick($runId);          // or:
 
 A kick re-drives a run that may still start work. A run that has finished, or is rolling back, is left exactly as it
 was; the command reports its status instead of claiming a re-drive.
+
+It also refills the repair budget of the run and of every step it has not finished, and sends a fresh job for the
+sequential step the run is parked on — so a run stopped at a step the doctor gave up on moves again, rather than
+replaying up to that step and parking on it a second time. The step it reaches is the one R1 and R3 read, without their
+throttle: `Pending`, or `Running` past its [reclaim](./reclaim-and-recovery.md) deadline. A `Running` row still inside
+that window belongs to a worker that may be alive and is left to it. A parallel block gets its budget back and nothing
+else, for the same reason R1 and R3 leave batch-bound work alone.
 
 ## Pruning
 

--- a/docs/docs/reclaim-and-recovery.md
+++ b/docs/docs/reclaim-and-recovery.md
@@ -41,7 +41,8 @@ The claim accepts a row that is `Pending` — and, for an action, `Failed`, whic
 the action's own native `$tries`. A row already `Running` is accepted only once its reclaim deadline has passed, and
 with reclaim off there is no deadline, so it is never accepted. A worker killed mid-execution (an evicted pod, the OOM
 killer, a `SIGKILL` deploy) leaves its row `Running` for good: replay reads a `Running` step as still in flight and
-parks the run, `saga-flow:kick` does the same, and the run waits indefinitely.
+parks the run, and `saga-flow:kick` has no deadline to tell it apart from a row still being worked on, so it leaves it
+there too and the run waits indefinitely.
 
 What that buys is that the engine never re-executes a step on its own initiative:
 
@@ -132,12 +133,13 @@ defaults):
 ## What changes once it's on
 
 A `Running` row becomes claimable again once its deadline passes — but only when something actually *claims* it, which
-means one of two things: a redelivered queue job for that row, or the doctor (next section). Reclaim is otherwise
-passive; it does not go looking for stale rows.
+means one of three things: a redelivered queue job for that row, the doctor (next section), or `saga-flow:kick`.
+Reclaim is otherwise passive; it does not go looking for stale rows.
 
-`saga-flow:kick` is not one of those two. It re-wakes the run, and the replay it triggers reads a `Running` step as
-still in flight and parks the run again without reaching the claim. Kick recovers a run whose *resume* was lost, not a
-row whose *worker* was.
+A kick sends a fresh job for the sequential step its run is parked on, so it reaches the claim rather than only
+re-waking the run. It reads the same deadline R3 does and skips a `Running` row that has not passed it, which is why,
+with reclaim off, it recovers a run whose *resume* was lost but not a row whose *worker* was: no `Running` row carries
+a deadline then, so none is ever its candidate.
 
 ## The doctor's active side (R3)
 

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -13,6 +13,7 @@ use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 use Illuminate\Database\ConnectionInterface;
 use Illuminate\Queue\Events\Looping;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Throwable;
@@ -324,11 +325,19 @@ final readonly class FlowDoctor
      * Refill the budget the automatic pass spent on this run and on the steps it has
      * not finished. A kick is somebody watching, which is what max_attempts stands in
      * for while nobody is.
+     *
+     * The refill carries the same hold ActionRecorder::retryAction() gives a rewound
+     * row, and for the same reason: the doctor holds a fresh row off by comparing
+     * created_at, which these passed long ago, so without one it would read the job
+     * this kick is about to send as lost and send a second — and the generation token
+     * cannot tell two jobs of one cycle apart.
      */
     private function clearRepairBudget(FlowRun $run): void
     {
+        $heldUntil = Carbon::now()->addSeconds((int) config('saga-lara-flow.repair.grace_seconds', 60));
+
         $run->repair_attempts = 0;
-        $run->repair_available_at = null;
+        $run->repair_available_at = $heldUntil;
         $run->save();
 
         $this->actionRunModel()::query()
@@ -338,7 +347,7 @@ final readonly class FlowDoctor
                 ActionStatus::Running,
                 ActionStatus::AwaitingRetry,
             ])
-            ->update(['repair_attempts' => 0, 'repair_available_at' => null]);
+            ->update(['repair_attempts' => 0, 'repair_available_at' => $heldUntil]);
     }
 
     /**

--- a/src/Runtime/FlowDoctor.php
+++ b/src/Runtime/FlowDoctor.php
@@ -30,10 +30,10 @@ use Throwable;
  *   R3  a stuck sequential Running action past its own reclaim window → re-dispatch.
  *
  * repair_attempts + repair_available_at throttle a pass per entity and give up after max_attempts.
- * saga-flow:kick re-wakes a run by hand, which is the manual answer to R2; it does not reset a
- * counter, so an action the doctor has given up on waits for a retry cycle to reschedule it.
- * Batch-bound work (parallel actions, compensations) is out of scope even for R3: adding a job back
- * into a Bus::batch needs an id this package does not store.
+ * saga-flow:kick is the manual answer to all three: it refills that budget for the run and its
+ * unfinished steps and sends the sequential step its own job back. Batch-bound work (parallel
+ * actions, compensations) is out of scope even for R3 and for a kick: adding a job back into a
+ * Bus::batch needs an id this package does not store.
  */
 final readonly class FlowDoctor
 {
@@ -237,9 +237,14 @@ final readonly class FlowDoctor
      * Running transition is an idempotent no-op and the run lock serializes against
      * any live job); a run that may not start work is left untouched.
      *
+     * The resume alone cannot move a run parked on a recorded step: the replay it
+     * triggers meets that row and parks on it exactly as the pass that recorded it did.
+     *
      * Decided on the writer, and the run it decided on is what comes back: a lagging
      * replica would answer with the status this read exists to replace, and an operator
      * would be told a run was re-driven while it was rolling back.
+     *
+     * @throws Throwable
      */
     public function kick(FlowRun $run): FlowRun
     {
@@ -249,11 +254,118 @@ final readonly class FlowDoctor
             return $current;
         }
 
-        $this->lifecycle->flowRewoken($current, 'manual');
+        /** @var array{0: ?FlowRun, 1: ?ActionRun} $kicked */
+        $kicked = $this->connection()->transaction(function () use ($current): array {
+            $locked = $this->lockFlow($current->id);
 
-        $this->dispatchResume($current);
+            if ($locked === null || ! $locked->status->canStartWork()) {
+                return [$locked, null];
+            }
 
-        return $current;
+            $this->clearRepairBudget($locked);
+
+            $step = $this->openSequentialStep($locked);
+
+            // Last of all: the re-wake event runs host listeners, and one that swallows
+            // a failing query leaves the connection unable to answer anything more.
+            $this->lifecycle->flowRewoken($locked, 'manual');
+
+            return [$locked, $step];
+        });
+
+        [$locked, $step] = $kicked;
+
+        if ($locked === null || ! $locked->status->canStartWork()) {
+            return $locked ?? $current;
+        }
+
+        $kickedRun = $this->budgetSurvivedCommit($locked);
+
+        $this->dispatchResume($kickedRun);
+
+        if ($step !== null) {
+            // The writer already answered with this run; lazy-loading the relation
+            // would ask a replica which connection and queue the recovery lands on.
+            $step->setRelation('flowRun', $kickedRun);
+
+            $this->dispatchActionJob($step);
+        }
+
+        return $kickedRun;
+    }
+
+    /**
+     * The run as the writer holds it once the kick's transaction has closed. Mirrors
+     * ActionRecorder::claimSurvivedCommit(): a commit reporting success is not proof,
+     * and the re-wake event runs host listeners inside this one. Both jobs are sent
+     * either way — neither reads what it wrote — but a caller handed a model claiming a
+     * budget the database never took would read the run as reachable again.
+     */
+    private function budgetSurvivedCommit(FlowRun $run): FlowRun
+    {
+        $stored = $this->rereadFlow($run);
+
+        if ($stored->repair_attempts === 0) {
+            return $stored;
+        }
+
+        app(AnomalyLog::class)->log(AnomalyLog::REASON_CLAIM_NOT_COMMITTED, [
+            'entity' => 'flow',
+            'flow_run_id' => $run->id,
+            'workflow_class' => $run->workflow_class,
+            'status' => $stored->status->value,
+            'stored_repair_attempts' => $stored->repair_attempts,
+        ]);
+
+        return $stored;
+    }
+
+    /**
+     * Refill the budget the automatic pass spent on this run and on the steps it has
+     * not finished. A kick is somebody watching, which is what max_attempts stands in
+     * for while nobody is.
+     */
+    private function clearRepairBudget(FlowRun $run): void
+    {
+        $run->repair_attempts = 0;
+        $run->repair_available_at = null;
+        $run->save();
+
+        $this->actionRunModel()::query()
+            ->where('flow_run_id', $run->id)
+            ->whereIn('status', [
+                ActionStatus::Pending,
+                ActionStatus::Running,
+                ActionStatus::AwaitingRetry,
+            ])
+            ->update(['repair_attempts' => 0, 'repair_available_at' => null]);
+    }
+
+    /**
+     * The step a kick can put back on the queue itself: the rows R1 and R3 read, without
+     * their throttle.
+     *
+     * A Running row still inside its reclaim window is skipped rather than left to lose
+     * the claim: a second job for a row a live worker holds waits on that worker's lock,
+     * and the queue giving up on the wait is recorded against the row it is running.
+     */
+    private function openSequentialStep(FlowRun $run): ?ActionRun
+    {
+        return $this->actionRunModel()::query()
+            ->where('flow_run_id', $run->id)
+            ->whereNull('parallel_group')
+            ->where(function ($query): void {
+                $query
+                    ->where('status', ActionStatus::Pending)
+                    ->orWhere(function ($stale): void {
+                        $stale
+                            ->where('status', ActionStatus::Running)
+                            ->whereNotNull('reclaim_stale_at')
+                            ->where('reclaim_stale_at', '<=', now());
+                    });
+            })
+            ->orderBy('sequence')
+            ->first();
     }
 
     private function rereadFlow(FlowRun $run): FlowRun
@@ -293,10 +405,18 @@ final readonly class FlowDoctor
 
     private function lockAction(string $id): ?ActionRun
     {
+        return $this->actionRunModel()::query()->lockForUpdate()->find($id);
+    }
+
+    /**
+     * @return class-string<ActionRun>
+     */
+    private function actionRunModel(): string
+    {
         /** @var class-string<ActionRun> $model */
         $model = config('saga-lara-flow.models.action_run');
 
-        return $model::query()->lockForUpdate()->find($id);
+        return $model;
     }
 
     private function lockFlow(string $id): ?FlowRun

--- a/tests/Feature/DoctorKickReachesStepTest.php
+++ b/tests/Feature/DoctorKickReachesStepTest.php
@@ -1,0 +1,230 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Contracts\FlowRepository;
+use DiscoveryUkraine\SagaLaraFlow\Contracts\Serializer;
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\RunMode;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\ActionRun;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\ActionRecorder;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ParallelEchoWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\TwoStepWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\UnsavedFlowRun;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Drive a workflow far enough to schedule its first step, then take away everything
+ * that would ever run it again: the queued job is gone, the step is old enough to be
+ * a repair candidate, and its repair budget is spent. This is the state the doctor
+ * has given up on for good.
+ *
+ * @param  list<mixed>  $arguments
+ */
+function kickReachStageStuckRun(string $workflow, array $arguments = []): FlowRun
+{
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => $workflow,
+        'status' => FlowStatus::Pending,
+        'arguments' => app(Serializer::class)->serialize($arguments),
+    ]);
+
+    $driven = app(FlowExecutor::class)->drive($run, RunMode::Queued);
+
+    expect($driven->status)->toBe(FlowStatus::Waiting);
+
+    // The lost job: nothing on the queue can move this run on any more.
+    DB::connection('testing')->table('jobs')->delete();
+
+    ActionRun::query()->where('flow_run_id', $driven->id)->update([
+        'created_at' => now()->subHours(2),
+        'repair_attempts' => (int) config('saga-lara-flow.repair.max_attempts'),
+        'repair_available_at' => null,
+    ]);
+
+    return $driven;
+}
+
+function kickReachJobCount(): int
+{
+    return DB::connection('testing')->table('jobs')->count();
+}
+
+it('runs a sequential step the doctor has given up on', function () {
+    $run = kickReachStageStuckRun(TwoStepWorkflow::class, ['order-1']);
+
+    $report = app(FlowDoctor::class)->repair();
+
+    expect($report->redispatchedActions)->toBe(0)
+        ->and(kickReachJobCount())->toBe(0);
+
+    app(FlowDoctor::class)->kick($run);
+
+    drainQueue();
+
+    $final = SagaFlow::findRun($run->id);
+    $steps = $final->actions()->orderBy('sequence')->get();
+
+    expect($final->status)->toBe(FlowStatus::Completed)
+        ->and($steps)->toHaveCount(2)
+        ->and($steps[0]->status)->toBe(ActionStatus::Completed)
+        ->and($steps[0]->repair_attempts)->toBe(0)
+        ->and($steps[1]->status)->toBe(ActionStatus::Completed);
+});
+
+it('sends the step job for the retry cycle the row is on', function () {
+    $run = kickReachStageStuckRun(OneActionWorkflow::class);
+
+    // The row was rewound by a retry cycle before it got stuck. A job sent for cycle 0
+    // loses the claim against it, so the step only runs if the kick carries the
+    // generation the row actually carries.
+    ActionRun::query()->where('flow_run_id', $run->id)->update(['retry_signal_attempts' => 1]);
+
+    app(FlowDoctor::class)->kick($run);
+
+    drainQueue();
+
+    $step = SagaFlow::findRun($run->id)->actions()->first();
+
+    expect($step->status)->toBe(ActionStatus::Completed)
+        ->and($step->retry_signal_attempts)->toBe(1);
+});
+
+it('clears the repair budget of a parallel step without sending its job', function () {
+    $run = kickReachStageStuckRun(ParallelEchoWorkflow::class);
+
+    $before = ActionRun::query()->where('flow_run_id', $run->id)->get();
+
+    expect($before)->toHaveCount(3)
+        ->and($before->every(fn (ActionRun $step): bool => $step->parallel_group !== null))->toBeTrue();
+
+    app(FlowDoctor::class)->kick($run);
+
+    // Only the resume: a batch-bound step cannot be put back on its batch.
+    expect(kickReachJobCount())->toBe(1);
+
+    $after = ActionRun::query()->where('flow_run_id', $run->id)->get();
+
+    expect($after->every(fn (ActionRun $step): bool => $step->repair_attempts === 0))->toBeTrue()
+        ->and($after->every(fn (ActionRun $step): bool => $step->status === ActionStatus::Pending))->toBeTrue();
+});
+
+it('clears the run own repair budget so the doctor can wake it again', function () {
+    useDatabaseQueue();
+    config()->set('saga-lara-flow.repair.enabled', true);
+
+    $run = app(FlowRepository::class)->create([
+        'workflow_class' => OneActionWorkflow::class,
+        'status' => FlowStatus::Waiting,
+        'arguments' => app(Serializer::class)->serialize([]),
+    ]);
+
+    ActionRun::create([
+        'flow_run_id' => $run->id,
+        'sequence' => 0,
+        'action_class' => MakeValueAction::class,
+        'status' => ActionStatus::Completed,
+        'result' => ['label' => 'value'],
+        'attempts' => 1,
+    ]);
+
+    FlowRun::query()->whereKey($run->id)->update([
+        'updated_at' => now()->subHours(2),
+        'repair_attempts' => (int) config('saga-lara-flow.repair.max_attempts'),
+        'repair_available_at' => null,
+    ]);
+
+    expect(app(FlowDoctor::class)->repair()->rewokenFlows)->toBe(0);
+
+    app(FlowDoctor::class)->kick($run->fresh());
+
+    expect(SagaFlow::findRun($run->id)->repair_attempts)->toBe(0);
+});
+
+it('leaves a Running step inside its reclaim window alone', function () {
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.after_seconds', 900);
+
+    $run = kickReachStageStuckRun(OneActionWorkflow::class);
+
+    // A live worker holds the row: the claim resolved its reclaim window into a
+    // deadline that has not passed.
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->firstOrFail();
+
+    expect(app(ActionRecorder::class)->startAction($step))->toBeTrue();
+
+    $step->refresh();
+
+    expect($step->status)->toBe(ActionStatus::Running)
+        ->and($step->reclaim_stale_at)->not->toBeNull()
+        ->and($step->reclaim_stale_at->isFuture())->toBeTrue();
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    app(FlowDoctor::class)->kick($run);
+
+    // Only the resume: the row is still the live worker's to finish.
+    expect(kickReachJobCount())->toBe(1)
+        ->and($step->fresh()->repair_attempts)->toBe(0);
+});
+
+it('sends a Running step its job back once its reclaim window has passed', function () {
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.enabled', true);
+    config()->set('saga-lara-flow.actions.reclaim.stale_running.after_seconds', 900);
+
+    $run = kickReachStageStuckRun(OneActionWorkflow::class);
+
+    $step = ActionRun::query()->where('flow_run_id', $run->id)->firstOrFail();
+
+    expect(app(ActionRecorder::class)->startAction($step))->toBeTrue();
+
+    DB::connection('testing')->table('jobs')->delete();
+
+    $this->travel(1800)->seconds();
+
+    app(FlowDoctor::class)->kick($run);
+
+    expect(kickReachJobCount())->toBe(2);
+
+    drainQueue();
+
+    expect(SagaFlow::findRun($run->id)->status)->toBe(FlowStatus::Completed);
+});
+
+it('answers with the budget the database holds, not the one it wrote', function () {
+    config()->set('saga-lara-flow.models.flow_run', UnsavedFlowRun::class);
+
+    $run = kickReachStageStuckRun(OneActionWorkflow::class);
+
+    FlowRun::query()->whereKey($run->id)->update([
+        'repair_attempts' => (int) config('saga-lara-flow.repair.max_attempts'),
+    ]);
+
+    $log = base_path('kick-budget.log');
+    logToFile($log);
+
+    // The re-wake event runs host listeners inside the kick's transaction, and one that
+    // swallows a failing query turns the commit into a rollback on PostgreSQL. The
+    // caller is then handed a model claiming a budget the database never took.
+    UnsavedFlowRun::$swallowSaves = true;
+
+    try {
+        $kicked = app(FlowDoctor::class)->kick($run);
+    } finally {
+        UnsavedFlowRun::reset();
+    }
+
+    $stored = SagaFlow::findRun($run->id);
+
+    expect($stored->repair_attempts)->toBe((int) config('saga-lara-flow.repair.max_attempts'))
+        ->and($kicked->repair_attempts)->toBe($stored->repair_attempts)
+        ->and(file_get_contents($log))->toContain('claim_not_committed');
+});

--- a/tests/Feature/DoctorKickReachesStepTest.php
+++ b/tests/Feature/DoctorKickReachesStepTest.php
@@ -147,6 +147,10 @@ it('clears the run own repair budget so the doctor can wake it again', function 
     app(FlowDoctor::class)->kick($run->fresh());
 
     expect(SagaFlow::findRun($run->id)->repair_attempts)->toBe(0);
+
+    $this->travel((int) config('saga-lara-flow.repair.grace_seconds') + 1)->seconds();
+
+    expect(app(FlowDoctor::class)->repair()->rewokenFlows)->toBe(1);
 });
 
 it('leaves a Running step inside its reclaim window alone', function () {
@@ -227,4 +231,23 @@ it('answers with the budget the database holds, not the one it wrote', function 
     expect($stored->repair_attempts)->toBe((int) config('saga-lara-flow.repair.max_attempts'))
         ->and($kicked->repair_attempts)->toBe($stored->repair_attempts)
         ->and(file_get_contents($log))->toContain('claim_not_committed');
+});
+
+it('holds the kicked step off the automatic pass for the repair grace period', function () {
+    $run = kickReachStageStuckRun(OneActionWorkflow::class);
+
+    app(FlowDoctor::class)->kick($run);
+
+    $queued = kickReachJobCount();
+
+    // The row is old enough to be a candidate the moment its counter is refilled, and
+    // the generation token cannot tell two jobs of one cycle apart: a second job would
+    // be claimable the instant the kicked one leaves the row Failed between its own
+    // native tries.
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(0)
+        ->and(kickReachJobCount())->toBe($queued);
+
+    $this->travel((int) config('saga-lara-flow.repair.grace_seconds') + 1)->seconds();
+
+    expect(app(FlowDoctor::class)->repair()->redispatchedActions)->toBe(1);
 });

--- a/tests/Fixtures/UnsavedFlowRun.php
+++ b/tests/Fixtures/UnsavedFlowRun.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+
+/**
+ * A flow run whose save() reports success and writes nothing, for the interval a test
+ * turns it on. Stands in for a transaction that a host listener aborted: the caller is
+ * handed a model saying one thing while the row says another, which is the only way a
+ * commit reporting success can still have kept nothing.
+ */
+class UnsavedFlowRun extends FlowRun
+{
+    public static bool $swallowSaves = false;
+
+    public static function reset(): void
+    {
+        self::$swallowSaves = false;
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     */
+    public function save(array $options = []): bool
+    {
+        if (self::$swallowSaves) {
+            return true;
+        }
+
+        return parent::save($options);
+    }
+}


### PR DESCRIPTION
`repair.max_attempts` (default 10) was a permanent give-up for a sequential step rather than a
throttle an operator could lift. `saga-flow:kick` is documented as the manual escape hatch, but it
only dispatched a `ResumeWorkflowJob`: the replay that job triggers meets the step's recorded row
and parks on it exactly as the pass that recorded it did, and it never sends that step's own job.
Nothing reset `action_runs.repair_attempts` except a new retry cycle, so a step with no
`retryOnSignal()` policy was unreachable without a manual database write and its run stayed
`Waiting` for good.

A kick now reaches the step. Under the run's row lock, in one transaction, it re-verifies the run
may still start work, refills the repair budget of the run and of every step it has not finished,
reads the step it will send, and records the re-wake last — nothing inside the transaction runs
after the event that carries host listeners. After the commit it re-reads the run from the writer,
dispatches the resume as before, and sends a fresh `RunActionJob` for the sequential step the run
is parked on, carrying that row's retry generation.

The step it reaches is the one R1 and R3 read, without their throttle: `Pending`, or `Running` past
its reclaim deadline. A `Running` row still inside that window belongs to a worker that may be
alive, and a second job for it would wait on that worker's lock and record the queue giving up on
the wait against the row the worker is running. A parallel block gets its budget back and nothing
else, for the same reason R1 and R3 leave batch-bound work alone.

`repair.max_attempts` therefore holds the automatic pass off rather than ending a run's recovery.
`startAction()` remains the sole arbiter of whether the job runs the step, and a run that has
finished or is rolling back is still left exactly as it was, decided on the writing connection.

`docs/docs/reclaim-and-recovery.md` said a kick was not one of the two things that can claim a
stale `Running` row. It is now the third, and both passages that turned on that are rewritten.

Every case in `tests/Feature/DoctorKickReachesStepTest.php` fails without the part of the fix it
covers. Nine mutations were checked separately: dropping the budget reset, the step redispatch, the
`parallel_group` filter, the retry generation, the flow-row reset alone, the step-row reset alone,
the reclaim-deadline condition on `Running` rows, the writer-read routing, and the read-back after
commit. Eight redden exactly the cases that cover them; the ninth — routing the step's job from the
writer-read run rather than lazy-loading the relation — cannot be reddened here, because the suite
has a single PDO and no replica to lag behind the kick. `DoctorKickTest.php` is unchanged.

SQLite, MySQL and PostgreSQL all pass.

Closes #67
