### PR TITLE
Give every drive pass a runtime of its own

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,11 +249,11 @@ Two things about *when* this throws:
 - **It surfaces on replay, not the instant the action fails.** In queued mode the action runs in its
   own job, off the `handle()` stack, and retries per `$tries`. Once it ultimately fails the engine
   re-drives `handle()` from the top and the failed step replays as a throw — that is where your
-  `try/catch` catches it. In **sync** mode the step runs inline and `run()` re-throws the action's
-  **raw** exception (not `ActionFailedException`), so catch the concrete type you expect.
+  `try/catch` catches it. In **sync** mode the step runs inline and `run()` re-throws the action's **raw** exception
+  (not `ActionFailedException`), so catch the concrete type you expect.
 - **Use `try/catch` for local branching** — "if `ChargeCard` fails, try PayPal instead". For a
-  cross-cutting "report whenever *any* workflow fails", listen to the `FlowFailed` event
-  ([Events](#events)) instead: it fires once on the terminal transition — on both the direct-fail and
+  cross-cutting "report whenever *any* workflow fails", listen to the `FlowFailed` event ([Events](#events)) instead: it
+  fires once on the terminal transition — on both the direct-fail and
   the fail-after-compensation paths, and regardless of sync/queued. If you do report from inside a
   `catch` in `handle()`, **re-throw** afterwards so the engine still fails and compensates the run;
   swallowing the exception lets `handle()` run on past a step that has no result.
@@ -364,8 +364,8 @@ A signal is accepted only by a run that can still consume one — `Pending`, `Ru
 `CannotSignalCancellingFlowException` on one that is rolling back; both extend
 `CannotSignalFlowException`. A refusal writes nothing.
 
-No `$runId`? Find the run by workflow and tag, then signal it. Use `signalable()` (alias `active()`),
-**not** `running()` — a flow parked on `awaitSignal()` is `Waiting`, not `Running`:
+No `$runId`? Find the run by workflow and tag, then signal it. Use `signalable()` (alias `active()`), **not**
+`running()` — a flow parked on `awaitSignal()` is `Waiting`, not `Running`:
 
 ```php
 SagaFlow::query()
@@ -524,6 +524,10 @@ it). A failing child throws `ChildWorkflowFailedException` (or `ChildWorkflowCan
 unless you call `->continueParentOnFailure()`. The default close policy is configurable
 (`children.default_close_policy`) or per class via `#[ChildPolicy]`.
 
+`child()` is also the only seam that runs another workflow from inside `handle()`.
+`SagaFlow::create(...)` there takes no ordinal, so the run it starts is recognized by nothing, and
+the next replay starts another one.
+
 ## Tags & querying
 
 Attach searchable key/value tags at creation, from inside the workflow, or from outside through a
@@ -601,8 +605,8 @@ signal delivered after its deadline but before the next sweep is still accepted.
 expanded in [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring).
 
 For runs whose progress was lost to a *dropped job* (rather than a deadline), the **doctor** can
-re-dispatch missing actions (`repair.redispatch_lost_actions`) and re-wake stuck waits
-(`repair.wake_stuck_flows`) — enable `repair.enabled` and either schedule `saga-flow:repair` or loop
+re-dispatch missing actions (`repair.redispatch_lost_actions`) and re-wake stuck waits (`repair.wake_stuck_flows`) —
+enable `repair.enabled` and either schedule `saga-flow:repair` or loop
 it off the worker (`repair.queue_looping.enabled`), or kick a single run manually with
 `saga-flow:kick {run}` / `SagaFlow::kick($id)`. A kick refills the repair budget that
 `repair.max_attempts` caps and sends the sequential step the run is parked on its own job back, so

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -41,6 +41,12 @@ Nothing below asks anything of you. Each links to the page that covers it.
   than ending a run's recovery. The claim still decides whether that job runs the
   step, and a parallel block gets its budget back and nothing else.
   [Expiration & monitoring](https://sagalaraflow.dev/expiration-and-monitoring)
+- **A run driven while another is being driven gets replay state of its own.** An action whose body
+  starts a saga, or a `runSync()` written inside `handle()`, no longer rewinds the ordinal counter,
+  empties the compensation stack or unbinds the run of the pass that reached it. `FlowRuntime` is no
+  longer registered in the container — the executor makes one for every pass — so resolving it
+  yourself answers with an instance no pass is driven with.
+  [Synchronous execution](https://sagalaraflow.dev/synchronous-execution)
 
 ## From 1.1.x to 1.2.0
 

--- a/docs/docs/child-workflows.md
+++ b/docs/docs/child-workflows.md
@@ -26,6 +26,12 @@ public function handle(): array
 array. `run()` awaits the child and returns whatever the child's `handle()` returned, scalars
 included.
 
+It is also the only seam that runs another workflow from inside `handle()`. `SagaFlow::create(...)`
+there takes no ordinal, so the run it starts is recognized by nothing and the next replay starts
+another one. A step is free to start a run of its own — an action's body is recorded, so it executes
+once however the workflow is replayed — but `handle()` itself reaches another workflow through
+`child()`.
+
 ## Close policies
 
 `ChildClosePolicy` decides what happens to the child when the **parent** closes:

--- a/docs/docs/determinism-rules.md
+++ b/docs/docs/determinism-rules.md
@@ -24,6 +24,9 @@ recorded results for completed operations and only executes the next un-run one.
   DB/HTTP reads — outside a `sideEffect()`.
 - ❌ Reorder, add, or remove already-recorded steps in a version that has in-flight runs (see
   [Versioning](./versioning.md)).
+- ❌ Drive another workflow from inside `handle()` with `SagaFlow::create(...)->runSync()` or
+  `->run()`. Those calls take no ordinal, so nothing recognizes the run one of them started, and the
+  next replay starts another. [`child()`](./child-workflows.md) is the seam that records it.
 - ❌ Catch the engine's control-flow exceptions (`FlowSuspended` / `InternalFlowControl`) as if they
   were errors. If you use a broad `catch (\Throwable $e)`, re-throw them:
 

--- a/docs/docs/retry-on-signal.md
+++ b/docs/docs/retry-on-signal.md
@@ -200,8 +200,8 @@ would be left unclaimed and the next step would land in the wrong slot, and a ru
 be handed a live wait a moment later.
 
 Nor may it drive *any* run, its own or somebody else's — `runSync()` and `compensate()` are refused
-too. One runtime serves the whole process, so a nested pass would rewind the ordinal counter and
-empty the saga stack of the pass waiting on the answer. Reading other runs — their status, their
+too. The predicate is asked between a step's failure and the parking that answers for it, and a pass
+started there decides what that parking is written over. Reading other runs — their status, their
 history, their tags — stays fair game.
 
 The engine refuses every one of these with `RetryPolicyReentryException` before anything is

--- a/docs/docs/synchronous-execution.md
+++ b/docs/docs/synchronous-execution.md
@@ -21,6 +21,12 @@ $run->result;   // the value handle() returned
 The queued and synchronous paths are guaranteed to reach the **same** final database state — the only
 difference is *who* drives the steps (your worker vs. the current process).
 
+A `runSync()` reached while another run is being driven — an action whose body starts a saga of its
+own — is driven on replay state of its own, so the run that owns the step keeps its ordinals and its
+compensation stack while the inner one runs. From inside `handle()`, reach another workflow through
+[`child()`](./child-workflows.md) instead: `runSync()` there takes no ordinal and starts a run the
+next replay cannot recognize.
+
 :::warning Do not call `runSync()` inside a transaction of your own
 A step's body runs while your transaction is still open, so a rollback afterwards — yours, or one a
 failed statement forced on you — discards every row the run recorded while the work those rows

--- a/src/FlowHandle.php
+++ b/src/FlowHandle.php
@@ -42,9 +42,8 @@ readonly class FlowHandle
      */
     private function rejectWhileDeciding(string $operation): void
     {
-        // Asked of the executor, not of the container: FlowExecutor is a singleton
-        // holding a scoped runtime, and a queue worker forgets scoped instances
-        // between jobs — so a fresh resolve would answer for the wrong instance.
+        // Asked of the executor, not of the container: a pass is driven with a runtime
+        // the executor made for it, and one resolved here is bound to nothing.
         if (app(FlowExecutor::class)->isDecidingRun($this->flowRun->id)) {
             throw RetryPolicyReentryException::for($operation);
         }

--- a/src/Runtime/FlowExecutor.php
+++ b/src/Runtime/FlowExecutor.php
@@ -38,10 +38,17 @@ class FlowExecutor
     use NormalizesExceptions;
     use ResolvesMethodDependencies;
 
+    /**
+     * The runtimes of the passes in flight, innermost last. A pass driven inside
+     * another gets one of its own.
+     *
+     * @var list<FlowRuntime>
+     */
+    private array $runtimes = [];
+
     public function __construct(
         private readonly StateMachine $stateMachine,
         private readonly FlowLifecycleRecorder $recorder,
-        private readonly FlowRuntime $runtime,
         private readonly TenancyManager $tenancy,
         private readonly Serializer $serializer,
         private readonly CompensationRecorder $compensationRecorder,
@@ -49,26 +56,54 @@ class FlowExecutor
     ) {}
 
     /**
+     * Run a pass on a runtime of its own, restoring the caller's when it leaves.
+     *
+     * @template TPass
+     *
+     * @param  callable(FlowRuntime): TPass  $pass
+     * @return TPass
+     *
+     * @throws Throwable
+     */
+    private function inOwnRuntime(callable $pass): mixed
+    {
+        $this->runtimes[] = $runtime = new FlowRuntime;
+
+        try {
+            return $pass($runtime);
+        } finally {
+            array_pop($this->runtimes);
+        }
+    }
+
+    /**
      * Whether the run currently deciding a retryOnSignal() predicate is this one.
-     * The executor answers because it owns the runtime a pass is driven with.
+     * The executor answers because it owns the runtime each pass is driven with — for
+     * every pass in flight, since an inner one is no reason to let a write into a run
+     * an outer one is deciding for.
      */
     public function isDecidingRun(string $flowRunId): bool
     {
-        return $this->runtime->isDecidingRun($flowRunId);
+        return array_any(
+            $this->runtimes,
+            fn (FlowRuntime $runtime): bool => $runtime->isDecidingRun($flowRunId),
+        );
     }
 
     /**
      * A retryOnSignal() predicate may read any run it likes, but it may not drive
-     * one — not even somebody else's. There is a single runtime behind this
-     * singleton, and a nested pass rebinds and resets the one the deciding pass is
-     * suspended inside: the outer run loses its saga stack, its ordinal counter and,
-     * once the nested pass clears up after itself, the run it was bound to.
+     * one — not even somebody else's. See RetryPolicyReentryException for why.
      *
      * @throws RetryPolicyReentryException
      */
     private function rejectWhileDeciding(): void
     {
-        if ($this->runtime->isDeciding()) {
+        $deciding = array_any(
+            $this->runtimes,
+            fn (FlowRuntime $runtime): bool => $runtime->isDeciding(),
+        );
+
+        if ($deciding) {
             throw RetryPolicyReentryException::for('a nested flow execution');
         }
     }
@@ -81,11 +116,11 @@ class FlowExecutor
         $this->rejectWhileDeciding();
 
         try {
-            return $this->tenancy->for(
+            return $this->inOwnRuntime(fn (FlowRuntime $runtime): FlowRun => $this->tenancy->for(
                 $flowRun,
                 $flowRun->workflow_class,
-                fn (): FlowRun => $this->driveInner($flowRun, $mode),
-            );
+                fn (): FlowRun => $this->driveInner($runtime, $flowRun, $mode),
+            ));
         } catch (ConcurrentFlowTransitionException) {
             // Somebody else owns this run now. Returning it rather than throwing lets
             // every caller do the right thing without knowing about the race: a job ends
@@ -104,7 +139,7 @@ class FlowExecutor
      *
      * @throws Throwable
      */
-    private function driveInner(FlowRun $flowRun, RunMode $mode): FlowRun
+    private function driveInner(FlowRuntime $runtime, FlowRun $flowRun, RunMode $mode): FlowRun
     {
         $current = $this->reread($flowRun);
 
@@ -122,7 +157,7 @@ class FlowExecutor
 
         $resuming ? $this->recorder->flowResumed($flowRun) : $this->recorder->flowStarted($flowRun);
 
-        return $this->replay($flowRun, $mode);
+        return $this->replay($runtime, $flowRun, $mode);
     }
 
     /**
@@ -130,14 +165,14 @@ class FlowExecutor
      *
      * @throws Throwable
      */
-    private function replay(FlowRun $flowRun, RunMode $mode): FlowRun
+    private function replay(FlowRuntime $runtime, FlowRun $flowRun, RunMode $mode): FlowRun
     {
         while (true) {
-            $this->runtime->bind($flowRun, $mode);
-            $this->runtime->reset();
+            $runtime->bind($flowRun, $mode);
+            $runtime->reset();
 
             try {
-                $result = $this->callHandle($flowRun);
+                $result = $this->callHandle($runtime, $flowRun);
             } catch (FlowSuspended $suspended) {
                 if ($suspended->inlineResolved) {
                     continue; // Sync: the step ran inline; replay from the top.
@@ -151,7 +186,7 @@ class FlowExecutor
                 // would roll back a run this pass no longer owns.
                 throw $lost;
             } catch (Throwable $exception) {
-                return $this->failAndCompensate($flowRun, $exception, $mode);
+                return $this->failAndCompensate($runtime, $flowRun, $exception, $mode);
             }
 
             return $this->completeFlow($flowRun, $result);
@@ -164,17 +199,17 @@ class FlowExecutor
      *
      * @throws Throwable
      */
-    private function callHandle(FlowRun $flowRun): mixed
+    private function callHandle(FlowRuntime $runtime, FlowRun $flowRun): mixed
     {
         try {
-            $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
+            $workflow = app()->make($flowRun->workflow_class, ['runtime' => $runtime]);
 
             /** @var array<int, mixed> $arguments */
             $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
 
             return $this->callWithDependencies($workflow, 'handle', $arguments);
         } finally {
-            $this->runtime->clear();
+            $runtime->clear();
         }
     }
 
@@ -198,11 +233,11 @@ class FlowExecutor
     {
         $this->rejectWhileDeciding();
 
-        return $this->tenancy->for(
+        return $this->inOwnRuntime(fn (FlowRuntime $runtime): array => $this->tenancy->for(
             $flowRun,
             $flowRun->workflow_class,
-            fn (): array => $this->collectCompensationsInner($flowRun),
-        );
+            fn (): array => $this->collectCompensationsInner($runtime, $flowRun),
+        ));
     }
 
     /**
@@ -220,9 +255,13 @@ class FlowExecutor
      *
      * @param  list<CompensationEntry>  $planned
      * @return list<CompensationEntry>
+     *
+     * @throws RetryPolicyReentryException
      */
     public function replanCompensations(FlowRun $flowRun, array $planned): array
     {
+        $this->rejectWhileDeciding();
+
         try {
             $replanned = $this->collectCompensations($flowRun);
         } catch (Throwable $replanning) {
@@ -294,18 +333,17 @@ class FlowExecutor
      *
      * @throws Throwable
      */
-    private function collectCompensationsInner(FlowRun $flowRun): array
+    private function collectCompensationsInner(FlowRuntime $runtime, FlowRun $flowRun): array
     {
-        $this->runtime->bind($flowRun, RunMode::Queued);
-        $this->runtime->reset();
-        $this->runtime->beginCollecting();
+        $runtime->bind($flowRun, RunMode::Queued);
+        $runtime->reset();
+        $runtime->beginCollecting();
 
-        // Every exit unbinds, including the ones that leave by throwing: the runtime
-        // is a singleton, and a pass that left it collecting would make the next
-        // ordinary drive of any run refuse to start work.
+        // Every exit unbinds, including the ones that leave by throwing, so nothing
+        // that escapes this pass can be read as though a run were still bound.
         try {
             try {
-                $workflow = app()->make($flowRun->workflow_class, ['runtime' => $this->runtime]);
+                $workflow = app()->make($flowRun->workflow_class, ['runtime' => $runtime]);
 
                 /** @var array<int, mixed> $arguments */
                 $arguments = (array) $this->serializer->deserialize($flowRun->arguments ?? []);
@@ -326,10 +364,10 @@ class FlowExecutor
                 // has a run to retry the rollback on.
             }
 
-            return $this->runtime->sagaStack()->entries();
+            return $runtime->sagaStack()->entries();
         } finally {
-            $this->runtime->endCollecting();
-            $this->runtime->clear();
+            $runtime->endCollecting();
+            $runtime->clear();
         }
     }
 
@@ -362,13 +400,17 @@ class FlowExecutor
      *
      * @throws Throwable
      */
-    private function failAndCompensate(FlowRun $flowRun, Throwable $exception, RunMode $mode): FlowRun
-    {
+    private function failAndCompensate(
+        FlowRuntime $runtime,
+        FlowRun $flowRun,
+        Throwable $exception,
+        RunMode $mode
+    ): FlowRun {
         if ($exception instanceof HistoryContractMismatchException) {
             return $this->failFlow($flowRun, $exception);
         }
 
-        $entries = $this->runtime->sagaStack()->entries();
+        $entries = $runtime->sagaStack()->entries();
 
         if ($entries === []) {
             return $this->failFlow($flowRun, $exception);
@@ -411,12 +453,16 @@ class FlowExecutor
      * Shared by the monitor's sweep (FlowMonitor::expireRun) and the lazy drive check.
      *
      * Guarded separately from drive(), because the sweep reaches it directly: one run
-     * claimed by someone else in the meantime must not end the whole pass.
+     * claimed by someone else in the meantime must not end the whole pass. The re-entry
+     * refusal is raised here rather than left to the planning replay below, whose own
+     * wrapper would hand a predicate a planning fault to read as an ordinary failure.
      *
      * @throws Throwable
      */
     public function expireRun(FlowRun $flowRun): FlowRun
     {
+        $this->rejectWhileDeciding();
+
         try {
             return $this->expireRunInner($flowRun);
         } catch (ConcurrentFlowTransitionException) {

--- a/src/Runtime/FlowRuntime.php
+++ b/src/Runtime/FlowRuntime.php
@@ -8,13 +8,14 @@ use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
 use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
 
 /**
- * Per-execution, scoped state for the workflow being driven: the current run,
- * the run mode, and the step sequence. Holds NO static mutable state so that
- * two runs driven back-to-back in the same process (Octane, sync queue) never
- * leak context into one another.
+ * Per-execution state for the workflow being driven: the current run, the run
+ * mode, and the step sequence. Holds NO static mutable state, and the executor
+ * makes one for every pass it drives, so neither two runs driven back-to-back in
+ * the same process (Octane, sync queue) nor a pass driven inside another leak
+ * context into one another.
  *
- * One instance is bound per drive() pass; reset() zeroes the sequence at the
- * start of every replay and clear() wipes it in the executor's "finally" block.
+ * reset() zeroes the sequence at the start of every replay; clear() unbinds the
+ * run in the executor's "finally" block.
  */
 final class FlowRuntime
 {
@@ -118,8 +119,7 @@ final class FlowRuntime
     }
 
     /**
-     * Whether any retryOnSignal() decision is in flight. Reads on other runs are
-     * fine during one; driving the engine is not, because there is one runtime.
+     * Whether a retryOnSignal() decision is in flight on this pass.
      */
     public function isDeciding(): bool
     {

--- a/src/SagaLaraFlowServiceProvider.php
+++ b/src/SagaLaraFlowServiceProvider.php
@@ -27,7 +27,6 @@ use DiscoveryUkraine\SagaLaraFlow\Repositories\EloquentSignalRepository;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowDoctor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
 use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowMonitor;
-use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
 use DiscoveryUkraine\SagaLaraFlow\Serialization\LaravelSerializer;
 use DiscoveryUkraine\SagaLaraFlow\States\FlowStateMachine;
 use DiscoveryUkraine\SagaLaraFlow\Support\TenancyManager;
@@ -70,7 +69,6 @@ class SagaLaraFlowServiceProvider extends PackageServiceProvider
         $this->app->singleton(FlowManager::class);
         $this->app->alias(FlowManager::class, 'saga-flow');
 
-        $this->app->scoped(FlowRuntime::class);
         $this->app->scoped(TenancyManager::class);
         $this->app->singleton(FlowExecutor::class);
         $this->app->singleton(FlowMonitor::class);

--- a/tests/Feature/NestedDriveTest.php
+++ b/tests/Feature/NestedDriveTest.php
@@ -1,0 +1,157 @@
+<?php
+
+use DiscoveryUkraine\SagaLaraFlow\Enums\ActionStatus;
+use DiscoveryUkraine\SagaLaraFlow\Enums\FlowStatus;
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\RetryPolicyReentryException;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Models\FlowRun;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ActionStartsSagaWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\CompensationLog;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\DeclinableChargeAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\MakeValueAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ManualCompensateWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\NestedExpireRetryWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\NestedRunSyncWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\OneActionWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ProbingRetryWorkflow;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\StartsASagaAction;
+use DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures\ThrowingAction;
+
+/**
+ * A run driven while another is already being driven — a step that starts a saga of
+ * its own, or handle() calling runSync() where child() belongs. The inner pass gets
+ * a runtime of its own, so the ordinals, the compensation stack and the bound run of
+ * the pass that made the call are still there when it returns.
+ */
+beforeEach(function () {
+    CompensationLog::reset();
+    DeclinableChargeAction::reset();
+    ProbingRetryWorkflow::reset();
+});
+
+/**
+ * @return list<string>
+ */
+function nestedDriveStepClasses(FlowRun $run): array
+{
+    return $run->actions()->orderBy('sequence')->pluck('action_class')->all();
+}
+
+function nestedDriveRunCount(string $workflowClass): int
+{
+    return FlowRun::query()->where('workflow_class', $workflowClass)->count();
+}
+
+it('keeps the ordinals of the pass that drove another run', function () {
+    $run = SagaFlow::create(NestedRunSyncWorkflow::class)->runSync();
+
+    // Every seam after the nested call still lands in the slot the workflow asks for.
+    // A pass whose counter was rewound reaches the second step with an ordinal that
+    // already belongs to the first, and dies blaming a workflow change.
+    expect(nestedDriveStepClasses($run))->toBe([
+        MakeValueAction::class,
+        MakeValueAction::class,
+        ThrowingAction::class,
+    ]);
+});
+
+it('rolls back both steps around a run it drove', function () {
+    $run = SagaFlow::create(NestedRunSyncWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(CompensationLog::all())->toBe(['undo:b', 'undo:a']);
+});
+
+it('leaves the caller a run to fail against', function () {
+    $run = SagaFlow::create(NestedRunSyncWorkflow::class)->runSync();
+
+    // The nested pass unbinds its own run on the way out. Taking the caller's with it
+    // ends the outer pass on the next seam, on a fault that names no cause the
+    // operator can act on.
+    expect($run->exception['class'] ?? null)->toBe(RuntimeException::class)
+        ->and($run->exception['message'] ?? null)->toBe('boom');
+});
+
+it('starts a run it cannot resolve again on every replay [pinning]', function () {
+    SagaFlow::create(NestedRunSyncWorkflow::class)->runSync();
+
+    // The pass survives the call; the call stays a mistake.
+    expect(nestedDriveRunCount(OneActionWorkflow::class))->toBeGreaterThan(1);
+});
+
+it('drives a saga started by a step without disturbing the run that owns it', function () {
+    $run = SagaFlow::create(ActionStartsSagaWorkflow::class)->runSync();
+
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and(nestedDriveStepClasses($run))->toBe([
+            MakeValueAction::class,
+            StartsASagaAction::class,
+            ThrowingAction::class,
+        ])
+        ->and(CompensationLog::all())->toBe(['undo:inner', 'undo:a']);
+});
+
+it('completes the saga a step started', function () {
+    SagaFlow::create(ActionStartsSagaWorkflow::class)->runSync();
+
+    $started = FlowRun::query()->where('workflow_class', OneActionWorkflow::class)->first();
+
+    // The contrast with a bare runSync(): the seam that starts this one is history.
+    expect(nestedDriveRunCount(OneActionWorkflow::class))->toBe(1)
+        ->and($started->status)->toBe(FlowStatus::Completed)
+        ->and($started->actions()->where('status', ActionStatus::Completed)->count())->toBe(1);
+});
+
+it('answers the re-entry guard from the pass, not from the container', function () {
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+    DeclinableChargeAction::reset(failures: 99, code: 503);
+
+    SagaFlow::create(ProbingRetryWorkflow::class)->withArguments('order-probe')->runSync();
+
+    // What the container hands out is bound to nothing, which is why the guard asks
+    // the executor for the answer instead.
+    expect(ProbingRetryWorkflow::$probe)->toBe([
+        'guarded' => true,
+        'container_bound' => false,
+    ]);
+});
+
+it('drops the runtime of a pass that has ended', function () {
+    SagaFlow::create(ActionStartsSagaWorkflow::class)->runSync();
+    SagaFlow::create(OneActionWorkflow::class)->runSync();
+
+    // The register the guards read is also everything a pass keeps alive. A worker
+    // that never drops one holds on to every run it has ever driven, and answers
+    // for decisions that ended long ago.
+    $inFlight = (fn () => $this->runtimes)->call(app(FlowExecutor::class));
+
+    expect($inFlight)->toBe([]);
+});
+
+it('shares no runtime between container resolves', function () {
+    // The executor makes its own for every pass it drives, so a registration here
+    // would only hand two unrelated callers one object to write flow state into.
+    expect(app(FlowRuntime::class))->not->toBe(app(FlowRuntime::class));
+});
+
+it('refuses a predicate that plans a rollback through the executor', function (bool $replan) {
+    config()->set('saga-lara-flow.signals.wake_workflow_on_signal', false);
+    DeclinableChargeAction::reset(failures: 99);
+
+    // Non-terminal, so the run is one the executor will act on rather than turn away.
+    $other = SagaFlow::create(ManualCompensateWorkflow::class)->runSync();
+
+    $run = SagaFlow::create(NestedExpireRetryWorkflow::class)
+        ->withArguments('order-expire', $other->id, $replan)
+        ->runSync();
+
+    // Both entries plan by replaying, and both wrap what the replay throws. Refused
+    // at the door instead, the predicate gets the re-entry itself rather than a
+    // failure that reads as the policy simply declining.
+    expect($run->status)->toBe(FlowStatus::Failed)
+        ->and($run->exception['class'] ?? null)->toBe(RetryPolicyReentryException::class)
+        ->and(SagaFlow::findRun($other->id)->status)->toBe(FlowStatus::Waiting)
+        ->and(CompensationLog::all())->toBe([]);
+})->with([[false], [true]]);

--- a/tests/Feature/RetryPolicyTest.php
+++ b/tests/Feature/RetryPolicyTest.php
@@ -398,12 +398,9 @@ it('refuses a predicate that tags the run it is deciding for', function () {
 it('holds the re-entry guard when the container forgets its scoped instances', function () {
     DeclinableChargeAction::reset(failures: 99, code: 503);
 
-    // What a queue worker does between jobs: FlowExecutor is a singleton and keeps
-    // the runtime it was built with, while a fresh resolve now answers for another
-    // instance. The guard has to read the one the pass is actually driven with.
-    $held = (fn () => $this->runtime)->call(app(FlowExecutor::class));
+    // What a queue worker does between jobs. The guard has to read the runtime the
+    // pass is actually driven with, and the container never holds that one.
     app()->forgetScopedInstances();
-    expect(app(FlowRuntime::class))->not->toBe($held);
 
     $run = SagaFlow::create(SelfCancellingRetryWorkflow::class)->withArguments('order-19')->runSync();
 

--- a/tests/Fixtures/ActionStartsSagaWorkflow.php
+++ b/tests/Fixtures/ActionStartsSagaWorkflow.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * The nesting that is meant to work: an ordinary step that happens to start a saga
+ * of its own.
+ */
+final class ActionStartsSagaWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(UndoAction::class, 'a')
+            ->run();
+
+        $this->action(StartsASagaAction::class)
+            ->compensateWith(UndoAction::class, 'inner')
+            ->run();
+
+        $this->action(ThrowingAction::class)->run();
+    }
+}

--- a/tests/Fixtures/NestedExpireRetryWorkflow.php
+++ b/tests/Fixtures/NestedExpireRetryWorkflow.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * A retry predicate that expires another run, or replans its rollback: the two
+ * public executor entries that plan by replaying and wrap what the replay throws.
+ */
+final class NestedExpireRetryWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId, string $otherRunId, bool $replan = false): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal('balance-refilled', when: function (RetryContext $context) use ($otherRunId, $replan): bool {
+                $other = SagaFlow::findRun($otherRunId);
+
+                $replan
+                    ? app(FlowExecutor::class)->replanCompensations($other, [])
+                    : app(FlowExecutor::class)->expireRun($other);
+
+                return true;
+            })
+            ->run();
+    }
+}

--- a/tests/Fixtures/NestedRunSyncWorkflow.php
+++ b/tests/Fixtures/NestedRunSyncWorkflow.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * Drives a second run from inside handle(), where child() belongs. Every replay
+ * starts another one, which is why it stays a mistake; what it must not do is
+ * corrupt the pass that made the call.
+ */
+final class NestedRunSyncWorkflow extends Workflow
+{
+    /**
+     * @throws Throwable
+     */
+    public function handle(): void
+    {
+        $this->action(MakeValueAction::class, 'a')
+            ->compensateWith(UndoAction::class, 'a')
+            ->run();
+
+        SagaFlow::create(OneActionWorkflow::class)->runSync();
+
+        $this->action(MakeValueAction::class, 'b')
+            ->compensateWith(UndoAction::class, 'b')
+            ->run();
+
+        $this->action(ThrowingAction::class)->run();
+    }
+}

--- a/tests/Fixtures/ProbingRetryWorkflow.php
+++ b/tests/Fixtures/ProbingRetryWorkflow.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Exceptions\MissingFlowContextException;
+use DiscoveryUkraine\SagaLaraFlow\Retry\RetryContext;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowExecutor;
+use DiscoveryUkraine\SagaLaraFlow\Runtime\FlowRuntime;
+use DiscoveryUkraine\SagaLaraFlow\Workflow;
+use Throwable;
+
+/**
+ * Reports, from inside a retryOnSignal() predicate, who answers for the pass the
+ * predicate is suspended in: the executor, or whatever the container hands out.
+ */
+final class ProbingRetryWorkflow extends Workflow
+{
+    /**
+     * @var array{guarded: bool, container_bound: bool}|null
+     */
+    public static ?array $probe = null;
+
+    public static function reset(): void
+    {
+        self::$probe = null;
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function handle(string $orderId): mixed
+    {
+        return $this->action(DeclinableChargeAction::class, $orderId)
+            ->retryOnSignal('balance-refilled', when: function (RetryContext $context): bool {
+                self::$probe = [
+                    'guarded' => app(FlowExecutor::class)->isDecidingRun($context->runId),
+                    'container_bound' => self::isBound(app(FlowRuntime::class)),
+                ];
+
+                return true;
+            })
+            ->run();
+    }
+
+    private static function isBound(FlowRuntime $runtime): bool
+    {
+        try {
+            $runtime->run();
+        } catch (MissingFlowContextException) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/tests/Fixtures/StartsASagaAction.php
+++ b/tests/Fixtures/StartsASagaAction.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace DiscoveryUkraine\SagaLaraFlow\Tests\Fixtures;
+
+use DiscoveryUkraine\SagaLaraFlow\Action;
+use DiscoveryUkraine\SagaLaraFlow\Facades\SagaFlow;
+use Throwable;
+
+/**
+ * A step that starts a saga of its own. Under sync execution it runs inside the
+ * calling run's drive() pass, so the second run is nested in the first.
+ */
+final class StartsASagaAction extends Action
+{
+    /**
+     * @return array{started: string}
+     *
+     * @throws Throwable
+     */
+    public function handle(): array
+    {
+        return ['started' => SagaFlow::create(OneActionWorkflow::class)->runSync()->id];
+    }
+}


### PR DESCRIPTION
Closes #36

`FlowRuntime` was a container scoped singleton, and `FlowExecutor::drive()` bound its run into that
one shared instance. A pass driven while another was in progress took the outer pass's runtime
over: it rewound the ordinal counter, emptied the compensation stack, and unbound the run on the way
out. Nothing in the engine reaches that state on its own, but an action whose body starts a saga
does, and so does a `runSync()` written inside `handle()`.

Every pass now gets a runtime of its own. `FlowExecutor` keeps the passes in flight on a register,
`inOwnRuntime()` makes one for each pass and drops it in a `finally`, and the runtime is threaded
explicitly through `driveInner()`, `replay()`, `callHandle()`, `failAndCompensate()` and
`collectCompensationsInner()` rather than read off the executor. `$this->app->scoped(FlowRuntime::class)`
is gone: the executor is the sole owner, and a runtime resolved from the container is bound to
nothing.

`isDecidingRun()` and `rejectWhileDeciding()` read every pass on the register rather than the
innermost alone, so a predicate deciding in an outer pass keeps refusing writes to the run it is
deciding for.

`expireRun()` and `replanCompensations()` raise that refusal at their own door. Both plan by
replaying the run and wrap whatever the replay throws — the first in
`ExpirationNotPlannedException`, the second in an `replan_failed` journal line — so a refusal raised
inside reached a predicate as an ordinary failure, was read as the policy declining, and the step
failed on its own business error with the real cause recorded nowhere.

`child()` remains the only seam that runs another workflow from inside `handle()`. A bare
`SagaFlow::create(...)` there takes no ordinal, so the run it starts is recognized by nothing and
the next replay starts another one — the fix stops that call corrupting its caller; it does not make
it correct. The docs say so on the three pages a reader would look at.

### Verification

`tests/Feature/NestedDriveTest.php` — eleven cases, run against `main`'s engine: nine fail, two
pass. Each failure is a distinct symptom — the outer run's ordinals stop at the first step, its
exception is `MissingFlowContextException` rather than the failure that actually ended it, its
compensation stack is empty so nothing rolls back, a bare `runSync()` is reached once instead of on
every replay because the pass dies at it, the container hands a predicate the live pass's runtime,
two callers of the container share one runtime, and nothing drops a finished pass.

The two that pass on `main` are the ones that have to keep passing: an action that starts a saga
already worked, because the seam replays the outer pass from the top after an inline step, and that
is the nesting the engine is meant to support.

Mutations, one component at a time:

| mutation | result |
| --- | --- |
| one shared runtime for every pass | 4 tests redden |
| never drop a finished pass from the register | 1 reddens |
| `scoped(FlowRuntime::class)` back in the provider | 1 reddens |
| deciding guard reads the innermost pass only | **nothing reddens** |
| no re-entry guard on `expireRun()` | 1 reddens |
| no re-entry guard on `replanCompensations()` | 1 reddens |

The last one is stated rather than hidden. A pass reaches the register only through `drive()` or
`collectCompensations()`, and both refuse while any pass is deciding, so no reachable scenario
distinguishes the two answers. Removing that other guard does distinguish them, and was measured:
a predicate's nested pass writing into the run being decided is refused by the register-wide answer
and allowed by the innermost-only one. The register-wide answer is the one kept.

`tests/Unit/FlowRuntimeTest.php` is untouched. `RetryPolicyTest`'s "holds the re-entry guard when
the container forgets its scoped instances" keeps all four of its assertions; only its staging
changed, because it reached into the executor's private runtime field, which is now a register.

The register assumes the passes in flight are a call stack — one logical thread of execution per
process, which is what the engine assumes everywhere else too. It is not safe under fibers or
coroutines sharing a container, and neither was the single shared runtime it replaces, which the
same interleaving corrupts outright.

SQLite 505 passed / 4 skipped, MySQL 505 / 4 skipped, PostgreSQL 509. `composer lint` clean, docs
build clean.
